### PR TITLE
Feature/merge cics

### DIFF
--- a/Rdmp.Core.Tests/CohortCreation/CohortIdentificationConfigurationMergerTests.cs
+++ b/Rdmp.Core.Tests/CohortCreation/CohortIdentificationConfigurationMergerTests.cs
@@ -1,0 +1,70 @@
+﻿using NUnit.Framework;
+using Rdmp.Core.Curation.Data.Cohort;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using Tests.Common;
+
+namespace Rdmp.Core.Tests.CohortCreation
+{
+    class CohortIdentificationConfigurationMergerTests : CohortIdentificationTests
+    {
+        [Test]
+        public void TestSimpleMerge()
+        {
+            var merger = new CohortIdentificationConfigurationMerger(CatalogueRepository);
+
+            var cic1 = new CohortIdentificationConfiguration(CatalogueRepository,"cic1");
+            var cic2 = new CohortIdentificationConfiguration(CatalogueRepository,"cic2");
+
+            cic1.CreateRootContainerIfNotExists();
+            var root1 = cic1.RootCohortAggregateContainer;
+            root1.Name = "Root1";
+            root1.SaveToDatabase();
+            root1.AddChild(aggregate1,1);
+
+            cic2.CreateRootContainerIfNotExists();
+            var root2 = cic2.RootCohortAggregateContainer;
+            root2.Name = "Root2";
+            root2.SaveToDatabase();
+            root2.AddChild(aggregate2,2);
+
+            Assert.AreEqual(1,cic1.RootCohortAggregateContainer.GetAllAggregateConfigurationsRecursively().Count);
+            Assert.AreEqual(1,cic2.RootCohortAggregateContainer.GetAllAggregateConfigurationsRecursively().Count);
+            
+            int numberOfCicsBefore = CatalogueRepository.GetAllObjects<CohortIdentificationConfiguration>().Count();
+
+            var result = merger.Merge(new []{cic1,cic2 },SetOperation.UNION);
+
+            //original should still be in tact
+            Assert.AreEqual(1,cic1.RootCohortAggregateContainer.GetAllAggregateConfigurationsRecursively().Count);
+            Assert.AreEqual(1,cic2.RootCohortAggregateContainer.GetAllAggregateConfigurationsRecursively().Count);
+
+            //the new merged set should contain both
+            Assert.AreEqual(2,result.RootCohortAggregateContainer.GetAllAggregateConfigurationsRecursively().Count);
+
+            Assert.IsFalse(result.RootCohortAggregateContainer.GetAllAggregateConfigurationsRecursively().Any(c=>c.Equals(aggregate1)),"Expected the merge to include clone aggregates not the originals! (aggregate1)");
+            Assert.IsFalse(result.RootCohortAggregateContainer.GetAllAggregateConfigurationsRecursively().Any(c=>c.Equals(aggregate2)),"Expected the merge to include clone aggregates not the originals! (aggregate2)");
+
+            // Now should be a new one
+            Assert.AreEqual(numberOfCicsBefore + 1,CatalogueRepository.GetAllObjects<CohortIdentificationConfiguration>().Count());
+
+            var newCicId = result.ID;
+
+            // Should have the root containers of the old configs
+            Assert.AreEqual("Root2",result.RootCohortAggregateContainer.GetSubContainers()[0].Name);
+            Assert.AreEqual("Root1",result.RootCohortAggregateContainer.GetSubContainers()[1].Name);
+
+            // And should have
+            Assert.AreEqual($"cic_{newCicId}_UnitTestAggregate2",result.RootCohortAggregateContainer.GetSubContainers()[0].GetAggregateConfigurations()[0].Name);
+            Assert.AreEqual($"cic_{newCicId}_UnitTestAggregate1",result.RootCohortAggregateContainer.GetSubContainers()[1].GetAggregateConfigurations()[0].Name);
+
+            Assert.AreEqual($"Merged cics (IDs {cic1.ID},{cic2.ID})",result.Name);
+
+            Assert.IsTrue(cic1.Exists());
+            Assert.IsTrue(cic2.Exists());
+
+        }
+    }
+}

