### PR TITLE
Added ability to detect and remove deleted objects from history/recent

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,13 +6,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
-- Added double click to expand tree option for RDMP
 ...
+
+### Fixed
+
+- Opening 'Recent' items that have been deleted now prompts to remove from list
 
 ## [4.1.0] - 2020-05-05
 
 ### Added
 
+- Added double click to expand tree option for RDMP
 - Added tool strip to tree collection user interfaces
 - Added new [PipelineComponent] `SetNull` which detects bad data in a specific column of pipeline data and sets cells matching the `Regex` to null
 - Added support for template based metadata extractions ([Catalogue] descriptions etc) 

--- a/Rdmp.UI/Collections/Providers/HistoryProvider.cs
+++ b/Rdmp.UI/Collections/Providers/HistoryProvider.cs
@@ -124,5 +124,14 @@ namespace Rdmp.UI.Collections.Providers
             UserSettings.RecentHistory = "";
             History.Clear();
         }
+
+        public void Remove(IMapsDirectlyToDatabaseTable o)
+        {
+            if(o == null)
+                return;
+
+            foreach (var historyEntry in History.Where(h => h.Object.Equals(o)).ToArray())
+                History.Remove(historyEntry);
+        }
     }
 }


### PR DESCRIPTION
Fixes an issue in HomeUI where recent items still appeared despite being deleted from the database.  

We could do an exists check up front but it would result in things vanishing and its not how things like word / windows do it so probably best to follow the standard.