### PR TITLE
Standardised GoTo and made tab context menu rebuild after refresh

### DIFF
--- a/Application/ResearchDataManagementPlatform/WindowManagement/WindowFactory.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/WindowFactory.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Drawing;
 using System.Windows.Forms;
 using MapsDirectlyToDatabaseTable;
@@ -129,7 +130,27 @@ namespace ResearchDataManagementPlatform.WindowManagement
             var tab = content as RDMPSingleControlTab;
 
             if (tab != null)
+            {
                 content.TabPageContextMenuStrip = new RDMPSingleControlTabMenu(activator, tab, _windowManager);
+
+                //Create handler for AfterPublish
+                RefreshObjectEventHandler handler = null;
+                handler = (s,e)=>
+                { 
+                    // After global changes, rebuild the context menu
+
+                    if(!content.IsDisposed)
+                        content.TabPageContextMenuStrip = new RDMPSingleControlTabMenu(activator, tab, _windowManager);
+                    else
+                        if(handler != null)
+                            activator.RefreshBus.AfterPublish -= handler; //don't leak handlers
+                };
+
+                //register the event handler
+                activator.RefreshBus.AfterPublish += handler;
+                
+            }
+                
         }
     }
 }

--- a/Application/ResearchDataManagementPlatform/WindowManagement/WindowFactory.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/WindowFactory.cs
@@ -120,16 +120,12 @@ namespace ResearchDataManagementPlatform.WindowManagement
             if(image != null)
                 content.Icon = _iconFactory.GetIcon(image);
 
-            var consult = control as IConsultableBeforeClosing;
-
-            if (consult != null)
+            if (control is IConsultableBeforeClosing consult)
                 content.FormClosing += consult.ConsultAboutClosing;
 
             content.KeyPreview = true;
-            
-            var tab = content as RDMPSingleControlTab;
 
-            if (tab != null)
+            if (content is RDMPSingleControlTab tab)
             {
                 content.TabPageContextMenuStrip = new RDMPSingleControlTabMenu(activator, tab, _windowManager);
 

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandShow.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandShow.cs
@@ -30,9 +30,12 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
         public ExecuteCommandShow(IActivateItems activator, IMapsDirectlyToDatabaseTable objectToShow, int expansionDepth, bool useIconAndTypeName=false):base(activator)
         {
             _objectToShow = objectToShow;
-            _objectType = _objectToShow.GetType();
+            _objectType = _objectToShow?.GetType();
             _expansionDepth = expansionDepth;
             _useIconAndTypeName = useIconAndTypeName;
+
+            if(_objectToShow == null)
+                SetImpossible("No objects found");
         }
 
 

--- a/Rdmp.UI/ExtractionUIs/ExtractionInformationUI.cs
+++ b/Rdmp.UI/ExtractionUIs/ExtractionInformationUI.cs
@@ -145,8 +145,6 @@ namespace Rdmp.UI.ExtractionUIs
             ObjectSaverButton1.BeforeSave += objectSaverButton1OnBeforeSave;
 
             CommonFunctionality.Add(ragSmiley1);
-            CommonFunctionality.AddToMenu(new ExecuteCommandActivate(activator, databaseObject.CatalogueItem), "Go To Description (CatalogueItem)");
-            CommonFunctionality.AddToMenu(new ExecuteCommandShow(activator, databaseObject.ColumnInfo, 0, true));
 
             CommonFunctionality.AddHelp(cbHashOnDataRelease, "IColumn.HashOnDataRelease", "Hash on Data Release");
             CommonFunctionality.AddHelp(cbIsExtractionIdentifier, "IColumn.IsExtractionIdentifier", "Is Extraction Identifier");

--- a/Rdmp.UI/MainFormUITabs/CatalogueItemUI.cs
+++ b/Rdmp.UI/MainFormUITabs/CatalogueItemUI.cs
@@ -76,13 +76,8 @@ namespace Rdmp.UI.MainFormUITabs
             base.SetDatabaseObject(activator,databaseObject);
             
 
-            if (_catalogueItem.ExtractionInformation != null)
-                CommonFunctionality.AddToMenu(new ExecuteCommandActivate(activator, _catalogueItem.ExtractionInformation), "Go To Extraction Information");
-            else
+            if (_catalogueItem.ExtractionInformation == null)
                 CommonFunctionality.AddToMenu(new ExecuteCommandMakeCatalogueItemExtractable(activator, _catalogueItem), "Make Extractable");
-
-            if (_catalogueItem.ColumnInfo_ID != null)
-                CommonFunctionality.AddToMenu(new ExecuteCommandShow(activator, _catalogueItem.ColumnInfo, 0, true));
         }
 
         protected override void SetBindings(BinderWithErrorProviderFactory rules, CatalogueItem databaseObject)


### PR DESCRIPTION
This relates to the changelog entry:

```
Fixed bugs in using GoTo menu of document tabs after a Refresh
```

It removes legacy GoTo commands that were part of the 'burger bar' button (in favour of using the right click context menu GoTo):

![image](https://user-images.githubusercontent.com/31306100/85693833-7f17b600-b6ce-11ea-8ba4-947ac80604d8.png)

Also includes rebuilding the `TabPageContextMenuStrip` on every tab after global refreshes (fixes stale GoTo options).