### PR TITLE
Feature/column swapper mixed types

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -20,7 +20,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed startup error when user enters a corrupt connection string for platform database locations.  This bug affected syntactically invalid (malformed) connection strings (i.e. not simply connection strings that point to non existant databases)
 - Fixed various issues in ColumnSwapper
   - If input table contains nulls these are now passed through unchanged
-  - If mapping table contains null an error is thrown
+  - If mapping table contains nulls these are ignored (and not used to map input nulls)
   - If input table column is of a different Type than the database table a suitable Type conversion is applied
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed startup error when user enters a corrupt connection string for platform database locations.  This bug affected syntactically invalid (malformed) connection strings (i.e. not simply connection strings that point to non existant databases)
+- Fixed various issues in ColumnSwapper
+  - If input table contains nulls these are now passed through unchanged
+  - If mapping table contains null an error is thrown
+  - If input table column is of a different Type than the database table a suitable Type conversion is applied
 
 ### Changed
 

--- a/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Components/ColumnSwapperTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Components/ColumnSwapperTests.cs
@@ -199,6 +199,55 @@ namespace Rdmp.Core.Tests.DataLoad.Engine.Integration.PipelineTests.Components
         }
         
         /// <summary>
+        /// Tests ColumnSwapper when there are null values in the input <see cref="DataTable"/> being processed
+        /// </summary>
+        [Test]
+        public void TestColumnSwapper_InputTableNulls()
+        {
+            var dt = new DataTable();
+            dt.Columns.Add("In");
+            dt.Columns.Add("Out");
+
+            dt.Rows.Add(1, 1);
+            dt.Rows.Add(2, 2);
+
+            var db = GetCleanedServer(DatabaseType.MicrosoftSQLServer);
+            TableInfo map;
+            ColumnInfo[] mapCols;
+
+            Import(db.CreateTable("Map", dt), out map, out mapCols);
+
+            var swapper = new ColumnSwapper();
+            swapper.MappingFromColumn = mapCols.Single(c => c.GetRuntimeName().Equals("In"));
+            swapper.MappingToColumn = mapCols.Single(c => c.GetRuntimeName().Equals("Out"));
+
+            swapper.Check(new ThrowImmediatelyCheckNotifier());
+
+            var dtToSwap = new DataTable();
+
+            dtToSwap.Columns.Add("In",typeof(int));
+            dtToSwap.Columns.Add("Name");
+            dtToSwap.Columns.Add("Age");
+
+            dtToSwap.Rows.Add(1, "Dave", 30);
+            dtToSwap.Rows.Add(null, "Bob", 30);
+            dtToSwap.Rows.Add(2, "Frank", 50);
+
+            var resultDt = swapper.ProcessPipelineData(dtToSwap, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken());
+
+            Assert.AreEqual(3, resultDt.Rows.Count);
+            AreBasicallyEquals(1, resultDt.Rows[0]["Out"]);
+            Assert.AreEqual("Dave", resultDt.Rows[0]["Name"]);
+            
+            AreBasicallyEquals(null, resultDt.Rows[1]["Out"]);
+            Assert.AreEqual("Bob", resultDt.Rows[1]["Name"]);
+            
+            AreBasicallyEquals(2, resultDt.Rows[2]["Out"]);
+            Assert.AreEqual("Frank", resultDt.Rows[2]["Name"]);
+            
+
+        }
+        /// <summary>
         /// Tests the systems ability to compare an integer in the input data table with a string in the database
         /// </summary>
         [Test]


### PR DESCRIPTION
- Fixed various issues in ColumnSwapper
  - If input table contains nulls these are now passed through unchanged
  - If mapping table contains nulls these are ignored (and not used to map input nulls)
  - If input table column is of a different Type than the database table a suitable Type conversion is applied

/fixes #160