### PR TITLE
Feature/better provider disposing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Fixed
 
-- Fixed memory leak during refreshes
+- reduced memory overhead during refreshes
 
 ## [4.1.9] - 2020-09-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Fixed
+
+- Fixed memory leak during refreshes
+
 ## [4.1.9] - 2020-09-17
 
 ### Added

--- a/Rdmp.Core/Providers/CatalogueChildProvider.cs
+++ b/Rdmp.Core/Providers/CatalogueChildProvider.cs
@@ -1469,7 +1469,9 @@ namespace Rdmp.Core.Providers
                 AllCataloguesDictionary = null;
                 AllSupportingDocuments = null;
                 AllSupportingSQL = null;
+                _childDictionary?.Clear();
                 _childDictionary = null;
+                _descendancyDictionary?.Clear();
                 _descendancyDictionary = null;
                 _catalogueToCatalogueItems = null;
                 AllCatalogueItemsDictionary= null;
@@ -1506,6 +1508,10 @@ namespace Rdmp.Core.Providers
                 AllLookups = null;
                 AllJoinInfos = null;
                 AllAnyTableParameters = null;
+                AllMasqueraders?.Clear();
+                AllMasqueraders = null;
+                AllExtractionInformationsDictionary?.Clear();
+                AllExtractionInformationsDictionary = null;
             }
         }
 

--- a/Rdmp.Core/Providers/DataExportChildProvider.cs
+++ b/Rdmp.Core/Providers/DataExportChildProvider.cs
@@ -637,14 +637,19 @@ namespace Rdmp.Core.Providers
                 SelectedDataSets = null;
                 AllPackages = null;
                 Projects = null;
+                _cohortsByOriginId?.Clear();
                 _cohortsByOriginId = null;
                 Cohorts = null;
                 ExtractionConfigurations = null;
+                ExtractionConfigurationsByProject?.Clear();
                 ExtractionConfigurationsByProject = null;
+                _configurationToDatasetMapping?.Clear();
                 _configurationToDatasetMapping = null;
                 _dataExportFilterManager = null;
                 BlackListedSources = null;
+                DuplicatesByProject?.Clear();
                 DuplicatesByProject = null;
+                DuplicatesByCohortSourceUsedByProjectNode?.Clear();
                 DuplicatesByCohortSourceUsedByProjectNode = null;
                 ProjectNumberToCohortsDictionary = null;
                 AllProjectAssociatedCics = null;
@@ -652,6 +657,7 @@ namespace Rdmp.Core.Providers
                 _cicAssociations = null;
                 AllFreeCohortIdentificationConfigurationsNode = null;
                 AllProjectCohortIdentificationConfigurationsNode = null;
+                _selectedDataSetsWithNoIsExtractionIdentifier?.Clear();
                 _selectedDataSetsWithNoIsExtractionIdentifier = null;
                  AllContainers = null;
                 AllDeployedExtractionFilters = null;


### PR DESCRIPTION
This PR clears and nulls a couple of extra properties in child providers that were sticking around after refreshes.  In both the Before and After cases repeated refreshes do not result in continued RAM growth but after this PR the memory usage is slightly reduced.

![image](https://user-images.githubusercontent.com/31306100/93988805-10a3cc00-fd81-11ea-8d1d-f8e22ffa48e9.png)
