### PR TITLE
Fix for emphasise on tab change when selecting objects under a cic

### DIFF
--- a/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
+++ b/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
@@ -254,7 +254,12 @@ namespace ResearchDataManagementPlatform.Menus
 
                 //don't emphasise things that live under cics because it doesn't result in a collection being opened but instead opens the cic Tab (which could result in you being unable to get to your original tab!)
                 if(isCicChild == false)
+                {
+                    _windowManager.Navigation.Suspend();
                     Activator.RequestItemEmphasis(this, new EmphasiseRequest(singleObject.DatabaseObject));
+                    _windowManager.Navigation.Resume();
+                }
+                    
             }
                 
 

--- a/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
+++ b/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
@@ -247,7 +247,7 @@ namespace ResearchDataManagementPlatform.Menus
             var saveable = singleObjectControlTab.GetControl() as ISaveableUI;
             var singleObject = singleObjectControlTab.GetControl() as IRDMPSingleDatabaseObjectControl;
 
-            //if user wants to emphasise on tab change and theres an object we can emphasise associated with the control
+            //if user wants to emphasise on tab change and there's an object we can emphasise associated with the control
             if (singleObject != null && UserSettings.EmphasiseOnTabChanged && singleObject.DatabaseObject != null)
             {
                 bool? isCicChild = Activator.CoreChildProvider.GetDescendancyListIfAnyFor(singleObject.DatabaseObject)?.Parents?.Any(p=>p is CohortIdentificationConfiguration);

--- a/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
+++ b/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Windows.Forms;
 using Rdmp.Core.CommandExecution;
 using Rdmp.Core.CommandExecution.AtomicCommands;
+using Rdmp.Core.Curation.Data.Cohort;
 using Rdmp.Core.DataQualityEngine;
 using Rdmp.Core.Logging;
 using Rdmp.Core.Reports;
@@ -248,7 +249,14 @@ namespace ResearchDataManagementPlatform.Menus
 
             //if user wants to emphasise on tab change and theres an object we can emphasise associated with the control
             if (singleObject != null && UserSettings.EmphasiseOnTabChanged && singleObject.DatabaseObject != null)
-                Activator.RequestItemEmphasis(this, new EmphasiseRequest(singleObject.DatabaseObject));
+            {
+                bool? isCicChild = Activator.CoreChildProvider.GetDescendancyListIfAnyFor(singleObject.DatabaseObject)?.Parents?.Any(p=>p is CohortIdentificationConfiguration);
+
+                //don't emphasise things that live under cics because it doesn't result in a collection being opened but instead opens the cic Tab (which could result in you being unable to get to your original tab!)
+                if(isCicChild == false)
+                    Activator.RequestItemEmphasis(this, new EmphasiseRequest(singleObject.DatabaseObject));
+            }
+                
 
             _saveToolStripMenuItem.Saveable = saveable;
         }

--- a/Application/ResearchDataManagementPlatform/WindowManagement/HomePane/HomeBoxUI.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/HomePane/HomeBoxUI.cs
@@ -58,7 +58,7 @@ namespace ResearchDataManagementPlatform.WindowManagement.HomePane
                 };
 
             
