### PR TITLE
Feature/template cli

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Custom Metadata Report now supports looping items in a Catalogue (use `$foreach CatalogueItem` to start and `$end` to end)
 - Added help to 'New Project' user interface
 - Forward/Backward now includes selection changes in tree collections
+- Added support for newline replacement in custom metadata doc templates
 
 ### Changed
 
@@ -28,6 +29,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed alias changes not showing up as 'Differences' in edit dataeset extraction user interface
 - Fixed bugs in using GoTo menu of document tabs after a Refresh
 - Fixed ALTER context sub menu of TableInfo when Server property is null (or other fundamental connection details cannot be resolved).
+- Fixed whitespace only literal strings (e.g. `" "`) on command line causing error while parsing arguments
 
 ## [4.1.3] - 2020-06-15
 

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandDescribeCommand.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandDescribeCommand.cs
@@ -51,6 +51,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         public void Test_DescribeDeleteCommand()
         {
             AssertHelpIs( @"cmd Delete <deletable> 
+
 PARAMETERS:
 deletable	IDeleteable	The object you want to delete",typeof(ExecuteCommandDelete));
         }
@@ -61,6 +62,7 @@ deletable	IDeleteable	The object you want to delete",typeof(ExecuteCommandDelete
         {
             AssertHelpIs( 
 @"cmd ImportTableInfo <table> <createCatalogue> 
+
 PARAMETERS:
 table	DiscoveredTable	The table or view you want to reference from RDMP.  See PickTable for syntax
 createCatalogue	Boolean	True to create a Catalogue as well as a TableInfo"

--- a/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
@@ -63,6 +63,27 @@ namespace Rdmp.Core.Tests.CommandLine
            Assert.AreEqual(cata,picker[0].DatabaseEntities.Single());
         }
 
+        /// <summary>
+        /// Tests behaviour of picker when user passes an explicit empty string e.g. ./rdmp.exe DoSomething " "
+        /// </summary>
+        [TestCase(" ")]
+        [TestCase("\t")]
+        [TestCase("\r\n")]
+        public void Test_PickerForWhitespace(string val)
+        {
+            var picker = new CommandLineObjectPicker(new []{val },RepositoryLocator);
+
+            Assert.AreEqual(1,picker.Length);
+            
+            Assert.IsNull(picker[0].Database);
+            Assert.IsNull(picker[0].DatabaseEntities);
+            Assert.IsFalse(picker[0].ExplicitNull);
+            Assert.AreEqual(val,picker[0].RawValue);
+            Assert.IsNull(picker[0].Type);
+            
+            Assert.AreEqual(val,picker[0].GetValueForParameterOfType(typeof(string)));
+            Assert.IsTrue(picker.HasArgumentOfType(0, typeof(string)));
+        }
         
         [Test]
         public void Test_PickCatalogueByID_PickTwo()

--- a/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
+++ b/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
@@ -39,7 +39,7 @@ namespace Rdmp.Core.Tests.Reports
                 @"| Name | Desc|
 | $Name | $Description |");
 
-            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", oneFile);
+            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", oneFile,null);
             cmd.Execute();
 
             var outFile = Path.Combine(outDir.FullName, "ffff.md");
@@ -71,7 +71,7 @@ namespace Rdmp.Core.Tests.Reports
                 @"| Name | Desc| Range |
 | $Name | $Description | $StartDate$EndDate$DateRange |");
 
-            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", false);
+            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", false,null);
             cmd.Execute();
 
             var outFile = Path.Combine(outDir.FullName, "ffff.md");
@@ -115,7 +115,7 @@ namespace Rdmp.Core.Tests.Reports
 
 
             var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata,cata2}, outDir, template, 
-                oneFile ? "results.xml" : "$Name.xml", oneFile);
+                oneFile ? "results.xml" : "$Name.xml", oneFile,null);
             cmd.Execute();
 
             if (oneFile)
@@ -199,7 +199,7 @@ $foreach CatalogueItem
 | $Name | $Description |
 $end");
 
-            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", oneFile);
+            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", oneFile,null);
             cmd.Execute();
 
             var outFile = Path.Combine(outDir.FullName, "ffff.md");
@@ -265,7 +265,7 @@ $foreach CatalogueItem
 | $Name | $Description |
 $end");
 