--- a/Rdmp.Core.Tests/CohortCreation/CohortIdentificationConfigurationMergerTests.cs
+++ b/Rdmp.Core.Tests/CohortCreation/CohortIdentificationConfigurationMergerTests.cs
@@ -1,4 +1,10 @@
-﻿using NUnit.Framework;
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using NUnit.Framework;
 using Rdmp.Core.Curation.Data.Cohort;
 using System;
 using System.Collections.Generic;

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMergeCohortIdentificationConfigurations.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMergeCohortIdentificationConfigurations.cs
@@ -1,0 +1,48 @@
+﻿using Rdmp.Core.Curation.Data.Cohort;
+using Rdmp.Core.Repositories;
+using System;
+using System.Collections.Generic;
+using System.Text;
+
+namespace Rdmp.Core.CommandExecution.AtomicCommands
+{
+    public class ExecuteCommandMergeCohortIdentificationConfigurations : BasicCommandExecution
+    {
+        public CohortIdentificationConfiguration[] ToMerge { get; }
+
+        public ExecuteCommandMergeCohortIdentificationConfigurations(IBasicActivateItems activator,CohortIdentificationConfiguration[] toMerge):base(activator)
+        {
+            ToMerge = toMerge;
+        }
+
+        public override void Execute()
+        {
+            base.Execute();
+
+            var toMerge = ToMerge;
+
+            if(toMerge == null || toMerge.Length <= 1)
+            {
+                if(!SelectMany(BasicActivator.RepositoryLocator.CatalogueRepository.GetAllObjects<CohortIdentificationConfiguration>(),out toMerge))
+                    return;
+            }
+
+            if(toMerge == null || toMerge.Length <= 1)
+            {
+                BasicActivator.Show($"You must select at least 2 configurations to merge");
+                return;
+            }
+
+            var merger = new CohortIdentificationConfigurationMerger((CatalogueRepository)BasicActivator.RepositoryLocator.CatalogueRepository);
+            var result = merger.Merge(toMerge,SetOperation.UNION);
+
+            if(result != null)
+            { 
+                BasicActivator.Show($"Succesfully created '{result}'");
+                Publish(result);
+                Emphasise(result);
+            }
+        }
+
+    }
+}

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMergeCohortIdentificationConfigurations.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMergeCohortIdentificationConfigurations.cs
@@ -1,4 +1,10 @@
-﻿using Rdmp.Core.Curation.Data.Cohort;
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data.Cohort;
 using Rdmp.Core.Repositories;
 using System;
 using System.Collections.Generic;

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandUnMergeCohortIdentificationConfiguration.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandUnMergeCohortIdentificationConfiguration.cs
@@ -1,0 +1,65 @@
+﻿using Rdmp.Core.Curation.Data.Cohort;
+using Rdmp.Core.Repositories;
+using Rdmp.Core.Repositories.Construction;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rdmp.Core.CommandExecution.AtomicCommands
+{
+    public class ExecuteCommandUnMergeCohortIdentificationConfiguration : BasicCommandExecution
+    {
+        private readonly CohortAggregateContainer _target;
+
+        [UseWithObjectConstructor]
+        public ExecuteCommandUnMergeCohortIdentificationConfiguration(IBasicActivateItems activator, CohortIdentificationConfiguration cic) :
+            this(activator,cic?.RootCohortAggregateContainer)
+        {
+
+        }
+        public ExecuteCommandUnMergeCohortIdentificationConfiguration(IBasicActivateItems activator,CohortAggregateContainer container): base(activator)
+        {
+            _target = container;
+            
+            if(_target == null)
+            {
+                SetImpossible("No root container");
+                return;
+            }
+            
+            if(!_target.IsRootContainer())
+            { 
+                SetImpossible("Only root containers can be unmerged");
+                return;
+            }
+
+            if(_target.GetAggregateConfigurations().Any())
+            { 
+                SetImpossible("Container must contain only subcontainers (i.e. no aggregate sets)");
+                return;
+            }
+
+            if(_target.GetSubContainers().Count() <= 1)
+            { 
+                SetImpossible("Container must have 2 or more immediate subcontainers for unmerging");
+                return;
+            }
+        }
+
+        public override void Execute()
+        {
+            base.Execute();
+
+            var merger = new CohortIdentificationConfigurationMerger((CatalogueRepository)BasicActivator.RepositoryLocator.CatalogueRepository);
+            var results = merger.UnMerge(_target);
+
+            if(results != null && results.Any())
+            {
+                BasicActivator.Show($"Created {results.Length} new configurations:{Environment.NewLine} {string.Join(Environment.NewLine,results.Select(r=>r.Name))}");
+                Publish(results.First());
+                Emphasise(results.First());
+            }
+        }
+    }
+}

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandUnMergeCohortIdentificationConfiguration.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandUnMergeCohortIdentificationConfiguration.cs
@@ -1,4 +1,10 @@
-﻿using Rdmp.Core.Curation.Data.Cohort;
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data.Cohort;
 using Rdmp.Core.Repositories;
 using Rdmp.Core.Repositories.Construction;
 using System;