-                //if theres only one command for new
+                //if there's only one command for new
                 if (newCommands.Length == 1)
                 {
                     //don't use the dropdown

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed ALTER context sub menu of TableInfo when Server property is null (or other fundamental connection details cannot be resolved).
 - Fixed whitespace only literal strings (e.g. `" "`) on command line causing error while parsing arguments
 - Fixed bug with YesNoToAll popups launched from ChecksUI when running as a modal dialogue.
+- Fixed bug with user setting 'Show Object Collection On Tab Change' when selecting tabs for objects in CohortBuilder configurations.
 
 ## [4.1.3] - 2020-06-15
 

--- a/Rdmp.Core.Tests/CohortCreation/QueryTests/CohortQueryBuilderTests.cs
+++ b/Rdmp.Core.Tests/CohortCreation/QueryTests/CohortQueryBuilderTests.cs
@@ -51,7 +51,7 @@ FROM
 
         /// <summary>
         /// When we <see cref="CohortQueryBuilder.GetDatasetSampleSQL"/> we normally get "select TOP 1000 *" of the query body BUT
-        /// if theres HAVING sql then SQL will balk at select *.  In this case we expect it to just run the normal distinct chi
+        /// if there's HAVING sql then SQL will balk at select *.  In this case we expect it to just run the normal distinct chi
         /// bit but put a TOP X on it.
         /// </summary>
         [Test]

--- a/Rdmp.Core.Tests/Curation/CrossPlatformParameterTests/BasicParameterUseTests.cs
+++ b/Rdmp.Core.Tests/Curation/CrossPlatformParameterTests/BasicParameterUseTests.cs
@@ -31,7 +31,7 @@ namespace Rdmp.Core.Tests.Curation.CrossPlatformParameterTests
             //Pick the destination server
             var tableName = TestDatabaseNames.GetConsistentName("tbl");
             
-            //make sure theres a database ready to receive the data
+            //make sure there's a database ready to receive the data
             var db = GetCleanedServer(dbType);
             db.Create(true);
 

--- a/Rdmp.Core.Tests/Curation/Integration/QueryBuildingTests/AggregateBuilderTests/AggregateDataBasedTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/QueryBuildingTests/AggregateBuilderTests/AggregateDataBasedTests.cs
@@ -378,7 +378,7 @@ namespace Rdmp.Core.Tests.Curation.Integration.QueryBuildingTests.AggregateBuild
                 //axis is ordered ascending by date starting in 2000 so that row should come first
                 Assert.IsTrue(AreBasicallyEquals("2000", resultTable.Rows[0][0]));
 
-                VerifyRowExist(resultTable, "2000", null); //records only showing where there are more than 3 records (HAVING refers to the year since theres no pivot)
+                VerifyRowExist(resultTable, "2000", null); //records only showing where there are more than 3 records (HAVING refers to the year since there's no pivot)
                 VerifyRowExist(resultTable, "2001", 5);
                 VerifyRowExist(resultTable, "2002", 5);
                 VerifyRowExist(resultTable, "2003", null);

--- a/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Sources/DelimitedFileSourceTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Sources/DelimitedFileSourceTests.cs
@@ -234,7 +234,7 @@ namespace Rdmp.Core.Tests.DataLoad.Engine.Integration.PipelineTests.Sources
         /// <summary>
         /// Test checks that IgnoreBadReads lets you load quotes in the middle of free text without having to set IgnoreQuotes to true:
         /// 1. There is a row (2) with quotes in the middle which should get loaded correctly
-        /// 2. Theres a row (4) with quotes in the middle of the text and the cell itself is quoted.  This loads but drops some quotes.
+        /// 2. there's a row (4) with quotes in the middle of the text and the cell itself is quoted.  This loads but drops some quotes.
         /// 
         /// <para>The proper way to express row 4 is by escaping the quote with another quote i.e. "" (See test DelimitedFlatFileDataFlowSource_ProperQuoteEscaping) </para>
         /// </summary>

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandChooseCohort.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandChooseCohort.cs
@@ -50,7 +50,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             if (_childProvider.ProjectNumberToCohortsDictionary.ContainsKey(project.ProjectNumber.Value))
                 _compatibleCohorts = (_childProvider.ProjectNumberToCohortsDictionary[project.ProjectNumber.Value]).ToList();
 
-            //if theres only one compatible cohort and that one is already selected
+            //if there's only one compatible cohort and that one is already selected
             if (_compatibleCohorts.Count == 1 && _compatibleCohorts.Single().ID == _extractionConfiguration.Cohort_ID)
                 SetImpossible("The currently select cohort is the only one available");
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetDataAccessContextForCredentials.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetDataAccessContextForCredentials.cs
@@ -28,7 +28,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 return;
             }
             