-            var cmd = new ExecuteCommandExtractMetadata(null, new[] {c1,c2}, outDir, template, "Datasets.md", true);
+            var cmd = new ExecuteCommandExtractMetadata(null, new[] {c1,c2}, outDir, template, "Datasets.md", true,null);
             cmd.Execute();
 
             var outFile = Path.Combine(outDir.FullName, "Datasets.md");
@@ -311,7 +311,7 @@ $Description
 $foreach CatalogueItem
 | $Name | $Description |");
 
-            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", false);
+            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", false,null);
             var ex = Assert.Throws<CustomMetadataReportException>(cmd.Execute);
 
             Assert.AreEqual(4,ex.LineNumber);
@@ -345,11 +345,31 @@ $foreach CatalogueItem
 $end
 $end");
 
-            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", false);
+            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", false,null);
             var ex = Assert.Throws<CustomMetadataReportException>(cmd.Execute);
 
             Assert.AreEqual(6,ex.LineNumber);
             StringAssert.StartsWith("Error, encountered '$foreach CatalogueItem' on line 6",ex.Message);
+        }
+
+        [Test]
+        public void TestNewlineSubstitution()
+        {
+            var report = new CustomMetadataReport();
+
+            //default is no substitution
+            Assert.IsNull(report.NewlineSubstitution);
+
+            Assert.IsNull(report.ReplaceNewlines(null));
+
+            Assert.AreEqual("aa\r\nbb",report.ReplaceNewlines("aa\r\nbb"));
+            Assert.AreEqual("aa\nbb",report.ReplaceNewlines("aa\nbb"));
+
+            report.NewlineSubstitution = "<br/>";
+
+            Assert.AreEqual("aa<br/>bb",report.ReplaceNewlines("aa\r\nbb"));
+            Assert.AreEqual("aa<br/>bb",report.ReplaceNewlines("aa\nbb"));
+
         }
     }
 }

--- a/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
+++ b/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
@@ -371,5 +371,54 @@ $end");
             Assert.AreEqual("aa<br/>bb",report.ReplaceNewlines("aa\nbb"));
 
         }
+
+        [Test]
+        public void TestNewlineSubstitution_FullTemplate()
+        {
+            var cata = WhenIHaveA<Catalogue>();
+            cata.Name = "ffff";
+            cata.Description = @"A cool
+dataset with interesting stuff";
+            cata.SaveToDatabase();
+
+            var cataItem1 = new CatalogueItem(RepositoryLocator.CatalogueRepository, cata, "Col1");
+            cataItem1.Description = "some info about column 1";
+            cataItem1.SaveToDatabase();
+
+            var cataItem2 = new CatalogueItem(RepositoryLocator.CatalogueRepository, cata, "Col2");
+            cataItem2.Description = @"some info 
+about column 2";
+            cataItem2.SaveToDatabase();
+
+            var template = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "template.md"));
+            var outDir = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "outDir"));
+
+            if(outDir.Exists)
+                outDir.Delete(true);
+            
+            outDir.Create();
+
+            File.WriteAllText(template.FullName,
+                @"## $Name
+$Description
+| Column | Description |
+$foreach CatalogueItem
+| $Name | $Description |
+$end");
+
+            var cmd = new ExecuteCommandExtractMetadata(null, new[] {cata}, outDir, template, "$Name.md", false,"<br/>");
+            cmd.Execute();
+
+            var outFile = Path.Combine(outDir.FullName, "ffff.md");
+
+            FileAssert.Exists(outFile);
+            var resultText = File.ReadAllText(outFile);
+
+            StringAssert.AreEqualIgnoringCase(@"## ffff
+A cool<br/>dataset with interesting stuff
+| Column | Description |
+| Col1 | some info about column 1 |
+| Col2 | some info <br/>about column 2 |",resultText.TrimEnd());
+        }
     }
 }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribeCommand.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribeCommand.cs
