### PR TITLE
Feature/foreach doc

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- Custom Metadata Report now supports looping items in a Catalogue (use `$foreach CatalogueItem` to start and `$end` to end)
+
 ## [4.1.3] - 2020-06-15
 
 ### Added

--- a/Rdmp.Core/Reports/CustomMetadataReport.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReport.cs
@@ -20,8 +20,15 @@ namespace Rdmp.Core.Reports
     /// </summary>
     public class CustomMetadataReport
     {
+        /// <summary>
+        /// Wildcards that are used during template value replacement e.g. $Name => Catalogue.Name
+        /// </summary>
 
         Dictionary<string,Func<Catalogue,object>> Replacements = new Dictionary<string, Func<Catalogue,object>>();
+
+        /// <summary>
+        /// Wildcards that are used during template value replacement when inside a '$foreach CatalogueItem' block e.g. $Name => CatalogueItem.Name
+        /// </summary>
 
         Dictionary<string,Func<CatalogueItem,object>> ReplacementsCatalogueItem = new Dictionary<string, Func<CatalogueItem,object>>();
 

--- a/Rdmp.Core/Reports/CustomMetadataReport.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReport.cs
@@ -163,7 +163,7 @@ namespace Rdmp.Core.Reports
                 }
 
                 if(current == LoopCatalogueItems)
-                    throw new CustomMetadataReportException($"Error, encountered '{current}' on line {i+1} before the end of current block which started on line {index}.  Make sure to add {EndLoop} at the end of each loop",i+1);
+                    throw new CustomMetadataReportException($"Error, encountered '{current}' on line {i+1} before the end of current block which started on line {index +1}.  Make sure to add {EndLoop} at the end of each loop",i+1);
 
                 block.AppendLine(current);
             }

--- a/Rdmp.Core/Reports/CustomMetadataReport.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReport.cs
@@ -21,13 +21,13 @@ namespace Rdmp.Core.Reports
     public class CustomMetadataReport
     {
         /// <summary>
-        /// Wildcards that are used during template value replacement e.g. $Name => Catalogue.Name
+        /// Substitutions that are used during template value replacement e.g. $Name => Catalogue.Name
         /// </summary>
 
         Dictionary<string,Func<Catalogue,object>> Replacements = new Dictionary<string, Func<Catalogue,object>>();
 
         /// <summary>
-        /// Wildcards that are used during template value replacement when inside a '$foreach CatalogueItem' block e.g. $Name => CatalogueItem.Name
+        /// Substitutions that are used during template value replacement when inside a '$foreach CatalogueItem' block e.g. $Name => CatalogueItem.Name
         /// </summary>
 
         Dictionary<string,Func<CatalogueItem,object>> ReplacementsCatalogueItem = new Dictionary<string, Func<CatalogueItem,object>>();
@@ -67,9 +67,9 @@ namespace Rdmp.Core.Reports
         /// </summary>
         /// <param name="catalogues">All catalogues that you want to produce metadata for</param>
         /// <param name="outputDirectory">The directory to write output file(s) into</param>
-        /// <param name="template">Template file with free text and wildcards (e.g. $Name).  Also supports looping e.g. $foreach CatalogueItem</param>
-        /// <param name="fileNaming">Determines how output file(s) will be named in the <paramref name="outputDirectory"/>.  Supports wild cards e.g. $Name.md</param>
-        /// <param name="oneFile">True to concatenate the results together and output in a single file.  If true then <paramref name="fileNaming"/> should not contain wildcards.  If false then <paramref name="fileNaming"/> should contain wildcards (e.g. $Name.doc) to prevent duplicate file names</param>
+        /// <param name="template">Template file with free text and substitutions (e.g. $Name).  Also supports looping e.g. $foreach CatalogueItem</param>
+        /// <param name="fileNaming">Determines how output file(s) will be named in the <paramref name="outputDirectory"/>.  Supports substitution e.g. $Name.md</param>
+        /// <param name="oneFile">True to concatenate the results together and output in a single file.  If true then <paramref name="fileNaming"/> should not contain substitutions.  If false then <paramref name="fileNaming"/> should contain substitutions (e.g. $Name.doc) to prevent duplicate file names</param>
         public void GenerateReport(Catalogue[] catalogues, DirectoryInfo outputDirectory, FileInfo template, string fileNaming, bool oneFile)
         {
             if(catalogues == null || !catalogues.Any())

--- a/Rdmp.Core/Reports/CustomMetadataReport.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReport.cs
@@ -55,6 +55,14 @@ namespace Rdmp.Core.Reports
                 (c) => _timespanCalculator?.GetHumanReadableTimepsanIfKnownOf(c, true, out _));
         }
         
