### PR TITLE
Fixed RowVerCache crashing when user lacks required permissions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Fixed
+
+- Fixed object caching system when RDMP user has insufficient permissions to view Change Tracking tables. 
+
 ## [4.1.1] - 2020-05-11
 
 

--- a/Rdmp.Core.Tests/Providers/RowVerTest.cs
+++ b/Rdmp.Core.Tests/Providers/RowVerTest.cs
@@ -68,6 +68,8 @@ namespace Rdmp.Core.Tests.Providers
             Assert.AreEqual(1,rowVerCache.GetAllObjects().Count(c=>c.Name.Equals("vroom")));
 
             Assert.AreEqual(1,rowVerCache.GetAllObjects().Count(c=>c.Name.Equals("vroom")));
+
+            Assert.IsFalse(rowVerCache.Broken);
         }
     }
 }


### PR DESCRIPTION
Fix for performance improvements when users do not have VIEW CHANGE TRACKING permission