### PR TITLE
Feature/broken pipes

### DIFF
--- a/Rdmp.Core.Tests/Curation/Integration/PipelineTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/PipelineTests.cs
@@ -183,11 +183,11 @@ namespace Rdmp.Core.Tests.Curation.Integration
             var clone = p.Clone();
 
             Assert.AreEqual(clone.Source.Class,p.Source.Class);
+            Assert.AreEqual("fffffzololz",clone.Source.GetAllArguments().Single().Type);
 
             p.DeleteInDatabase();
             clone.DeleteInDatabase();
 
-            Assert.AreEqual("fffffzololz",clone.Source.GetAllArguments().Single().Type);
 
         }
     }

--- a/Rdmp.Core.Tests/Curation/Integration/PipelineTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/PipelineTests.cs
@@ -159,5 +159,36 @@ namespace Rdmp.Core.Tests.Curation.Integration
             p.DeleteInDatabase();
             p2.DeleteInDatabase();
         }
+
+        [Test]
+        public void CloneAPipeline_BrokenPipes()
+        {
+            Pipeline p = new Pipeline(CatalogueRepository);
+
+            //Setup a pipeline with a source component type that doesnt exist
+            var source = new PipelineComponent(CatalogueRepository, p, typeof (DelimitedFlatFileAttacher), 0);
+            source.Class = "Trollololol";
+
+            var arg = source.CreateNewArgument();
+
+            //Also give the source component a non existant argument
+            arg.GetType().GetProperty("Type").SetValue(arg,"fffffzololz");
+            arg.SaveToDatabase();
+
+            p.SourcePipelineComponent_ID = source.ID;
+            p.SaveToDatabase();
+            
+            Assert.AreEqual("fffffzololz",p.Source.GetAllArguments().Single().Type);
+
+            var clone = p.Clone();
+
+            Assert.AreEqual(clone.Source.Class,p.Source.Class);
+
+            p.DeleteInDatabase();
+            clone.DeleteInDatabase();
+
+            Assert.AreEqual("fffffzololz",clone.Source.GetAllArguments().Single().Type);
+
+        }
     }
 }

--- a/Rdmp.Core.Tests/Curation/Integration/PipelineTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/PipelineTests.cs
@@ -165,13 +165,13 @@ namespace Rdmp.Core.Tests.Curation.Integration
         {
             Pipeline p = new Pipeline(CatalogueRepository);
 
-            //Setup a pipeline with a source component type that doesnt exist
+            //Setup a pipeline with a source component type that doesn't exist
             var source = new PipelineComponent(CatalogueRepository, p, typeof (DelimitedFlatFileAttacher), 0);
             source.Class = "Trollololol";
 
             var arg = source.CreateNewArgument();
 
-            //Also give the source component a non existant argument
+            //Also give the source component a non existent argument
             arg.GetType().GetProperty("Type").SetValue(arg,"fffffzololz");
             arg.SaveToDatabase();
 

--- a/Rdmp.Core/Curation/Data/Pipelines/IPipelineComponentArgument.cs
+++ b/Rdmp.Core/Curation/Data/Pipelines/IPipelineComponentArgument.cs
@@ -20,5 +20,11 @@ namespace Rdmp.Core.Curation.Data.Pipelines
         /// per public property with <see cref="DemandsInitializationAttribute"/> on the <see cref="PipelineComponent.Class"/>.
         /// </summary>
         int PipelineComponent_ID { get; set; }
+
+        /// <summary>
+        /// Creates a new copy of the current argument and associates it with <paramref name="intoTargetComponent"/>
+        /// </summary>
+        /// <param name="intoTargetComponent"></param>
+        void Clone(PipelineComponent intoTargetComponent);
     }
 }

--- a/Rdmp.Core/Curation/Data/Pipelines/PipelineComponent.cs
+++ b/Rdmp.Core/Curation/Data/Pipelines/PipelineComponent.cs
@@ -142,15 +142,9 @@ namespace Rdmp.Core.Curation.Data.Pipelines
             var cataRepo = (ICatalogueRepository) intoTargetPipeline.Repository;
 
             var clone = new PipelineComponent(cataRepo, intoTargetPipeline, GetClassAsSystemType(), Order);
-            foreach (IPipelineComponentArgument argument in PipelineComponentArguments)
+            foreach (var argument in PipelineComponentArguments)
             {
-                var cloneArg = new PipelineComponentArgument(cataRepo, clone);
-
-                cloneArg.Name = argument.Name;
-                cloneArg.Value = argument.Value;
-                cloneArg.SetType(argument.GetSystemType());
-                cloneArg.Description = argument.Description;
-                cloneArg.SaveToDatabase();
+                argument.Clone(clone);
             }
 
             clone.Name = Name;

--- a/Rdmp.Core/Curation/Data/Pipelines/PipelineComponentArgument.cs
+++ b/Rdmp.Core/Curation/Data/Pipelines/PipelineComponentArgument.cs
@@ -87,5 +87,17 @@ namespace Rdmp.Core.Curation.Data.Pipelines
         {
             return new IHasDependencies[0];
         }
+
+        /// <inheritdoc/>
+        public void Clone(PipelineComponent intoTargetComponent)
+        {
+            var cloneArg = new PipelineComponentArgument(intoTargetComponent.CatalogueRepository, intoTargetComponent);
+
+            cloneArg.Name = Name;
+            cloneArg.Value = Value;
+            cloneArg.Type = Type;
+            cloneArg.Description = Description;
+            cloneArg.SaveToDatabase();
+        }
     }
 }


### PR DESCRIPTION
This PR ostensibly changes:

```
cloneArg.SetType(argument.GetSystemType());
```
_System.Type operation_

Into 
```
cloneArg.Type = argument.Type;
```
_string operation_

Because the setter for Type is protected method Clone was added to the `PipelineComponentArgument` class.