### PR TITLE
Catalogues under a DLE load now show full range of icons (e.g. projec…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Ability to Enable/Disable many objects at once
+- Catalogue icons under a load now show full range of status icons (e.g. internal / project specific)
 
 ### Changed
 

--- a/Rdmp.UI/Icons/IconProvision/CatalogueIconProvider.cs
+++ b/Rdmp.UI/Icons/IconProvision/CatalogueIconProvider.cs
@@ -113,8 +113,8 @@ namespace Rdmp.UI.Icons.IconProvision
             if (concept is LinkedColumnInfoNode)
                 return GetImageImpl(ImagesCollection[RDMPConcept.ColumnInfo], OverlayKind.Link);
 
-            if (concept is CatalogueUsedByLoadMetadataNode)
-                return GetImageImpl(ImagesCollection[RDMPConcept.Catalogue], OverlayKind.Link);
+            if (concept is CatalogueUsedByLoadMetadataNode usedByLmd)
+                return GetImageImpl(usedByLmd.ObjectBeingUsed, OverlayKind.Link);
 
             if (concept is DataAccessCredentialUsageNode)
                 return GetImageImpl(ImagesCollection[RDMPConcept.DataAccessCredentials], OverlayKind.Link);


### PR DESCRIPTION
…t specific / internal)