### PR TITLE
Feature/cli file

### DIFF
--- a/Rdmp.Core.Tests/CommandLine/RdmpScriptTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/RdmpScriptTests.cs
@@ -1,0 +1,48 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using NUnit.Framework;
+using Rdmp.Core.CommandLine.Options;
+using Rdmp.Core.CommandLine.Runners;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataFlowPipeline;
+using ReusableLibraryCode.Checks;
+using ReusableLibraryCode.Progress;
+using Tests.Common;
+
+namespace Rdmp.Core.Tests.CommandLine
+{
+    class RdmpScriptTests : UnitTests
+    {
+        [TestCase("NewObject Catalogue 'trog dor'","trog dor")]
+        [TestCase("NewObject Catalogue \"trog dor\"","trog dor")]
+        [TestCase("NewObject Catalogue \"'trog dor'\"","'trog dor'")]
+        [TestCase("NewObject Catalogue '\"trog dor\"'","\"trog dor\"")]
+
+        public void TestRdmpScript_NewObject(string command, string expectedName)
+        {
+            foreach(var c in RepositoryLocator.CatalogueRepository.GetAllObjects<Catalogue>())
+                c.DeleteInDatabase();
+
+            var runner = new ExecuteCommandRunner(new ExecuteCommandOptions()
+            {
+                Script = new RdmpScript()
+                {
+                    Commands = new[] {command}
+                }
+            });
+            
+            SetupMEF();
+
+            var exitCode = runner.Run(RepositoryLocator, new ThrowImmediatelyDataLoadEventListener(), new ThrowImmediatelyCheckNotifier(), new GracefulCancellationToken());
+
+            Assert.AreEqual(0,exitCode);
+            Assert.AreEqual(1,RepositoryLocator.CatalogueRepository.GetAllObjects<Catalogue>().Length);
+
+            Assert.AreEqual(expectedName,RepositoryLocator.CatalogueRepository.GetAllObjects<Catalogue>().Single().Name);
+
+
+        }
+    }
+}

--- a/Rdmp.Core/CommandExecution/CommandInvoker.cs
+++ b/Rdmp.Core/CommandExecution/CommandInvoker.cs
@@ -130,8 +130,7 @@ namespace Rdmp.Core.CommandExecution
         
         public IEnumerable<Type> GetSupportedCommands()
         {
-            
-            return _basicActivator.RepositoryLocator.CatalogueRepository.MEF.GetAllTypes().Where(IsSupported);
+            return _basicActivator.RepositoryLocator.CatalogueRepository?.MEF?.GetAllTypes()?.Where(IsSupported) ?? throw new Exception("MEF property has not been initialized on the activator");
         }
 
         /// <summary>

--- a/Rdmp.Core/CommandLine/Options/ExecuteCommandOptions.cs
+++ b/Rdmp.Core/CommandLine/Options/ExecuteCommandOptions.cs
@@ -24,6 +24,15 @@ namespace Rdmp.Core.CommandLine.Options
         
         [Value(1,HelpText = "The arguments to provide for the command e.g. Catalogue:12")]
         public IEnumerable<string> CommandArgs { get; set; }
+
+        [Option('f',"file",HelpText="Runs commands in the given yaml file")]
+        public string File {get;set;}
+
+        /// <summary>
+        /// The deserialized contents of File or null if File is not provided.  It is up to the hosting API to populate this property
+        /// </summary>
+        /// <value></value>
+        public RdmpScript Script {get;set;}
         
         [Usage]
         public static IEnumerable<Example> Examples
@@ -32,9 +41,9 @@ namespace Rdmp.Core.CommandLine.Options
             {
                 yield return new Example("Runs the delete command on Catalogue with ID 1",new ExecuteCommandOptions(){CommandName = "Delete", CommandArgs = new string[]{"Catalogue:1"}});
                 yield return new Example("List available commands",new ExecuteCommandOptions(){CommandName = "ListSupportedCommands"});
+                yield return new Example("Runs all commands in the file",new ExecuteCommandOptions(){File = "./myfile.yaml"});
                 yield return new Example("Prompts you which command to run",new ExecuteCommandOptions());
             }
         }
