### PR TITLE
Feature/set array types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added Import command for bringing in one or more [CohortIdentificationConfiguration] into an existing container (like Merge / UnMerge but for existing configurations)
 - Added checks for LoadProgress dates being in sensible ranges during DLE
 
+### Fixed
+
+- Fixed [bug when parsing lists of ints in CLI](https://github.com/HicServices/RDMP/issues/84)
+
 ## [4.1.5] - 2020-07-14
 
 ### Added

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandSet.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandSet.cs
@@ -12,6 +12,7 @@ using NUnit.Framework;
 using Rdmp.Core.CommandExecution.AtomicCommands;
 using Rdmp.Core.CommandLine.Interactive.Picking;
 using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Curation.Data.DataLoad;
 using Tests.Common;
 
 namespace Rdmp.Core.Tests.CommandExecution
@@ -42,6 +43,34 @@ namespace Rdmp.Core.Tests.CommandExecution
             cata.RevertToDatabaseState();
             Assert.IsNull(cata.Description);
 
+        }
+
+        [Test]
+        public void TestExecuteCommandSet_SetArrayValueFromCLI()
+        {
+            var pta = WhenIHaveA<ProcessTaskArgument>();
+            pta.SetType(typeof(TableInfo[]));
+            pta.Name = "TablesToIsolate";
+            pta.SaveToDatabase();
+
+            var t1 = WhenIHaveA<TableInfo>();
+            var t2 = WhenIHaveA<TableInfo>();
+            var t3 = WhenIHaveA<TableInfo>();
+            var t4 = WhenIHaveA<TableInfo>();
+
+            var ids = t1.ID + "," + t2.ID + "," + t3.ID + "," + t4.ID;
+
+            Assert.IsNull(pta.Value);
+            Assert.IsNull(pta.GetValueAsSystemType());
+
+            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSet),new CommandLineObjectPicker(new []{"ProcessTaskArgument:TablesToIsolate" ,"Value",ids},RepositoryLocator));
+
+            Assert.AreEqual(ids,pta.Value);
+
+            Assert.Contains(t1,(TableInfo[])pta.GetValueAsSystemType());
+            Assert.Contains(t2,(TableInfo[])pta.GetValueAsSystemType());
+            Assert.Contains(t3,(TableInfo[])pta.GetValueAsSystemType());
+            Assert.Contains(t4,(TableInfo[])pta.GetValueAsSystemType());
         }
     }
 }

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByName.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByName.cs
@@ -54,7 +54,7 @@ NamePattern2+: (optional) only allowed if you are being prompted for multiple ob
             {
                 t = RepositoryLocator.CatalogueRepository.MEF.GetType(possibleTypeName);
             }
-            catch (AmbiguousTypeException )
+            catch (Exception )
             {
                 t = null;
                 return false;

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickType.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickType.cs
@@ -45,7 +45,7 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
                     ??
                     RepositoryLocator.CatalogueRepository.MEF.GetType(arg);
             }
-            catch (AmbiguousTypeException )
+            catch (Exception)
             {
                 return null;
             }


### PR DESCRIPTION
/fixes #84 

For each string on the command line RDMP looks at the string and decides what it could be.  Then it tries to fit the results of that command to the constructor(s) on the command to be run.

The parsing process was crashing when interpretting strings like "1,2,3".  The reason is when asking MEF if "1,2,3" is a string it gets an error (presumably looking for the dll 2 with a namespace?! or public key 3?!).  Anyway now if theres any Exception thrown when considering if something is a Type we consider it not a type.