### PR TITLE
Feature/remote table attacher load progresses

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added new property RemoteServerReference to RemoteTableAttacher which centralises server name/database/credentials when creating many attachers that all pull data from the same place
 - Added double click to expand tree option for RDMP
 - When searching (Ctrl+F), exact matches now appear first
 - Added RDMP platform database name (and server) to the window title

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,6 +20,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Catalogue collection no longer expands when CatalogueFolder changes
 
+### Fixed
+
+- LoadProgress with RemoteTableAttacher now works correctly with DBMS that do not support Sql parameter declarations (Oracle / Postgres)
+
 ## [4.0.3] - 2020-02-28
 
 ### Added

--- a/Rdmp.Core.Tests/DataLoad/Modules/Attachers/RemoteTableAttacherTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Modules/Attachers/RemoteTableAttacherTests.cs
@@ -93,6 +93,8 @@ namespace Rdmp.Core.Tests.DataLoad.Modules.Attachers
             attacher.RemoteTableName = "table1";
             attacher.RAWTableName = "table2";
 
+            attacher.Check(new ThrowImmediatelyCheckNotifier());
+
             attacher.Initialize(null,db);
 
             var dt = new DataTable();
@@ -129,6 +131,8 @@ namespace Rdmp.Core.Tests.DataLoad.Modules.Attachers
             //the table to get data from
             attacher.RemoteSelectSQL = $"SELECT * FROM table1 WHERE {syntax.EnsureWrapped("DateCol")} >= @startDate AND {syntax.EnsureWrapped("DateCol")} <= @endDate";
             attacher.RAWTableName = "table2";
+
+            attacher.Check(new ThrowImmediatelyCheckNotifier());
 
             attacher.Initialize(null,db);
 

