### PR TITLE
Feature/mysql validfrom versionfix

### DIFF
--- a/Rdmp.Core.Tests/Curation/Integration/MySqlTriggerImplementerTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/MySqlTriggerImplementerTests.cs
@@ -1,0 +1,21 @@
+using FAnsi;
+using FAnsi.Discovery;
+using NUnit.Framework;
+using Rdmp.Core.DataLoad.Triggers.Implementations;
+using Tests.Common;
+
+namespace Rdmp.Core.Tests.Curation.Integration
+{
+    public class MySqlTriggerImplementerTests
+    {
+        [TestCase("4.0",true)]
+        [TestCase("5.1",true)]
+        [TestCase("8.5",false)]
+        [TestCase("5.5.64-MariaDB",true)]
+        [TestCase("10.5.64-MariaDB",false)]
+        public void TestOldNew(string versionString, bool expectToUseOldMethod)
+        {
+            Assert.AreEqual(expectToUseOldMethod,MySqlTriggerImplementer.UseOldDateTimeDefaultMethod(versionString));
+        }
+    }
+}

--- a/Rdmp.Core.Tests/Curation/Integration/MySqlTriggerImplementerTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/MySqlTriggerImplementerTests.cs
@@ -1,3 +1,9 @@
+// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
 using FAnsi;
 using FAnsi.Discovery;
 using NUnit.Framework;

--- a/Rdmp.Core/DataLoad/Triggers/Implementations/MySqlTriggerImplementer.cs
+++ b/Rdmp.Core/DataLoad/Triggers/Implementations/MySqlTriggerImplementer.cs
@@ -81,7 +81,11 @@ namespace Rdmp.Core.DataLoad.Triggers.Implementations
         public bool UseOldDateTimeDefaultMethod(DiscoveredTable table)
         {
             using (var con = table.Database.Server.GetConnection())
+            {
+                con.Open();
                 return UseOldDateTimeDefaultMethod(table.GetCommand("SELECT VERSION()", con).ExecuteScalar()?.ToString());
+            }
+                
         }
 
         public static bool UseOldDateTimeDefaultMethod(string version)

--- a/Rdmp.Core/DataLoad/Triggers/Implementations/MySqlTriggerImplementer.cs
+++ b/Rdmp.Core/DataLoad/Triggers/Implementations/MySqlTriggerImplementer.cs
@@ -6,7 +6,9 @@
 
 using System;
 using System.Linq;
+using System.Text.RegularExpressions;
 using FAnsi.Discovery;
+using FAnsi.Discovery.QuerySyntax;
 using ReusableLibraryCode.Checks;
 using ReusableLibraryCode.Exceptions;
 
@@ -63,6 +65,40 @@ namespace Rdmp.Core.DataLoad.Triggers.Implementations
             }
 
             return creationSql;
+        }
+
+        protected override void AddValidFrom(DiscoveredTable table, IQuerySyntaxHelper syntaxHelper, int timeout)
+        {
+            // MySql changed how they do default date fields between 5.5 and 5.6
+            //https://dba.stackexchange.com/a/132954
+ 
+            if (UseOldDateTimeDefaultMethod(table))
+                table.AddColumn(SpecialFieldNames.ValidFrom,"TIMESTAMP DEFAULT CURRENT_TIMESTAMP",true,timeout);
+            else
+                table.AddColumn(SpecialFieldNames.ValidFrom,"DATETIME DEFAULT CURRENT_TIMESTAMP",true,timeout);
+        }
+
+        public bool UseOldDateTimeDefaultMethod(DiscoveredTable table)
+        {
+            using (var con = table.Database.Server.GetConnection())
+                return UseOldDateTimeDefaultMethod(table.GetCommand("SELECT VERSION()", con).ExecuteScalar()?.ToString());
+        }
+
+        public static bool UseOldDateTimeDefaultMethod(string version)
+        {
+            if (string.IsNullOrWhiteSpace(version))
+                return false;
+            
+            var match = Regex.Match(version,@"(\d+)\.(\d+)");
+
+            //If the version string doesn't start with numbers we have bigger problems than creating a default constraint
+            if (!match.Success)
+                return false;
+
+            var major = int.Parse(match.Groups[1].Value);
+            var minor = int.Parse(match.Groups[2].Value);
+
+            return major < 5 || (major == 5 && minor <= 5);
         }
 
         protected virtual string CreateTriggerBody()