-            //if theres already another credentials for that context (other than this one)
+            //if there's already another credential for that context (other than this one)
             if (existingCredentials.ContainsKey(newContext))
                 SetImpossible("DataAccessCredentials '" + existingCredentials[newContext] + "' are used for accessing table under context " + newContext);
         }

--- a/Rdmp.Core/CommandExecution/Combining/AggregateConfigurationCombineable.cs
+++ b/Rdmp.Core/CommandExecution/Combining/AggregateConfigurationCombineable.cs
@@ -70,7 +70,7 @@ namespace Rdmp.Core.CommandExecution.Combining
             //assume no join users
             JoinableUsersIfAny = new AggregateConfiguration[0];
 
-            //unless theres a cic
+            //unless there's a cic
             if(CohortIdentificationConfigurationIfAny != null)
             {
                 //with this aggregate as a joinable

--- a/Rdmp.Core/Curation/ANOEngineering/ColumnInfoANOPlan.cs
+++ b/Rdmp.Core/Curation/ANOEngineering/ColumnInfoANOPlan.cs
@@ -127,7 +127,7 @@ namespace Rdmp.Core.Curation.ANOEngineering
                         Plan = Plan.PassThroughUnchanged; //it is extractable but not special
 
 
-            //if theres an associated ANOTable with a different ColumnInfo with the same name e.g. chi=>ANOChi in another dataset that was already anonymised
+            //if there's an associated ANOTable with a different ColumnInfo with the same name e.g. chi=>ANOChi in another dataset that was already anonymised
             MakeANOTableSuggestionIfApplicable();
         }
 