--- a/Rdmp.Core.Tests/DataLoad/Modules/Attachers/RemoteTableAttacherTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Modules/Attachers/RemoteTableAttacherTests.cs
@@ -124,9 +124,10 @@ namespace Rdmp.Core.Tests.DataLoad.Modules.Attachers
         private void RunAttachStageWithLoadProgressJob(RemoteTableAttacher attacher, DiscoveredDatabase db,
             bool mismatchProgress)
         {
-           
+            var syntax = db.Server.GetQuerySyntaxHelper();
+
             //the table to get data from
-            attacher.RemoteSelectSQL = "SELECT * FROM table1 WHERE DateCol >= @startDate AND DateCol <= @endDate";
+            attacher.RemoteSelectSQL = $"SELECT * FROM table1 WHERE {syntax.EnsureWrapped("DateCol")} >= @startDate AND {syntax.EnsureWrapped("DateCol")} <= @endDate";
             attacher.RAWTableName = "table2";
 
             attacher.Initialize(null,db);

--- a/Rdmp.Core.Tests/DataLoad/Modules/Attachers/RemoteTableAttacherTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Modules/Attachers/RemoteTableAttacherTests.cs
@@ -1,0 +1,84 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Text;
+using FAnsi;
+using FAnsi.Discovery;
+using Moq;
+using NUnit.Framework;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataFlowPipeline;
+using Rdmp.Core.DataLoad.Engine.DatabaseManagement.EntityNaming;
+using Rdmp.Core.DataLoad.Engine.Job;
+using Rdmp.Core.DataLoad.Modules.Attachers;
+using Rdmp.Core.Logging;
+using ReusableLibraryCode.Checks;
+using ReusableLibraryCode.Progress;
+using Tests.Common;
+using TypeGuesser;
+
+namespace Rdmp.Core.Tests.DataLoad.Modules.Attachers
+{
+    class RemoteTableAttacherTests : DatabaseTests
+    {
+        [TestCaseSource(typeof(All),nameof(All.DatabaseTypes))]
+        public void TestRemoteTableAttacher_Normal(DatabaseType dbType)
+        {
+            var db = GetCleanedServer(dbType);
+
+            var attacher = new RemoteTableAttacher();
+            //where to go for data
+            attacher.RemoteServer = db.Server.Name;
+            attacher.RemoteDatabaseName = db.GetRuntimeName();
+            attacher.DatabaseType = db.Server.DatabaseType;
+
+            if (db.Server.ExplicitUsernameIfAny != null)
+            {
+                var creds = new DataAccessCredentials(CatalogueRepository);
+                creds.Username = db.Server.ExplicitUsernameIfAny;
+                creds.Password = db.Server.ExplicitPasswordIfAny;
+                creds.SaveToDatabase();
+                attacher.RemoteTableAccessCredentials = creds;
+            }
+
+            //the table to get data from
+            attacher.RemoteTableName = "table1";
+            attacher.RAWTableName = "table2";
+
+            attacher.Initialize(null,db);
+
+            var dt = new DataTable();
+            dt.Columns.Add("Col1");
+            dt.Rows.Add("fff");
+
+            var tbl1 = db.CreateTable("table1", dt);
+            var tbl2 = db.CreateTable("table2", new []{new DatabaseColumnRequest("Col1",new DatabaseTypeRequest(typeof(string),5))});
+
+            Assert.AreEqual(1,tbl1.GetRowCount());
+            Assert.AreEqual(0,tbl2.GetRowCount());
+
+            var logManager = new LogManager(new DiscoveredServer(UnitTestLoggingConnectionString));
+
+            var lmd = RdmpMockFactory.Mock_LoadMetadataLoadingTable(tbl2);
+            Mock.Get(lmd).Setup(p=>p.CatalogueRepository).Returns(CatalogueRepository);
+            logManager.CreateNewLoggingTaskIfNotExists(lmd.GetDistinctLoggingTask());
+
+            var dbConfiguration = new HICDatabaseConfiguration(lmd, RdmpMockFactory.Mock_INameDatabasesAndTablesDuringLoads(db, "table2"));
+
+            var job = new DataLoadJob(RepositoryLocator,"test job",logManager,lmd,new TestLoadDirectory(),new ThrowImmediatelyDataLoadEventListener(),dbConfiguration);
+            job.StartLogging();
+            attacher.Attach(job, new GracefulCancellationToken());
+
+            Assert.AreEqual(1,tbl1.GetRowCount());
+            Assert.AreEqual(1,tbl2.GetRowCount());
+            
+        }
+    }
+
+}

--- a/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
+++ b/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
@@ -33,6 +33,11 @@ namespace Rdmp.Core.DataLoad.Engine.Pipeline.Sources
         public bool AllowEmptyResultSets { get; set; }
         public int TotalRowsRead { get; set; }
 
+        /// <summary>
+        /// Called after command sql has been set up, allows last minute changes by subscribers before it is executed
+        /// </summary>
+        public Action<DbCommand> CommandAdjuster { get; set; }
+
         public DbDataCommandDataFlowSource(string sql,string taskBeingPerformed, DbConnectionStringBuilder builder, int timeout)
         {
             Sql = sql;
@@ -58,7 +63,8 @@ namespace Rdmp.Core.DataLoad.Engine.Pipeline.Sources
 
                 cmd = DatabaseCommandHelper.GetCommand(Sql, _con);
                 cmd.CommandTimeout = _timeout;
-                
+                CommandAdjuster?.Invoke(cmd);
+
                 _reader = cmd.ExecuteReaderAsync(cancellationToken.AbortToken).Result;
                 _numberOfColumns = _reader.FieldCount;
             }

--- a/Tests.Common/RdmpMockFactory.cs
+++ b/Tests.Common/RdmpMockFactory.cs
@@ -16,6 +16,8 @@ namespace Tests.Common
 {
     public class RdmpMockFactory
     {
+        private const string TestLoggingTask = "TestLoggingTask";
+
         /// <summary>
         /// Generates an implementation of <see cref="INameDatabasesAndTablesDuringLoads"/> which always returns the provided table regardless of the
         /// DLE load stage.
@@ -59,9 +61,10 @@ namespace Tests.Common
 
             lmd.Setup(m => m.GetDistinctLiveDatabaseServer()).Returns(tableInfo.Discover(DataAccessContext.DataLoad).Database.Server);
             lmd.Setup(m => m.GetAllCatalogues()).Returns(new[] { cata.Object });
-
+            lmd.Setup(p => p.GetDistinctLoggingTask()).Returns(TestLoggingTask);
+            
             cata.Setup(m => m.GetTableInfoList(It.IsAny<bool>())).Returns(new[] { tableInfo });
-
+            cata.Setup(m => m.LoggingDataTask).Returns(TestLoggingTask);
             return lmd.Object;
         }
 

--- a/Tests.Common/TestLoadDirectory.cs
+++ b/Tests.Common/TestLoadDirectory.cs
@@ -11,33 +11,19 @@ using Rdmp.Core.Curation;
 namespace Tests.Common
 {
     public class TestLoadDirectory :ILoadDirectory{
-        private readonly XmlDocument _configurationData;
 
-        public TestLoadDirectory(XmlDocument configurationData)
+        /// <summary>
+        /// Creates a new blank/null implementation of <see cref="ILoadDirectory"/>
+        /// </summary>
+        public TestLoadDirectory()
         {
-            _configurationData = configurationData;
+
         }
-
-        public DirectoryInfo ForLoading { get; private set; }
-        public DirectoryInfo ForArchiving { get; private set; }
-        public DirectoryInfo Cache { get; private set; }
-        public DirectoryInfo RootPath { get; private set; }
-        public DirectoryInfo DataPath { get; private set; }
-        public DirectoryInfo ExecutablesPath { get; private set; }
-        public FileInfo FTPDetails { get; private set; }
-
-        public XmlNodeList GetTagFromConfigurationDataXML(string tagName)
-        {
-            return _configurationData.GetElementsByTagName(tagName);
-        }
-
-        public bool HasTagInConfigurationDataXML(string tagName)
-        {
-            var toReturn =_configurationData.GetElementsByTagName(tagName);
-
-            return toReturn != null && toReturn.Count>0;
-        }
-
-        public bool IsDesignTime { get; private set; }
+        public DirectoryInfo ForLoading { get; set; }
+        public DirectoryInfo ForArchiving { get; set; }
+        public DirectoryInfo Cache { get; set; }
+        public DirectoryInfo RootPath { get; set; }
+        public DirectoryInfo DataPath { get; set; }
+        public DirectoryInfo ExecutablesPath { get; set; }
     }
 }


### PR DESCRIPTION
Improvements to RemoteTableAttacher

For background.  A LoadProgress is a DLE job that operates only with a give range of hours/days.  It is designed to let you run a specific date range or iteratively load e.g. 5 days at a time till you reach some boundary.  The remote table attacher is a specific DLE module that fetches data with SQL queries.  The PR is about the interaction of the two i.e. give you are running a LoadProgress DLE job how does the attacher harness those dates to fetch your data only for that range of time