--- a/Rdmp.Core/DataLoad/Triggers/Implementations/OracleTriggerImplementer.cs
+++ b/Rdmp.Core/DataLoad/Triggers/Implementations/OracleTriggerImplementer.cs
@@ -4,10 +4,13 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Linq;
 using FAnsi.Discovery;
+using FAnsi.Discovery.QuerySyntax;
 using Oracle.ManagedDataAccess.Client;
 using ReusableLibraryCode.Exceptions;
+using TypeGuesser;
 
 namespace Rdmp.Core.DataLoad.Triggers.Implementations
 {
@@ -40,6 +43,12 @@ namespace Rdmp.Core.DataLoad.Triggers.Implementations
 
             return null;
         }
+
+        protected override void AddValidFrom(DiscoveredTable table, IQuerySyntaxHelper syntaxHelper, int timeout)
+        {
+            _table.AddColumn(SpecialFieldNames.ValidFrom, " DATE DEFAULT CURRENT_TIMESTAMP", true, timeout);
+        }
+
         protected override string CreateTriggerBody()
         {
             var syntax = _table.GetQuerySyntaxHelper();

--- a/Rdmp.Core/DataLoad/Triggers/Implementations/TriggerImplementer.cs
+++ b/Rdmp.Core/DataLoad/Triggers/Implementations/TriggerImplementer.cs
@@ -74,12 +74,11 @@ namespace Rdmp.Core.DataLoad.Triggers.Implementations
                 _table.AddColumn(SpecialFieldNames.DataLoadRunID, new DatabaseTypeRequest(typeof(int)), true, timeout);
 
             var syntaxHelper = _server.GetQuerySyntaxHelper();
-            var dateTimeDatatype = syntaxHelper.TypeTranslater.GetSQLDBTypeForCSharpType(new DatabaseTypeRequest(typeof (DateTime)));
-            var nowFunction = syntaxHelper.GetScalarFunctionSql(MandatoryScalarFunctions.GetTodaysDate);
+            
 
             //must add validFrom outside of transaction if we want SMO to pick it up
             if (b_mustCreate_validFrom)
-                _table.AddColumn(SpecialFieldNames.ValidFrom, string.Format(" {0} DEFAULT {1}", dateTimeDatatype, nowFunction), true, timeout);
+                AddValidFrom(_table, syntaxHelper,timeout);
 
             //if we created columns we need to update _column
             if (b_mustCreate_dataloadRunId || b_mustCreate_validFrom)
@@ -103,7 +102,14 @@ namespace Rdmp.Core.DataLoad.Triggers.Implementations
             return sql;
         }
 
-        
+        protected virtual void AddValidFrom(DiscoveredTable table, IQuerySyntaxHelper syntaxHelper, int timeout)
+        {
+            var dateTimeDatatype = syntaxHelper.TypeTranslater.GetSQLDBTypeForCSharpType(new DatabaseTypeRequest(typeof (DateTime)));
+            var nowFunction = syntaxHelper.GetScalarFunctionSql(MandatoryScalarFunctions.GetTodaysDate);
+            
+            _table.AddColumn(SpecialFieldNames.ValidFrom, string.Format(" {0} DEFAULT {1}", dateTimeDatatype, nowFunction), true, timeout);
+        }
+
 
         private string WorkOutArchiveTableCreationSQL()
         {


### PR DESCRIPTION
Fix for hic_validFrom DLE field creation in MySql versions older than 5.6

(https://dba.stackexchange.com/questions/132951/cant-default-date-to-current-timestamp-in-mysql-5-5)