### PR TITLE
Feature/set arg cmd

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- New command `SetArgument` for easier changing of values of modules (e.g. [PipelineComponent]) from command line
+- Support for `DescribeCommand` help text on `NewObject` and other commands that take dynamic argument lists (command line)
+
 ## [4.1.6] - 2020-08-04
 
 ### Added

--- a/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetArgumentTests.cs
+++ b/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetArgumentTests.cs
@@ -9,6 +9,7 @@ using Rdmp.Core.CommandExecution.AtomicCommands;
 using Rdmp.Core.CommandLine.Interactive.Picking;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Curation.Data.DataLoad;
+using Rdmp.Core.Curation.Data.Pipelines;
 
 namespace Rdmp.Core.Tests.CommandExecution
 {
@@ -83,6 +84,103 @@ namespace Rdmp.Core.Tests.CommandExecution
             Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
 
             Assert.AreEqual(5,pta.GetValueAsSystemType());
+        }
+        
+        [Test]
+        public void TestSetArgument_Catalogue_Valid()
+        {
+            var cata = WhenIHaveA<Catalogue>();
+            cata.Name = "kapow splat";
+            cata.SaveToDatabase();
+
+            var pta = WhenIHaveA<ProcessTaskArgument>();
+            var pt = pta.ProcessTask;
+            
+            pta.Name = "fff";
+            pta.SetType(typeof(Catalogue));
+
+            Assert.IsNull(pta.Value);
+
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff",$"Catalogue:kapow splat" },RepositoryLocator);
+            
+            Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
+
+            Assert.AreEqual(cata,pta.GetValueAsSystemType());
+        }
+        [Test]
+        public void TestSetArgument_CatalogueArrayOf1_Valid()
+        {
+            var cata1 = WhenIHaveA<Catalogue>();
+            cata1.Name = "lolzzzyy";
+            cata1.SaveToDatabase();
+
+
+            //Lets also test that PipelineComponentArgument also work (not just ProcessTaskArgument)
+            var pca = WhenIHaveA<PipelineComponentArgument>();
+            var pc = pca.PipelineComponent;
+            
+            pca.Name = "ggg";
+            pca.SetType(typeof(Catalogue[]));
+
+            Assert.IsNull(pca.Value);
+
+            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Catalogue:lolzzzyy" },RepositoryLocator);
+            
+            Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
+
+            Assert.Contains(cata1, (System.Collections.ICollection)pca.GetValueAsSystemType());
+        }
+        [Test]
+        public void TestSetArgument_CatalogueArrayOf2_Valid()
+        {
+            var cata1 = WhenIHaveA<Catalogue>();
+            cata1.Name = "kapow bob";
+            cata1.SaveToDatabase();
+
+            var cata2 = WhenIHaveA<Catalogue>();
+            cata2.Name = "kapow frank";
+            cata2.SaveToDatabase();
+
+            //Lets also test that PipelineComponentArgument also work (not just ProcessTaskArgument)
+            var pca = WhenIHaveA<PipelineComponentArgument>();
+            var pc = pca.PipelineComponent;
+            
+            pca.Name = "ggg";
+            pca.SetType(typeof(Catalogue[]));
+
+            Assert.IsNull(pca.Value);
+
+            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Catalogue:kapow*" },RepositoryLocator);
+            
+            Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
+
+            Assert.Contains(cata1, (System.Collections.ICollection)pca.GetValueAsSystemType());
+            Assert.Contains(cata2, (System.Collections.ICollection)pca.GetValueAsSystemType());
+        }
+        [Test]
+        public void TestSetArgument_CatalogueArray_SetToNull_Valid()
+        {
+            var cata1 = WhenIHaveA<Catalogue>();
+            cata1.Name = "lolzzzyy";
+            cata1.SaveToDatabase();
+
+
+            //Lets also test that PipelineComponentArgument also work (not just ProcessTaskArgument)
+            var pca = WhenIHaveA<PipelineComponentArgument>();
+            var pc = pca.PipelineComponent;
+            
+            pca.Name = "ggg";
+            pca.SetType(typeof(Catalogue[]));
+            pca.SetValue(new Catalogue[]{ cata1});
+            pca.SaveToDatabase();
+            
+            Assert.Contains(cata1, (System.Collections.ICollection)pca.GetValueAsSystemType());
+
+            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Null" },RepositoryLocator);
+            
+            Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
+
+            Assert.IsNull(pca.GetValueAsSystemType());
         }
     }
 }