-
     }
 }

--- a/Rdmp.Core/CommandLine/Options/RdmpScript.cs
+++ b/Rdmp.Core/CommandLine/Options/RdmpScript.cs
@@ -1,0 +1,22 @@
+// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.CommandLine.Runners;
+
+namespace Rdmp.Core.CommandLine.Options
+{
+    /// <summary>
+    /// Describes a series of commands to run in sequence.
+    /// </summary>
+    public  class RdmpScript
+    {        
+        /// <summary>
+        /// Commands which should be run by a <see cref="ExecuteCommandRunner"/>
+        /// </summary>
+        /// <value></value>
+        public string[] Commands {get;set;}
+    }
+}

--- a/Tools/rdmp/Program.cs
+++ b/Tools/rdmp/Program.cs
@@ -143,15 +143,23 @@ namespace Rdmp.Core
                     return -55;
                 }
 
+                var content = File.ReadAllText(opts.File);
+
+                if (string.IsNullOrWhiteSpace(content))
+                {
+                    Console.WriteLine($"File is empty ('{opts.File}')");
+                    return -56;
+                }
+
                 try
                 {
                     var d = new Deserializer();
-                    opts.Script = d.Deserialize<RdmpScript>(File.ReadAllText(opts.File));
+                    opts.Script = d.Deserialize<RdmpScript>(content);
                 }
                 catch(Exception ex)
                 {
                     Console.WriteLine($"Error deserializing '{opts.File}': {ex.Message}");
-                    return -66;                    
+                    return -57;                    
                 }
             }
 

--- a/Tools/rdmp/Program.cs
+++ b/Tools/rdmp/Program.cs
@@ -24,6 +24,7 @@ using Rdmp.Core.Startup;
 using ReusableLibraryCode;
 using ReusableLibraryCode.Checks;
 using YamlDotNet.RepresentationModel;
+using YamlDotNet.Serialization;
 
 namespace Rdmp.Core
 {
@@ -97,7 +98,7 @@ namespace Rdmp.Core
                             (CohortCreationOptions opts) => Run(opts),
                             (PackOptions opts) => Run(opts),
                             (PlatformDatabaseCreationOptions opts) => Run(opts),
-                            (ExecuteCommandOptions opts) => Run(opts),
+                            (ExecuteCommandOptions opts) => RunCmd(opts),
                             (ConsoleGuiOptions opts) => Run(opts),
                             errs => 1);
 
@@ -132,6 +133,30 @@ namespace Rdmp.Core
             return 0;
         }
 
+        private static int RunCmd(ExecuteCommandOptions opts)
+        {
+            if(!string.IsNullOrWhiteSpace(opts.File))
+            {
+                if(!File.Exists(opts.File))
+                {
+                    Console.WriteLine($"Could not find file '{opts.File}'");
+                    return -55;
+                }
+
+                try
+                {
+                    var d = new Deserializer();
+                    opts.Script = d.Deserialize<RdmpScript>(File.ReadAllText(opts.File));
+                }
+                catch(Exception ex)
+                {
+                    Console.WriteLine($"Error deserializing '{opts.File}': {ex.Message}");
+                    return -66;                    
+                }
+            }
+
+            return Run((RDMPCommandLineOptions) opts);
+        }
 
         private static int Run(RDMPCommandLineOptions opts)
         {


### PR DESCRIPTION
Adds the ability to provide a whole script to `rdmp.exe` instead of having to call it many times.  I have used yaml to allow for easy comments and to leave open the possibility for more advanced stuff later on (like paramaterization).

Yaml is only used in the `rdmp.csproj` while the main code execution uses the new `RdmpScript` object so this does not introduce a new dependency into the main RDMP.Core plugin/project.

![image](https://user-images.githubusercontent.com/31306100/84236420-84caa480-aaef-11ea-8993-e2d159f63809.png)