--- a/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
+++ b/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
@@ -1,4 +1,10 @@
-﻿using Rdmp.Core.Curation.Data.Aggregation;
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data.Aggregation;
 using Rdmp.Core.Repositories;
 using ReusableLibraryCode.Checks;
 using System;

--- a/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
+++ b/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
@@ -1,0 +1,140 @@
+﻿using Rdmp.Core.Repositories;
+using ReusableLibraryCode.Checks;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rdmp.Core.Curation.Data.Cohort
+{
+    /// <summary>
+    /// Handles combining 2 <see cref="CohortIdentificationConfiguration"/> into a single new combined config.  Also handles splitting 1 into 2 (i.e. the reverse).
+    /// </summary>
+    public class CohortIdentificationConfigurationMerger
+    {
+        private readonly CatalogueRepository _repository;
+
+        public CohortIdentificationConfigurationMerger(CatalogueRepository repository)
+        {
+            this._repository = repository;
+        }
+
+        /// <summary>
+        /// Clones and combines two <see cref="CohortIdentificationConfiguration"/> into a single new cic.
+        /// </summary>
+        /// <param name="cic1"></param>
+        /// <param name="cic2"></param>
+        /// <param name="operation"></param>
+        public void Merge(CohortIdentificationConfiguration cic1, CohortIdentificationConfiguration cic2, SetOperation operation)
+        {
+            //clone them
+            try
+            {
+                cic1 = cic1.CreateClone(new ThrowImmediatelyCheckNotifier());
+                cic2 = cic2.CreateClone(new ThrowImmediatelyCheckNotifier());
+            }
+            catch(Exception ex)
+            {
+                throw new Exception("Error during pre merge cloning stage, no merge will be attempted",ex);
+            }
+            
+
+            using(var trans = _repository.BeginNewTransactedConnection())
+            {
+                // Create a new master configuration
+                var cicMaster = new CohortIdentificationConfiguration(_repository,$"Merged cic ({cic1.ID } with {cic2.ID})" );
+                
+                // With a single top level container with the provided operation
+                cicMaster.CreateRootContainerIfNotExists();
+                var rootContainer = cicMaster.RootCohortAggregateContainer;
+                rootContainer.Operation = operation;
+                rootContainer.SaveToDatabase();
+                
+                //Grab the root container of each of the input cics
+                var cont1 = cic1.RootCohortAggregateContainer;
+                var cont2 = cic2.RootCohortAggregateContainer;
+
+                //clear them to avoid dual parentage
+                cic1.RootCohortAggregateContainer_ID = null;
+                cic1.SaveToDatabase();
+
+                cic2.RootCohortAggregateContainer_ID = null;
+                cic2.SaveToDatabase();
+
+                //add both to the new master cic root container
+                rootContainer.AddChild(cont1);
+                rootContainer.AddChild(cont2);
+
+                // Make the new name of all the AggregateConfigurations match the new master cic
+                foreach(var child in cont1.GetAllAggregateConfigurationsRecursively().Union(cont2.GetAllAggregateConfigurationsRecursively()))
+                    cicMaster.EnsureNamingConvention(child);
+                
+                // Delete the old now empty clones
+                cic1.DeleteInDatabase();
+                cic2.DeleteInDatabase();
+
+                //finish transaction
+                _repository.EndTransactedConnection(true);
+            }
+        }
+
+        /// <summary>
+        /// Splits the root container of a <see cref="CohortIdentificationConfiguration"/> into multiple new cic.
+        /// </summary>
+        /// <param name="rootContainer"></param>
+        public void UnMerge(CohortAggregateContainer rootContainer)
+        {
+            if(!rootContainer.IsRootContainer())
+                throw new ArgumentException("Container must be a root container to be unmerged",nameof(rootContainer));
+            
+            if(rootContainer.GetAggregateConfigurations().Any())
+                throw new ArgumentException("Container must contain only sub-containers (i.e. no aggregates)",nameof(rootContainer));
+
+            if(rootContainer.GetSubContainers().Length <= 1)
+                throw new ArgumentException("Container must contain 2+ sub-containers to be unmerged",nameof(rootContainer));
+
+            var cic = rootContainer.GetCohortIdentificationConfiguration();
+                        
+            try
+            {
+                // clone the input cic 
+                cic = cic.CreateClone(new ThrowImmediatelyCheckNotifier());
+
+                // grab the new clone root container
+                rootContainer = cic.RootCohortAggregateContainer;
+            }
+            catch(Exception ex)
+            {
+                throw new Exception("Error during pre merge cloning stage, no UnMerge will be attempted",ex);
+            }
+                        
+            using(var trans = _repository.BeginNewTransactedConnection())
+            {
+                // For each of these
+                foreach(var subContainer in rootContainer.GetSubContainers())
+                {
+                    // create a new config
+                    var newCic = new CohortIdentificationConfiguration(_repository,$"Un Merged { subContainer.Name } ({subContainer.ID }) ");
+                    
+                    //take the container we are splitting out
+                    subContainer.MakeIntoAnOrphan();
+
+                    //make it the root container of the new cic
+                    newCic.RootCohortAggregateContainer_ID = subContainer.ID;
+                    newCic.SaveToDatabase();
+                                        
+                    // Make the new name of all the AggregateConfigurations match the new cic
+                    foreach(var child in subContainer.GetAllAggregateConfigurationsRecursively())
+                        newCic.EnsureNamingConvention(child);
+                }
+
+                //Now delete the original clone that we unmerged the containers out of
+                cic.DeleteInDatabase();
+
+                //finish transaction
+                _repository.EndTransactedConnection(true);
+            }
+        }
+
+    }
+}