--- a/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetArgumentTests.cs
+++ b/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetArgumentTests.cs
@@ -1,0 +1,88 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using NUnit.Framework;
+using Rdmp.Core.CommandExecution.AtomicCommands;
+using Rdmp.Core.CommandLine.Interactive.Picking;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Curation.Data.DataLoad;
+
+namespace Rdmp.Core.Tests.CommandExecution
+{
+    class ExecuteCommandSetArgumentTests : CommandCliTests
+    {
+        [Test]
+        public void TestSetArgument_WrongArgCount()
+        {
+            var picker = new CommandLineObjectPicker(new []{"yyy" },RepositoryLocator);
+            var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
+
+            Assert.IsTrue(cmd.IsImpossible);
+            Assert.AreEqual("Wrong number of parameters supplied to command, expected 3 but got 1",cmd.ReasonCommandImpossible);
+        }
+        [Test]
+        public void TestSetArgument_NotAHost()
+        {
+            var c = WhenIHaveA<Catalogue>();
+
+            var picker = new CommandLineObjectPicker(new []{$"Catalogue:{c.ID}","fff","yyy" },RepositoryLocator);
+            var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
+
+            Assert.IsTrue(cmd.IsImpossible);
+            Assert.AreEqual("First parameter must be an IArgumentHost",cmd.ReasonCommandImpossible);             
+        }
+
+        [Test]
+        public void TestSetArgument_NoArgumentFound()
+        {
+            var pt = WhenIHaveA<ProcessTask>();
+            
+
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","yyy" },RepositoryLocator);
+            var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
+
+            Assert.IsTrue(cmd.IsImpossible);
+            StringAssert.StartsWith("Could not find argument called 'fff' on ",cmd.ReasonCommandImpossible);             
+        }
+        
+        [Test]
+        public void TestSetArgument_ArgumentWrongType()
+        {
+            var pta = WhenIHaveA<ProcessTaskArgument>();
+            var pt = pta.ProcessTask;
+            
+            pta.Name = "fff";
+            
+            // Argument expects int but is given string value "yyy"
+            pta.SetType(typeof(int));
+
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","yyy" },RepositoryLocator);
+            var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
+
+            Assert.IsTrue(cmd.IsImpossible);
+            StringAssert.StartsWith("Provided value 'yyy' does not match expected Type 'Int32' of ",cmd.ReasonCommandImpossible);        
+        }
+
+        
+        [Test]
+        public void TestSetArgument_Int_Valid()
+        {
+            var pta = WhenIHaveA<ProcessTaskArgument>();
+            var pt = pta.ProcessTask;
+            
+            pta.Name = "fff";
+            pta.SetType(typeof(int));
+
+            Assert.IsNull(pta.Value);
+
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","5" },RepositoryLocator);
+            
+            Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
+
+            Assert.AreEqual(5,pta.GetValueAsSystemType());
+        }
+    }
+}

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandDescribeCommand.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandDescribeCommand.cs
@@ -61,5 +61,27 @@ createCatalogue	Boolean	True to create a Catalogue as well as a TableInfo"
                 ,typeof(ExecuteCommandImportTableInfo));
 
         }
