### PR TITLE
Removed throw when progress goes backwards in ToDatabase logging list…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Schema names (Sql Server) are now wrapped correctly e.g. `[My Cool Schema]`
+- Progress logged (e.g. done x of y files) can now go backwards.
 
 ### Added
 

--- a/Rdmp.Core/Logging/Listeners/ToLoggingDatabaseDataLoadEventListener.cs
+++ b/Rdmp.Core/Logging/Listeners/ToLoggingDatabaseDataLoadEventListener.cs
@@ -99,9 +99,6 @@ namespace Rdmp.Core.Logging.Listeners
                     TableLoads.Add(e.TaskDescription,t);
                 }
 
-                if (e.Progress.Value < TableLoads[e.TaskDescription].Inserts)
-                    throw new Exception("Received OnProgress event with a TaskDescription '" + e.TaskDescription +"' which has the same name as a previous Task but the number of Inserts is lower in this event.  Progress is not allowed to go backwards!");
-
                 TableLoads[e.TaskDescription].Inserts = e.Progress.Value;
             }
         }


### PR DESCRIPTION
Removes the restriction that all progress must be positive when using `ToLoggingDatabaseDataLoadEventListener`