--- a/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
+++ b/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
@@ -130,7 +130,7 @@ namespace Rdmp.Core.Curation.Data.Cohort
             using(var trans = _repository.BeginNewTransactedConnection())
             {
                 // For each of these
-                foreach(var subContainer in rootContainer.GetSubContainers())
+                foreach(var subContainer in rootContainer.GetSubContainers().OrderBy(c=>c.Order))
                 {
                     // create a new config
                     var newCic = new CohortIdentificationConfiguration(_repository,$"Un Merged { subContainer.Name } ({subContainer.ID }) ");

--- a/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
+++ b/Rdmp.Core/Curation/Data/Cohort/CohortIdentificationConfigurationMerger.cs
@@ -53,7 +53,7 @@ namespace Rdmp.Core.Curation.Data.Cohort
             }
             
 
-            using(var trans = _repository.BeginNewTransactedConnection())
+            using(_repository.BeginNewTransactedConnection())
             {
                 // Create a new master configuration
                 var cicMaster = new CohortIdentificationConfiguration(_repository,$"Merged cics (IDs {string.Join(",",cics.Select(c=>c.ID))})" );
@@ -133,7 +133,7 @@ namespace Rdmp.Core.Curation.Data.Cohort
                 throw new Exception("Error during pre merge cloning stage, no UnMerge will be attempted",ex);
             }
                         
-            using(var trans = _repository.BeginNewTransactedConnection())
+            using(_repository.BeginNewTransactedConnection())
             {
                 // For each of these
                 foreach(var subContainer in rootContainer.GetSubContainers().OrderBy(c=>c.Order))

--- a/Rdmp.UI/Collections/CohortIdentificationCollectionUI.cs
+++ b/Rdmp.UI/Collections/CohortIdentificationCollectionUI.cs
@@ -10,6 +10,7 @@ using Rdmp.Core.Curation.Data.Cohort;
 using Rdmp.Core.Providers;
 using Rdmp.Core.Providers.Nodes.CohortNodes;
 using Rdmp.UI.CommandExecution.AtomicCommands;
+using Rdmp.UI.CommandExecution.AtomicCommands.UIFactory;
 using Rdmp.UI.ItemActivation;
 using Rdmp.UI.Refreshing;
 
@@ -60,12 +61,17 @@ namespace Rdmp.UI.Collections
 
             tlvCohortIdentificationConfigurations.AddObject(Activator.CoreChildProvider.OrphanAggregateConfigurationsNode);
 
-            CommonTreeFunctionality.WhitespaceRightClickMenuCommandsGetter = (a)=>new IAtomicCommand[]{new ExecuteCommandCreateNewCohortIdentificationConfiguration(a)};
+            CommonTreeFunctionality.WhitespaceRightClickMenuCommandsGetter = (a)=>new IAtomicCommand[]{
+                new ExecuteCommandCreateNewCohortIdentificationConfiguration(a),
+                new ExecuteCommandMergeCohortIdentificationConfigurations(a,null)};
 
             Activator.RefreshBus.EstablishLifetimeSubscription(this);
+
+            var factory = new AtomicCommandUIFactory(activator);
             
             
-            CommonFunctionality.Add(new ExecuteCommandCreateNewCohortIdentificationConfiguration(Activator),"New");
+            CommonFunctionality.Add(factory.CreateMenuItem(new ExecuteCommandCreateNewCohortIdentificationConfiguration(Activator)),"New...");
+            CommonFunctionality.Add(factory.CreateMenuItem(new ExecuteCommandMergeCohortIdentificationConfigurations(Activator,null){OverrideCommandName = "By Merging Existing..."}),"New...");
         }
         
         public static bool IsRootObject(object root)

--- a/Rdmp.UI/Menus/CohortAggregateContainerMenu.cs
+++ b/Rdmp.UI/Menus/CohortAggregateContainerMenu.cs
@@ -52,6 +52,8 @@ namespace Rdmp.UI.Menus
             foreach (ToolStripMenuItem item in Items)
                 item.Enabled = item.Enabled && (cic != null && !cic.Frozen);
 
+            Add(new ExecuteCommandUnMergeCohortIdentificationConfiguration(_activator,container));
+
             //Add Graph results of container commands
 
             //this requires cache to exist (and be populated for the container)


### PR DESCRIPTION
Adds the ability to merge two CohortIdentificationConfiguration in cohort builder into a single new composite one.  The operation clones existing tree as a first step so the individual tree nodes are all new.

Also includes the reverse operation 'unmerge' by which a root container is split into seperate cics.

![merges](https://user-images.githubusercontent.com/31306100/87295536-4749a480-c4fd-11ea-9235-563234015068.gif)