+
+        [Test]
+        public void Test_DescribeCommand_ExecuteCommandNewObject()
+        {
+            AssertHelpIs( @"cmd NewObject <type> <arg1> <arg2> <etc>
+
+PARAMETERS:
+type	The object to create e.g. Catalogue
+args    Dynamic list of values to satisfy the types constructor",typeof(ExecuteCommandNewObject));
+        }
+
+        [Test]
+        public void Test_DescribeCommand_ExecuteCommandSetArgument()
+        {
+            AssertHelpIs( @"cmd SetArgument <component> <argName> <argValue>
+
+PARAMETERS:
+component    Module to set value on e.g. ProcessTask:1
+argName Name of an argument to set on the component e.g. Retry
+argValue    New value for argument e.g. Null, True, Catalogue:5 etc
+",typeof(ExecuteCommandSetArgument));
+        }
     }
 }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandNewObject.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandNewObject.cs
@@ -51,7 +51,10 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         /// </summary>
         /// <param name="activator"></param>
         /// <param name="picker"></param>
-        [UseWithCommandLine]
+        [UseWithCommandLine(
+            ParameterHelpList = "<type> <arg1> <arg2> <etc>", 
+            ParameterHelpBreakdown = @"type	The object to create e.g. Catalogue
+args    Dynamic list of values to satisfy the types constructor")]
         public ExecuteCommandNewObject(IBasicActivateItems activator,CommandLineObjectPicker picker):base(activator)
         {
             if(!picker.HasArgumentOfType(0, typeof(Type)))

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetArgument.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetArgument.cs
@@ -1,0 +1,113 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.CommandLine.Interactive.Picking;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Curation.Data.DataLoad;
+using Rdmp.Core.Repositories.Construction;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+
+namespace Rdmp.Core.CommandExecution.AtomicCommands
+{
+    /// <summary>
+    /// Sets the value of a named parameter on an RDMP module e.g. <see cref="ProcessTask"/>
+    /// </summary>
+    public class ExecuteCommandSetArgument : BasicCommandExecution
+    {
+        private IArgumentHost _host;
+        private IArgument _arg;
+        private object _value;
+        
+        public ExecuteCommandSetArgument(IBasicActivateItems activator,IArgumentHost host, IArgument arg, object value):base(activator)
+        {
+            _host = host;
+            _arg = arg;
+            _value = value;
+        }
+
+        /// <summary>
+        /// Automatic/Unattended constructor, construction values will come from <paramref name="picker"/>
+        /// </summary>
+        /// <param name="activator"></param>
+        /// <param name="picker"></param>
+        [UseWithCommandLine]
+        public ExecuteCommandSetArgument(IBasicActivateItems activator,CommandLineObjectPicker picker):base(activator)
+        {
+            if(picker.Arguments.Count != 3)
+            {
+                SetImpossible($"Wrong number of parameters supplied to command, expected 3 but got {picker.Arguments.Count}");
+                return;
+            }
+
+            if(!picker.HasArgumentOfType(0, typeof(IMapsDirectlyToDatabaseTable)))
+            {
+                SetImpossible("First parameter must be an IArgumentHost DatabaseEntity");
+                return;
+            }
+
+            _host = picker[0].GetValueForParameterOfType(typeof(IMapsDirectlyToDatabaseTable)) as IArgumentHost;
+            
+            if(_host == null)
+            {
+                SetImpossible("First parameter must be an IArgumentHost");
+                return;
+            }
+
+            var args = _host.GetAllArguments();
+
+            _arg = args.FirstOrDefault(a=>a.Name.Equals(picker[1].RawValue));
+
+            if(_arg == null)
+            {
+                SetImpossible($"Could not find argument called '{picker[1].RawValue}' on '{_host}'.  Arguments found were {string.Join(",",args.Select(a=>a.Name))}");
+                return;
+            }
+            
+            Type argType;
+
+            try
+            {
+                argType = _arg.GetConcreteSystemType();
+            }
+            catch (Exception e)
+            {
+                SetImpossible("Failed to get system Type of argument:" + e);
+                return;
+            }
+
+            if(argType == null)
+            {
+                SetImpossible($"Argument '{_arg.Name}' has no listed Type");
+                return;
+            }
+                
+
+            if(!picker[2].HasValueOfType(argType))
+            {
+                SetImpossible($"Provided value '{picker[2].RawValue}' does not match expected Type '{argType.Name}' of argument '{_arg.Name}'");
+                return;
+            }
+
+            _value = picker[2].GetValueForParameterOfType(argType);
+
+        }
+
+        public override void Execute()
+        {
+            base.Execute();
+
+            _arg.SetValue(_value);
+            _arg.SaveToDatabase();
+            
+            if(_arg is DatabaseEntity de)
+                Publish(de);
+        }
+    }
+}

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetArgument.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetArgument.cs
@@ -37,7 +37,11 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         /// </summary>
         /// <param name="activator"></param>
         /// <param name="picker"></param>
-        [UseWithCommandLine]
+        [UseWithCommandLine(
+            ParameterHelpList = "<component> <argName> <argValue>", 
+            ParameterHelpBreakdown = @"component    Module to set value on e.g. ProcessTask:1
+argName Name of an argument to set on the component e.g. Retry
+argValue    New value for argument e.g. Null, True, Catalogue:5 etc")]
         public ExecuteCommandSetArgument(IBasicActivateItems activator,CommandLineObjectPicker picker):base(activator)
         {
             if(picker.Arguments.Count != 3)

--- a/Rdmp.Core/Curation/Data/DataLoad/Argument.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/Argument.cs
@@ -60,7 +60,7 @@ namespace Rdmp.Core.Curation.Data.DataLoad
             //IMapsDirectlyToDatabaseTable
             typeof(TableInfo), typeof(ColumnInfo), typeof(PreLoadDiscardedColumn), typeof(LoadProgress), typeof(LoadMetadata),
             typeof(CacheProgress), typeof(ExternalDatabaseServer), typeof(StandardRegex),typeof(CohortIdentificationConfiguration),
-            typeof(RemoteRDMP),
+            typeof(RemoteRDMP),typeof(Catalogue),typeof(CatalogueItem),
             typeof(DataAccessCredentials),
            
             //wierd special cases

--- a/Rdmp.Core/Repositories/Construction/UseWithCommandLineAttribute.cs
+++ b/Rdmp.Core/Repositories/Construction/UseWithCommandLineAttribute.cs
@@ -16,6 +16,14 @@ namespace Rdmp.Core.Repositories.Construction
     [System.AttributeUsage(AttributeTargets.Constructor)]
     public class UseWithCommandLineAttribute : Attribute
     {
+        /// <summary>
+        /// List of the expected arguments the command should take in a format suitable for displaying in CLI help e.g. "&lt;param1&gt; &lt;param2&gt;"
+        /// </summary>
+        public string ParameterHelpList { get; set; } = @"<dynamic>";
 
+        /// <summary>
+        /// Help for each parameter listed in <see cref="ParameterHelpList"/> with descriptions of what you expect to be in them (suitable for displaying in CLI)
+        /// </summary>
+        public string ParameterHelpBreakdown { get; set; } = @"Unknown";
     }
 }

--- a/Rdmp.UI.Tests/DesignPatternTests/RunUITests.cs
+++ b/Rdmp.UI.Tests/DesignPatternTests/RunUITests.cs
@@ -77,7 +77,8 @@ typeof(ExecuteCommandReOrderAggregate),
 typeof(ExecuteCommandReOrderAggregateContainer),
 typeof(ExecuteCommandUseCredentialsToAccessTableInfoData),
 typeof(ExecuteCommandCreateLookup),
-typeof(ExecuteCommandImportFilterDescriptionsFromShare)
+typeof(ExecuteCommandImportFilterDescriptionsFromShare),
+typeof(ExecuteCommandSetArgument)
 
             });
 


### PR DESCRIPTION
/fixes #86 

This PR does the following:
- adds a new command for setting named arguments on components
- adds support in DescribeCommand for commands that take dynamic (numbered or typed) arguments