+        /// <summary>
+        /// Reads the contents of <paramref name="template"/> and generates one or more files (see <paramref name="oneFile"/>) by substituting tokens (e.g. $Name) for the values in the provided <paramref name="catalogues"/>
+        /// </summary>
+        /// <param name="catalogues">All catalogues that you want to produce metadata for</param>
+        /// <param name="outputDirectory">The directory to write output file(s) into</param>
+        /// <param name="template">Template file with free text and wildcards (e.g. $Name).  Also supports looping e.g. $foreach CatalogueItem</param>
+        /// <param name="fileNaming">Determines how output file(s) will be named in the <paramref name="outputDirectory"/>.  Supports wild cards e.g. $Name.md</param>
+        /// <param name="oneFile">True to concatenate the results together and output in a single file.  If true then <paramref name="fileNaming"/> should not contain wildcards.  If false then <paramref name="fileNaming"/> should contain wildcards (e.g. $Name.doc) to prevent duplicate file names</param>
         public void GenerateReport(Catalogue[] catalogues, DirectoryInfo outputDirectory, FileInfo template, string fileNaming, bool oneFile)
         {
             if(catalogues == null || !catalogues.Any())
@@ -62,7 +70,7 @@ namespace Rdmp.Core.Reports
             
             var templateBody = File.ReadAllLines(template.FullName);
 
-            string outname = DoReplacements(fileNaming,catalogues.First());
+            string outname = DoReplacements(new []{fileNaming},catalogues.First()).Trim();
 
             StreamWriter outFile = null;
             
@@ -77,8 +85,9 @@ namespace Rdmp.Core.Reports
                     outFile.WriteLine(newContents);
                 else
                 {
-                    using (var sw = new StreamWriter(Path.Combine(outputDirectory.FullName,
-                        DoReplacements(fileNaming, catalogue))))
+                    string filename = DoReplacements(new[] {fileNaming}, catalogue).Trim();
+
+                    using (var sw = new StreamWriter(Path.Combine(outputDirectory.FullName,filename)))
                     {
                         sw.Write(newContents);
                         sw.Flush();
@@ -90,10 +99,6 @@ namespace Rdmp.Core.Reports
             outFile?.Dispose();
         }
 
-        private string DoReplacements(string str, Catalogue catalogue)
-        {
-            return DoReplacements(new string[] {str}, catalogue);
-        }
         private string DoReplacements(string[] strs, Catalogue catalogue)
         {
             StringBuilder sb = new StringBuilder();

--- a/Rdmp.Core/Reports/CustomMetadataReport.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReport.cs
@@ -15,7 +15,6 @@ using Rdmp.Core.Repositories;
 
 namespace Rdmp.Core.Reports
 {
-
     /// <summary>
     /// Create a custom report e.g. markdown, xml etc by taking a template file and replicating it with replacements for each <see cref="Catalogue"/> property
     /// </summary>
@@ -151,11 +150,14 @@ namespace Rdmp.Core.Reports
                     break;
                 }
 
+                if(current == LoopCatalogueItems)
+                    throw new CustomMetadataReportException($"Error, encountered '{current}' on line {i+1} before the end of current block which started on line {index}.  Make sure to add {EndLoop} at the end of each loop",i+1);
+
                 block.AppendLine(current);
             }
 
             if(!blockTerminated)
-                throw new Exception($"Expected $end to match $foreach which started on line {index}");
+                throw new CustomMetadataReportException($"Expected {EndLoop} to match $foreach which started on line {index+1}",index+1);
 
             foreach (CatalogueItem ci in catalogueItems) 
                 sbResult.AppendLine(DoReplacements(block.ToString(), ci));

--- a/Rdmp.Core/Reports/CustomMetadataReportException.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReportException.cs
@@ -8,6 +8,9 @@ using System;
 
 namespace Rdmp.Core.Reports
 {
+    /// <summary>
+    /// Thrown when a problem is encountered parsing a template during <see cref="CustomMetadataReport"/> execution
+    /// </summary>
     public class CustomMetadataReportException : Exception
     {
         /// <summary>

--- a/Rdmp.Core/Reports/CustomMetadataReportException.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReportException.cs
@@ -1,0 +1,34 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+
+namespace Rdmp.Core.Reports
+{
+    public class CustomMetadataReportException : Exception
+    {
+        /// <summary>
+        /// The line number in the template that the error occurred (first line of file is 1)
+        /// </summary>
+        public int LineNumber { get; set; }
+
+        /// <summary>
+        /// Tells the user there is a problem with a template being used in <see cref="CustomMetadataReport"/>
+        /// </summary>
+        /// <param name="msg"></param>
+        /// <param name="lineNumber">The line number in the template that the error occurred (first line of file is 1)</param>
+        public CustomMetadataReportException(string msg,int lineNumber) : base(msg)
+        {
+            LineNumber = lineNumber;
+        }
+
+        public CustomMetadataReportException(string msg, Exception inner,int lineNumber):base(msg,inner)
+        {
+            LineNumber = lineNumber;
+        }
+        
+    }
+}


### PR DESCRIPTION
Support for looping through CatalogueItems (columns) in a dataset when producing a custom metadata report from a template:

```
## $Name
$Description
| Column | Description |
$foreach CatalogueItem
| $Name | $Description |
$end
```

This would produce an example output of:

```md
## My Cool Dataset
A cool dataset with interesting stuff
| Column | Description |
| Col1 | some info about column 1 |
| Col2 | some info about column 2 |
```