--- a/Rdmp.Core/Curation/Data/DataLoad/ArgumentFactory.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/ArgumentFactory.cs
@@ -47,7 +47,7 @@ namespace Rdmp.Core.Curation.Data.DataLoad
 
             foreach (var required in propertiesWeHaveToSet)
             {
-                //theres already a property with the same name
+                //there's already a property with the same name
                 if (existingArguments.Any(a => a.Name.Equals(required.Name)))
                     continue;
 

--- a/Rdmp.Core/Curation/Data/DataLoad/LoadMetadata.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/LoadMetadata.cs
@@ -309,7 +309,7 @@ namespace Rdmp.Core.Curation.Data.DataLoad
         /// <param name="catalogue"></param>
         public void EnsureLoggingWorksFor(ICatalogue catalogue)
         {
-            //if theres no logging task / logging server set them up with the same name as the lmd
+            //if there's no logging task / logging server set them up with the same name as the lmd
             IExternalDatabaseServer loggingServer;
 
             if (catalogue.LiveLoggingServer_ID == null)
@@ -324,7 +324,7 @@ namespace Rdmp.Core.Curation.Data.DataLoad
             else
                 loggingServer = Repository.GetObjectByID<ExternalDatabaseServer>(catalogue.LiveLoggingServer_ID.Value);
 
-            //if theres no logging task yet and theres a logging server
+            //if there's no logging task yet and there's a logging server
             if (string.IsNullOrWhiteSpace(catalogue.LoggingDataTask))
             {
                 var lm = new LogManager(loggingServer);

--- a/Rdmp.Core/Curation/Data/ImportExport/ShareManager.cs
+++ b/Rdmp.Core/Curation/Data/ImportExport/ShareManager.cs
@@ -519,7 +519,7 @@ namespace Rdmp.Core.Curation.Data.ImportExport
                             case RelationshipType.OptionalSharedObject:
                             case RelationshipType.SharedObject:
                                 
-                                //Confirm that the share definition includes the knowledge that theres a parent class to this object
+                                //Confirm that the share definition includes the knowledge that there's a parent class to this object
                                 if (!shareDefinition.RelationshipProperties.ContainsKey(relationshipAttribute))
                                     //if it doesn't but the field is optional, ignore it
                                     if(relationshipAttribute.Type == RelationshipType.OptionalSharedObject)

--- a/Rdmp.Core/Curation/FilterImporting/FilterImporter.cs
+++ b/Rdmp.Core/Curation/FilterImporting/FilterImporter.cs
@@ -151,7 +151,7 @@ namespace Rdmp.Core.Curation.FilterImporting
             //if we have not yet found a reason to complain, look at parameters for a reason to complain
             if (reason == null)
             {
-                //check to see if theres a problem with the parameters
+                //check to see if there's a problem with the parameters
                 foreach (ISqlParameter filterParameter in filter.GetAllParameters())
                 {
                     string reasonParameterRejected;

--- a/Rdmp.Core/Curation/FilterImporting/ParameterCreator.cs
+++ b/Rdmp.Core/Curation/FilterImporting/ParameterCreator.cs
@@ -111,7 +111,7 @@ namespace Rdmp.Core.Curation.FilterImporting
                     {
                         string toCreate = matchingTemplateFilter.ParameterSQL;
 
-                        //theres a rename requirement e.g. 'DECLARE @bob AS int' to 'DECLARE @bob2 AS int' because the existing scope already has a parameter called @bob
+                        //there's a rename requirement e.g. 'DECLARE @bob AS int' to 'DECLARE @bob2 AS int' because the existing scope already has a parameter called @bob
                         if (proposedNewParameterName != requiredParameterName)
                             toCreate = toCreate.Replace(requiredParameterName, proposedNewParameterName);
                         

--- a/Rdmp.Core/DataLoad/Engine/Checks/CheckEntireDataLoadProcess.cs
+++ b/Rdmp.Core/DataLoad/Engine/Checks/CheckEntireDataLoadProcess.cs
@@ -62,7 +62,7 @@ namespace Rdmp.Core.DataLoad.Engine.Checks
                 }
             }
 
-            //Make sure theres some load tasks and they are valid
+            //Make sure there are some load tasks and they are valid
             processTaskChecks.Check(notifier);
             
             

--- a/Rdmp.Core/Providers/CatalogueChildProvider.cs
+++ b/Rdmp.Core/Providers/CatalogueChildProvider.cs
@@ -406,7 +406,7 @@ namespace Rdmp.Core.Providers
 
             foreach (AggregateConfiguration ac in AllAggregateConfigurations)
             {
-                ac.InjectKnown(joinableDictionaryByAggregateConfigurationId.TryGetValue(ac.ID,out JoinableCohortAggregateConfiguration joinable) //if theres a joinable
+                ac.InjectKnown(joinableDictionaryByAggregateConfigurationId.TryGetValue(ac.ID,out JoinableCohortAggregateConfiguration joinable) //if there's a joinable
                     ? joinable //inject that we know the joinable (and what it is)
                     : null); //otherwise inject that it is not a joinable (suppresses database checking later)
             }

--- a/Rdmp.Core/Providers/SearchablesMatchScorer.cs
+++ b/Rdmp.Core/Providers/SearchablesMatchScorer.cs
@@ -173,7 +173,7 @@ namespace Rdmp.Core.Providers
 
             score += Weights[0] * CountMatchType(regexes, kvp.Key);
 
-            //match on the parents if theres a decendancy list
+            //match on the parents if there's a decendancy list
             if (kvp.Value != null)
             {
                 var parents = kvp.Value.Parents;

--- a/Rdmp.Core/QueryBuilding/AggregateBuilder.cs
+++ b/Rdmp.Core/QueryBuilding/AggregateBuilder.cs
@@ -484,7 +484,7 @@ namespace Rdmp.Core.QueryBuilding
                 {
                     queryLines.Add(new CustomLine("order by " ,QueryComponent.OrderBy));
 
-                    //if theres a top X (with an explicit order by)
+                    //if there's a top X (with an explicit order by)
                     if (AggregateTopX != null)
                     {
                         queryLines.Add(new CustomLine(GetOrderBySQL(AggregateTopX), QueryComponent.OrderBy) { Role = CustomLineRole.TopX });

--- a/Rdmp.Core/QueryBuilding/Parameters/ParameterManager.cs
+++ b/Rdmp.Core/QueryBuilding/Parameters/ParameterManager.cs
@@ -306,7 +306,7 @@ namespace Rdmp.Core.QueryBuilding.Parameters
                         if(AreDeclaredTheSame(overridingGlobal,parameterToImport))
                             continue;//override will replace both so don't bother importing it
                         else
-                            //Theres an override with the same name but different datatypes (that's a problem)
+                            //there's an override with the same name but different datatypes (that's a problem)
                             throw new QueryBuildingException("Parameter " + parameterToImport + " has the same name as an existing parameter with a global override but differing declarations (normally we would handle with a rename but we can't because of the overriding global)",new object[]{existing,parameterToImport,overridingGlobal});
 
                     //one already exists so we will have to do a parameter rename

--- a/Rdmp.Core/QueryBuilding/QueryBuilder.cs
+++ b/Rdmp.Core/QueryBuilding/QueryBuilder.cs
@@ -215,7 +215,7 @@ namespace Rdmp.Core.QueryBuilding
             TableInfo primary;
             TablesUsedInQuery = SqlQueryBuilderHelper.GetTablesUsedInQuery(this, out primary, _forceJoinsToTheseTables);
 
-            //force join to any TableInfos that would not be normally joined to but the user wants to anyway e.g. if theres WHERE sql that references them but no columns
+            //force join to any TableInfos that would not be normally joined to but the user wants to anyway e.g. if there's WHERE sql that references them but no columns
             if (_forceJoinsToTheseTables != null)
                 foreach (var force in _forceJoinsToTheseTables)
                     if (!TablesUsedInQuery.Contains(force))

--- a/Rdmp.Core/Reports/DitaCatalogueExtractor.cs
+++ b/Rdmp.Core/Reports/DitaCatalogueExtractor.cs
@@ -363,7 +363,7 @@ namespace Rdmp.Core.Reports
                 if (words[0].Length < 10)
                     return words[0];        //if the only word is less than 10 long it can be used as acronym anyway (will be the same as catalogue name)
                 else
-                    return words[0].Substring(0, 5); //theres only one word so just suggest using the first 5 letters... suboptimal but hey whatever
+                    return words[0].Substring(0, 5); //there's only one word so just suggest using the first 5 letters... suboptimal but hey whatever
 
             //return the first letter from every word and also add in all numbers that appear after the first letter in the word
             return words.Aggregate("", (s, n) => s + n.Substring(0, 1) + n.Skip(1).Where(char.IsDigit));

--- a/Rdmp.Core/Reports/MetadataReport.cs
+++ b/Rdmp.Core/Reports/MetadataReport.cs
@@ -67,7 +67,7 @@ namespace Rdmp.Core.Reports
         {
             try
             {
-                //if theres only one catalogue call it 'prescribing.docx' etc
+                //if there's only one catalogue call it 'prescribing.docx' etc
                 string filename = _args.Catalogues.Length == 1 ? _args.Catalogues[0].Name : "MetadataReport";
 
                 using (var document = GetNewDocFile(filename))

--- a/Rdmp.Core/Repositories/MEF.cs
+++ b/Rdmp.Core/Repositories/MEF.cs
@@ -97,7 +97,7 @@ namespace Rdmp.Core.Repositories
                             if(matches.Length == 0)
                                 matches = SafeDirectoryCatalog.TypesByName.Values.Where(t=>t.Name.Equals(type,StringComparison.CurrentCultureIgnoreCase)).ToArray();
 
-                            //great theres only one
+                            //great there's only one
                             if(matches.Length == 1)
                                 toReturn = matches[0];
                             else if(matches.Length > 1) //nope looks like everyone has a class called MyClass
@@ -121,7 +121,7 @@ namespace Rdmp.Core.Repositories
                             if(matches.Length == 0)
                                 matches =  SafeDirectoryCatalog.TypesByName.Values.Where(t=>t.Name.Equals(name,StringComparison.CurrentCultureIgnoreCase)).ToArray();
 
-                            //great theres only one
+                            //great there's only one
                             if(matches.Length == 1)
                                 toReturn = matches[0];
                             else if(matches.Length > 1) //nope looks like everyone has a class called MyClass

--- a/Rdmp.Core/Startup/Startup.cs
+++ b/Rdmp.Core/Startup/Startup.cs
@@ -276,7 +276,7 @@ namespace Rdmp.Core.Startup
                     
                     bool mustUnzip = true;
 
-                    //if theres already an unpacked version
+                    //if there's already an unpacked version
                     if(outDir != null && outDir.Exists)
                     {
                         //if the directory has no files we have to unzip - otherwise it has an unzipped version already yay

--- a/Rdmp.UI/AggregationUIs/Advanced/AggregateEditorUI.cs
+++ b/Rdmp.UI/AggregationUIs/Advanced/AggregateEditorUI.cs
@@ -301,7 +301,7 @@ namespace Rdmp.UI.AggregationUIs.Advanced
 
             var dimensions = _aggregate.AggregateDimensions;
 
-            //if theres an axis
+            //if there's an axis
             if (axisIfAny != null && !axisIfAny.Equals(pivotIfAny))//<- if this second thing is the case then the graph is totally messed up!
                 dimensions = dimensions.Except(new[] {axisIfAny}).ToArray();//don't offer the axis as a pivot dimension!
 
@@ -372,7 +372,7 @@ namespace Rdmp.UI.AggregationUIs.Advanced
         {
             var allDimensions = _aggregate.AggregateDimensions.ToArray();
             
-            //if theres a pivot then don't advertise that as an axis
+            //if there's a pivot then don't advertise that as an axis
             if (pivotIfAny != null && !pivotIfAny.Equals(axisIfAny))
                 allDimensions = allDimensions.Except(new[] {pivotIfAny}).ToArray();
             

--- a/Rdmp.UI/AggregationUIs/AggregateGraphUI.cs
+++ b/Rdmp.UI/AggregationUIs/AggregateGraphUI.cs
@@ -541,7 +541,7 @@ namespace Rdmp.UI.AggregationUIs
                 chart1.Series[index].Name = _dt.Columns[index + 1].ColumnName;
             }
 
-            //don't show legend if theres only the one series
+            //don't show legend if there's only one series
             if(chart1.Series.Count == 1)
                 chart1.Legends.Clear();
 

--- a/Rdmp.UI/Collections/CatalogueCollectionUI.cs
+++ b/Rdmp.UI/Collections/CatalogueCollectionUI.cs
@@ -233,7 +233,7 @@ namespace Rdmp.UI.Collections
             {
                 var oldFolder = tlvCatalogues.GetParent(cata) as CatalogueFolder;
 
-                //if theres a change to the folder of the catalogue or it is a new Catalogue (no parent folder) we have to rebuild the entire tree
+                //if there's a change to the folder of the catalogue or it is a new Catalogue (no parent folder) we have to rebuild the entire tree
                 if (oldFolder == null || !oldFolder.Path.Equals(cata.Folder.Path))
                     RefreshUIFromDatabase(CatalogueFolder.Root);
                 else

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandBulkImportTableInfos.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandBulkImportTableInfos.cs
@@ -109,7 +109,7 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
                 //find a Catalogue of the same name (possibly imported from Share Definition)
                 var matchingCatalogues = catalogues.Where(c => c.Name.Equals(ti.GetRuntimeName(), StringComparison.CurrentCultureIgnoreCase)).ToArray();
 
-                //if theres 1 Catalogue with the same name
+                //if there's 1 Catalogue with the same name
                 if (matchingCatalogues.Length == 1)
                 {
                     //we know we want to import all these ColumnInfos

--- a/Rdmp.UI/DataLoadUIs/LoadMetadataUIs/ProcessTasks/SqlProcessTaskUI.cs
+++ b/Rdmp.UI/DataLoadUIs/LoadMetadataUIs/ProcessTasks/SqlProcessTaskUI.cs
@@ -103,7 +103,7 @@ namespace Rdmp.UI.DataLoadUIs.LoadMetadataUIs.ProcessTasks
         
         private void SetupAutocomplete()
         {
-            //if theres an old one dispose it
+            //if there's an old one dispose it
             if (_autoComplete == null)
                 _autoComplete = new AutoCompleteProviderFactory(Activator).Create(_processTask.LoadMetadata.GetQuerySyntaxHelper());
             else

--- a/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/Options/ParameterCollectionUIOptionsFactory.cs
+++ b/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/Options/ParameterCollectionUIOptionsFactory.cs
@@ -92,7 +92,7 @@ namespace Rdmp.UI.ExtractionUIs.FilterUIs.ParameterUIs.Options
                 }
                 catch (QueryBuildingException)
                 {
-                    //if theres a problem with parameters or anything else, it is okay this diaog might let the user fix that
+                    //if there's a problem with parameters or anything else, it is okay this dialog might let the user fix that
                 }  
             }
             else
@@ -107,7 +107,7 @@ namespace Rdmp.UI.ExtractionUIs.FilterUIs.ParameterUIs.Options
                 }
                 catch (QueryBuildingException)
                 {
-                    //if theres a problem with parameters or anything else, it is okay this diaog might let the user fix that
+                    //if there's a problem with parameters or anything else, it is okay this dialog might let the user fix that
                 }          
             }
 

--- a/Rdmp.UI/Icons/IconProvision/CatalogueIconProvider.cs
+++ b/Rdmp.UI/Icons/IconProvision/CatalogueIconProvider.cs
@@ -176,12 +176,12 @@ namespace Rdmp.UI.Icons.IconProvision
             
             RDMPConcept t;
 
-            //It is a System.Type, get the name and see if theres a corresponding image
+            //It is a System.Type, get the name and see if there's a corresponding image
             if (concept is Type)
                 if (Enum.TryParse(((Type)concept).Name, out t))
                     return GetImageImpl(ImagesCollection[t], kind);
 
-            //It is an instance of something, get the System.Type and see if theres a corresponding image
+            //It is an instance of something, get the System.Type and see if there's a corresponding image
             if(Enum.TryParse(conceptTypeName,out t))
                 return GetImageImpl(ImagesCollection[t],kind);
 

--- a/Rdmp.UI/LoadExecutionUIs/ExecuteLoadMetadataUI.cs
+++ b/Rdmp.UI/LoadExecutionUIs/ExecuteLoadMetadataUI.cs
@@ -99,7 +99,7 @@ namespace Rdmp.UI.LoadExecutionUIs
                 //give the user the dropdown options for which load progress he wants to run
                 var loadProgressData = new Dictionary<int, string>( );
 
-                //if theres more than 1 let them pick any
+                //if there are more than 1 let them pick any
                 if(_allLoadProgresses.Length > 1)
                     loadProgressData.Add(0, "Any Available");
 

--- a/Rdmp.UI/ProjectUI/Datasets/ConfigureDatasetUI.cs
+++ b/Rdmp.UI/ProjectUI/Datasets/ConfigureDatasetUI.cs
@@ -621,7 +621,7 @@ namespace Rdmp.UI.ProjectUI.Datasets
 
                     ColumnInfo toEmphasise = null;
 
-                    //if theres only one column involved in the join
+                    //if there's only one column involved in the join
                     if (cols.Length == 1)
                         toEmphasise = cols[0]; //emphasise it to the user
                     else

--- a/Rdmp.UI/Raceway/RacewayRenderAreaUI.cs
+++ b/Rdmp.UI/Raceway/RacewayRenderAreaUI.cs
@@ -386,7 +386,7 @@ namespace Rdmp.UI.Raceway
                         var labelSize = e.Graphics.MeasureString(hoverLabel, Font);
                         var valueSize = e.Graphics.MeasureString(hoverValue, Font);
 
-                        //if theres a scroll down bar add 20 to the width to make space for the down arrow
+                        //if there's a scroll down bar add 20 to the width to make space for the down arrow
                         if (_allowScrollDown)
                             valueSize.Width += 20;
 

--- a/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.cs
@@ -88,7 +88,7 @@ namespace Rdmp.UI.SimpleDialogs
         {
             textBox1.ForeColor = Color.Black;
 
-            //if theres some text typed and we want typed text to be sane
+            //if there's some text typed and we want typed text to be sane
             if(RequireSaneHeaderText && !string.IsNullOrWhiteSpace(textBox1.Text))
             {
                 //if the sane name doesn't match the 

--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
@@ -104,7 +104,7 @@ namespace Rdmp.UI.SimpleDialogs
             var message = args.Message;
             var title = args.Title;
 
-            //todo hack:if theres a long title and no message
+            //todo hack:if there's a long title and no message
             if (!string.IsNullOrWhiteSpace(title) && string.IsNullOrWhiteSpace(message) && title.Length > 100)
             {
                 message = title;

--- a/Rdmp.UI/TransparentHelpSystem/HelpBox.cs
+++ b/Rdmp.UI/TransparentHelpSystem/HelpBox.cs
@@ -55,7 +55,7 @@ namespace Rdmp.UI.TransparentHelpSystem
         {
             var basicSize =  TextRenderer.MeasureText(text, SystemFonts.DefaultFont, new Size(FixedFormWidth, 0),TextFormatFlags.WordBreak);
 
-            //if theres an option button and very little text then widen the box
+            //if there's an option button and very little text then widen the box
             if (btnOption1.Visible)
                 basicSize.Width = Math.Max(basicSize.Width, btnOption1.Width + 3);
 

--- a/Rdmp.UI/Wizard/CreateNewDataExtractionProjectUI.cs
+++ b/Rdmp.UI/Wizard/CreateNewDataExtractionProjectUI.cs
@@ -142,7 +142,7 @@ namespace Rdmp.UI.Wizard
                     ddFilePipeline.Items.Add(pipeline);
             }
 
-            //for each dropdown if theres only one option
+            //for each dropdown if there's only one option
             foreach (var dd in new ComboBox[]{ddCicPipeline,ddExtractionPipeline,ddFilePipeline})
             {
                 if (dd.Items.Count == 1)

--- a/Reusable/ReusableLibraryCode/IHasDependencies.cs
+++ b/Reusable/ReusableLibraryCode/IHasDependencies.cs
@@ -9,7 +9,7 @@ namespace ReusableLibraryCode
     /// <summary>
     /// Indicates that an object is part of a network of dependant objects (e.g. CatalogueItem depends on Catalogue).  Ideally you should try to 
     /// list all IHasDependencies in a network of objects such that when A says it DependsOn B then B should report that A is DependingOnThis (B)
-    /// but if theres a few missing links it won't end the world.  The reason to do this is so that from any point we can find all related objects
+    /// but if there are a few missing links it won't end the world.  The reason to do this is so that from any point we can find all related objects
     /// up and down the hierarchies.
     /// </summary>
     public interface IHasDependencies

--- a/Reusable/ReusableLibraryCode/Progress/FromCheckNotifierToDataLoadEventListener.cs
+++ b/Reusable/ReusableLibraryCode/Progress/FromCheckNotifierToDataLoadEventListener.cs
@@ -33,7 +33,7 @@ namespace ReusableLibraryCode.Progress
 
         public void OnProgress(object sender, ProgressEventArgs e)
         {
-            //only tell the user once about each progress message because these can come 100 a second and theres no finished flag so all we can do is tell them it is happening
+            //only tell the user once about each progress message because these can come 100 a second and there's no finished flag so all we can do is tell them it is happening
             if (!_progressMessagesReceived.Contains(e.TaskDescription))
             {
                 _progressMessagesReceived.Add(e.TaskDescription);


### PR DESCRIPTION
Emphasise (GoTo etc) to something under a CohortIdentificationConfiguration results in the cic tab opening and the object behing highlighted (this is a difference to other emphasise events which result in a collection being brought to the front - or opened).

Combined with `EmphasiseOnTabChanged` this results in being unable to open a tab for an object under a cic! 

Fortunately this user setting is disabled by default.