### PR TITLE
Changed domain/thread exceptions to use IActivateItems delegate

### DIFF
--- a/Application/ResearchDataManagementPlatform/WindowManagement/WindowManager.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/WindowManager.cs
@@ -18,6 +18,7 @@ using Rdmp.UI.Collections;
 using Rdmp.UI.Icons.IconProvision;
 using Rdmp.UI.Refreshing;
 using Rdmp.UI.SimpleDialogs;
+using Rdmp.UI.TestsAndSetup;
 using Rdmp.UI.TestsAndSetup.ServicePropogation;
 using Rdmp.UI.Theme;
 using ResearchDataManagementPlatform.WindowManagement.ContentWindowTracking.Persistence;
@@ -63,6 +64,8 @@ namespace ResearchDataManagementPlatform.WindowManagement
         {
             _windowFactory = new WindowFactory(repositoryLocator,this);
             ActivateItems = new ActivateItems(theme,refreshBus, mainDockPanel, repositoryLocator, _windowFactory, this, globalErrorCheckNotifier);
+
+            GlobalExceptionHandler.Instance.Handler = (e)=>globalErrorCheckNotifier.OnCheckPerformed(new CheckEventArgs(e.Message,CheckResult.Fail,e));
 
             _mainDockPanel = mainDockPanel;
             

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Changed
+
+- Unhandled Application/Thread exceptions (rare) now show in the top right task bar instead of as a popup dialog
 
 ### Fixed
 

--- a/Rdmp.UI/TestsAndSetup/GlobalExceptionHandler.cs
+++ b/Rdmp.UI/TestsAndSetup/GlobalExceptionHandler.cs
@@ -1,0 +1,41 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.UI.SimpleDialogs;
+using System;
+using System.Threading;
+
+namespace Rdmp.UI.TestsAndSetup
+{
+    /// <summary>
+    /// Global singleton for registering/changing how global application errors are handled.
+    /// </summary>
+    public class GlobalExceptionHandler
+    {
+        public static GlobalExceptionHandler Instance {get;} = new GlobalExceptionHandler();
+
+        /// <summary>
+        /// What to do when errors occur, changing this discards the old action and sets a new one.  Defaults to launching a non modal <see cref="ExceptionViewer"/>
+        /// </summary>
+        public Action<Exception> Handler {get;set;}
+
+        public GlobalExceptionHandler()
+        {
+            Handler = (e)=>ExceptionViewer.Show(e,false);
+        }
+        internal void Handle(object sender, UnhandledExceptionEventArgs  args)
+        {
+            Handler((Exception)args.ExceptionObject);
+
+        }
+        internal void Handle(object sender, ThreadExceptionEventArgs args)
+        {
+            Handler(args.Exception);
+        }
+
+        
+    }
+}

--- a/Rdmp.UI/TestsAndSetup/RDMPBootStrapper.cs
+++ b/Rdmp.UI/TestsAndSetup/RDMPBootStrapper.cs
@@ -37,9 +37,9 @@ namespace Rdmp.UI.TestsAndSetup
             Scintilla.SetDestroyHandleBehavior(true);
 
             //tell me when you blow up somewhere in the windows API instead of somewhere sensible
-            Application.ThreadException += (sender, args) => ExceptionViewer.Show(args.Exception,false);
+            Application.ThreadException += GlobalExceptionHandler.Instance.Handle;
             Application.SetUnhandledExceptionMode(UnhandledExceptionMode.CatchException);
-            AppDomain.CurrentDomain.UnhandledException += (sender, args) => ExceptionViewer.Show((Exception)args.ExceptionObject,false);
+            AppDomain.CurrentDomain.UnhandledException += GlobalExceptionHandler.Instance.Handle;
 
             try
             {


### PR DESCRIPTION
Changes how we handle thread and unhandled application exceptions e.g. those caused during rendering and child gettering (see example below).  Previously these were passed to ExceptionViewer (dialog box).  Now this only happens until the main UI is up after which the errors are routed to the task bar error collector button.

![ducks](https://user-images.githubusercontent.com/31306100/86801714-3e278600-c06c-11ea-847e-3d64d225a8ac.gif)