@@ -41,14 +41,18 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 sb.AppendLine($"Command '{_commandType.Name}' is not supported by the current input type ({BasicActivator.GetType().Name})");
             else
             {
-                sb.AppendLine("COMMAND:" + _commandType.FullName);
+                sb.AppendLine("Name: " + _commandType.Name);
                 
                 var helpText = help.GetTypeDocumentationIfExists(_commandType);
 
                 if(helpText != null)
-                    sb.AppendLine(helpText);
-
-                sb.AppendLine("USAGE:");
+                {
+                    sb.AppendLine();
+                    sb.AppendLine("Description: " + helpText);
+                }
+                    
+                sb.AppendLine();
+                sb.AppendLine("USAGE: ");
                 
                 sb.Append(EnvironmentInfo.IsLinux ? "./rdmp" : "./rdmp.exe");
                 sb.Append(" cmd ");
@@ -57,6 +61,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 sb.Append(" ");
 
                 var sbParameters = new StringBuilder();
+                sbParameters.AppendLine();
                 sbParameters.AppendLine("PARAMETERS:");
 
                 foreach(ParameterInfo p in commandCtor.GetParameters())

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandExtractMetadata.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandExtractMetadata.cs
@@ -25,6 +25,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         private readonly FileInfo _template;
         private readonly string _fileNaming;
         private readonly bool _oneFile;
+        private readonly string _newlineSub;
 
         public ExecuteCommandExtractMetadata(IBasicActivateItems basicActivator, 
             Catalogue[] catalogues, 
@@ -36,13 +37,16 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             [DemandsInitialization("How output files based on the template should be named.  Uses same replacement strategy as template contents e.g. $Name.xml")]
             string fileNaming, 
             [DemandsInitialization("True to append all ouputs into a single file.  False to output a new file for every Catalogue")]
-            bool oneFile):base(basicActivator)
+            bool oneFile, 
+            [DemandsInitialization("Optional, specify a replacement for newlines when found in fields e.g. <br/>.  Leave as null to leave newlines intact.")]
+            string newlineSub):base(basicActivator)
         {
             _catalogues = catalogues;
             _outputDirectory = outputDirectory;
             _template = template;
             _fileNaming = fileNaming;
             _oneFile = oneFile;
+            _newlineSub = newlineSub;
         }
 
         public override void Execute()
@@ -81,7 +85,10 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             if (string.IsNullOrWhiteSpace(fileNaming))
                 return;
 
-            var reporter = new CustomMetadataReport();
+            var reporter = new CustomMetadataReport()
+            {
+                NewlineSubstitution = _newlineSub
+            };
             reporter.GenerateReport(catas.Cast<Catalogue>().ToArray(),outputDir,template, fileNaming, _oneFile);
         }
     }

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickType.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickType.cs
@@ -35,6 +35,9 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
 
         private Type GetType(string arg)
         {
+            if(string.IsNullOrWhiteSpace(arg))
+                return null;
+
             try
             {
                 return 

--- a/Rdmp.UI.Tests/DesignPatternTests/ClassFileEvaluation/DocumentationCrossExaminationTest.cs
+++ b/Rdmp.UI.Tests/DesignPatternTests/ClassFileEvaluation/DocumentationCrossExaminationTest.cs
@@ -248,7 +248,8 @@ namespace Rdmp.UI.Tests.DesignPatternTests.ClassFileEvaluation
             "SetupLazy",
             "TestCaseSourceAttribute",
             "DescribeCommand", //aka ExecuteCommandDescribeCommand
-            "MySqlConnector"
+            "MySqlConnector",
+            "DoSomething"
         };
         #endregion
         public DocumentationCrossExaminationTest(DirectoryInfo slndir)

--- a/Rdmp.UI/Menus/CatalogueMenu.cs
+++ b/Rdmp.UI/Menus/CatalogueMenu.cs
@@ -49,7 +49,7 @@ namespace Rdmp.UI.Menus
             Add(new ExecuteCommandImportCatalogueDescriptionsFromShare(_activator, catalogue),Keys.None,extract);
             Add(new ExecuteCommandExportInDublinCoreFormat(_activator, catalogue),Keys.None,extract);
             Add(new ExecuteCommandImportDublinCoreFormat(_activator, catalogue), Keys.None, extract);
-            Add(new ExecuteCommandExtractMetadata(_activator, new []{ catalogue},null,null,null,false){OverrideCommandName = "Custom..."}, Keys.None, extract);
+            Add(new ExecuteCommandExtractMetadata(_activator, new []{ catalogue},null,null,null,false,null){OverrideCommandName = "Custom..."}, Keys.None, extract);
             Items.Add(extract);
 
             Items.Add(new DQEMenuItem(_activator,catalogue));


### PR DESCRIPTION
This PR adds support for replacing newlines in metadata templates e.g. $Description with a substitution string e.g. `"<br/>"`

For example, the following would replace newlines with a single space:

```
rdmp.exe cmd ExtractMetadata Catalogue:* "C:/temp/deleteme" "C:/temp/myTemplate.md" $Name.md False " "
```