### PR TITLE
Fixed RemoteTableAttacher not honouring cancellation #164

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,7 +22,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - If input table contains nulls these are now passed through unchanged
   - If mapping table contains nulls these are ignored (and not used to map input nulls)
   - If input table column is of a different Type than the database table a suitable Type conversion is applied
-- Fixed RemoteTableAttacher not honouring cancellation
+- Better support for abort/cancel in
+  - RemoteTableAttacher
+  - ExcelAttacher
+  - KVPAttacher
+  - RemoteDatabaseAttacher
 
 ### Changed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -22,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - If input table contains nulls these are now passed through unchanged
   - If mapping table contains nulls these are ignored (and not used to map input nulls)
   - If input table column is of a different Type than the database table a suitable Type conversion is applied
+- Fixed RemoteTableAttacher not honouring cancellation
 
 ### Changed
 

--- a/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
+++ b/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
@@ -77,6 +77,8 @@ namespace Rdmp.Core.DataLoad.Engine.Pipeline.Sources
                 
                 while (_reader.Read())
                 {
+                    cancellationToken.ThrowIfCancellationRequested();
+
                     AddRowToDataTable(chunk, _reader);
                     readThisBatch ++;
 

--- a/Rdmp.Core/DataLoad/Modules/Attachers/DelimitedFlatFileAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/DelimitedFlatFileAttacher.cs
@@ -103,7 +103,6 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
         [DemandsInitialization(Attacher.ExplicitDateTimeFormat_DemandDescription)]
         public override string ExplicitDateTimeFormat {get => _source.ExplicitDateTimeFormat; set => _source.ExplicitDateTimeFormat = value; }
 
-        private GracefulCancellationToken cancellationToken = new GracefulCancellationToken();
 
           protected DelimitedFlatFileAttacher(char separator)
           {
@@ -123,7 +122,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
         private IDataLoadEventListener _listener;
         private FileInfo _currentFile;
 
-        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable dt, int maxBatchSize)
+        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable dt, int maxBatchSize,GracefulCancellationToken cancellationToken)
         {
             _source.MaxBatchSize = maxBatchSize;
             _source.SetDataTable(dt);
@@ -143,7 +142,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             return dt.Rows.Count;
         }
 
-        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener)
+        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {
             _source.StronglyTypeInput = false;
             _source.StronglyTypeInputBatchSize = 0;

--- a/Rdmp.Core/DataLoad/Modules/Attachers/ExcelAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/ExcelAttacher.cs
@@ -44,7 +44,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
 
         bool _haveServedData = false;
 
-        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener)
+        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {
             _haveServedData = false;
             _fileToLoad = fileToLoad;
@@ -55,7 +55,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             _hostedSource.PreInitialize(new FlatFileToLoad(fileToLoad),listener);
             listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information,  "About to start processing " + fileToLoad.FullName));
 
-            _dataTable = _hostedSource.GetChunk(listener, new GracefulCancellationToken());
+            _dataTable = _hostedSource.GetChunk(listener, cancellationToken);
 
             if (!string.IsNullOrEmpty(ForceReplacementHeaders))
             {
@@ -76,7 +76,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             }
 
             //all data should now be exhausted
-            if(_hostedSource.GetChunk(listener,new GracefulCancellationToken())!= null)
+            if(_hostedSource.GetChunk(listener,cancellationToken)!= null)
                 throw new Exception("Hosted source served more than 1 chunk, expected all the data to be read from the Excel file in one go");
         }
 
@@ -97,7 +97,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             return sb.ToString();
         }
 
-        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable loadTarget, int maxBatchSize)
+        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable loadTarget, int maxBatchSize,GracefulCancellationToken cancellationToken)
         {
             if (!_haveServedData)
             {

--- a/Rdmp.Core/DataLoad/Modules/Attachers/FixedWidthAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/FixedWidthAttacher.cs
@@ -8,6 +8,7 @@ using System.Data;
 using System.IO;
 using System.Linq;
 using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataFlowPipeline;
 using Rdmp.Core.DataLoad.Engine.Job;
 using ReusableLibraryCode.Checks;
 using ReusableLibraryCode.Progress;
@@ -34,7 +35,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
         public FileInfo PathToFormatFile { get; set; }
 
         DataTable _flatFile;
-        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener)
+        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {
             bHaveAlreadySubmittedData = false;
 
@@ -56,15 +57,16 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
         }
 
         private bool bHaveAlreadySubmittedData;
-        
+
 
         /// <summary>
         /// 
         /// </summary>
         /// <param name="destination"></param>
         /// <param name="maxBatchSize"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns></returns>
-        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable destination, int maxBatchSize)
+        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable destination, int maxBatchSize,GracefulCancellationToken cancellationToken)
         {
             if (bHaveAlreadySubmittedData)
                 return 0;

--- a/Rdmp.Core/DataLoad/Modules/Attachers/FlatFileAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/FlatFileAttacher.cs
@@ -94,14 +94,14 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             }
 
             foreach (var fileToLoad in filesToLoad)
-                LoadFile(table, fileToLoad, _dbInfo, timer, job);
+                LoadFile(table, fileToLoad, _dbInfo, timer, job,cancellationToken);
 
             timer.Stop();
 
             return ExitCodeType.Success;
         }
 
-        private void LoadFile(DiscoveredTable tableToLoad, FileInfo fileToLoad, DiscoveredDatabase dbInfo, Stopwatch timer, IDataLoadJob job)
+        private void LoadFile(DiscoveredTable tableToLoad, FileInfo fileToLoad, DiscoveredDatabase dbInfo, Stopwatch timer, IDataLoadJob job, GracefulCancellationToken token)
         {
             using (var con = dbInfo.Server.GetConnection())
             {
@@ -118,7 +118,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
 
                     //bulk insert ito destination
                     job.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "About to open file " + fileToLoad.FullName));
-                    OpenFile(fileToLoad,job);
+                    OpenFile(fileToLoad,job,token);
 
                     //confirm the validity of the headers
                     ConfirmFlatFileHeadersAgainstDataTable(dt,job);
@@ -133,7 +133,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
                     try
                     {
                         //while there is data to be loaded into table 
-                        while (IterativelyBatchLoadDataIntoDataTable(dt, maxBatchSize) != 0)
+                        while (IterativelyBatchLoadDataIntoDataTable(dt, maxBatchSize,token) != 0)
                         {
                             DropEmptyColumns(dt);
                             ConfirmFitToDestination(dt, tableToLoad, job);
@@ -165,7 +165,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             }
         }
 
-        protected abstract void OpenFile(FileInfo fileToLoad,IDataLoadEventListener listener);
+        protected abstract void OpenFile(FileInfo fileToLoad,IDataLoadEventListener listener,GracefulCancellationToken cancellationToken);
         protected abstract void CloseFile();
         
         public override void Check(ICheckNotifier notifier)
@@ -211,8 +211,9 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
         /// </summary>
         /// <param name="dt"></param>
         /// <param name="maxBatchSize"></param>
+        /// <param name="cancellationToken"></param>
         /// <returns>return the number of rows read, if you return >0 then you will be called again to get more data (if during this second or subsequent call there is no more data to read from source, return 0)</returns>
-        protected abstract int IterativelyBatchLoadDataIntoDataTable(DataTable dt, int maxBatchSize);
+        protected abstract int IterativelyBatchLoadDataIntoDataTable(DataTable dt, int maxBatchSize,GracefulCancellationToken cancellationToken);
         
 
         private void DropEmptyColumns(DataTable dt)

--- a/Rdmp.Core/DataLoad/Modules/Attachers/KVPAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/KVPAttacher.cs
@@ -46,7 +46,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
         public string TargetDataTableValueColumnName { get; set; }
 
         #region Attacher Functionality
-        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener)
+        protected override void OpenFile(FileInfo fileToLoad, IDataLoadEventListener listener,GracefulCancellationToken cancellationToken)
         {
             if(BatchesReadyForProcessing.Any())
                 throw new NotSupportedException("There are still batches awaiting dispatch to RAW, we cannot open a new file at this time");
@@ -57,7 +57,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             var dataFlow = new KVPAttacherPipelineUseCase(this, flatFileToLoad).GetEngine(PipelineForReadingFromFlatFile, listener);
 
             //will result in the opening and processing of the file and the passing of DataTables through the Pipeline finally arriving at the destination (us) in ProcessPipelineData
-            dataFlow.ExecutePipeline(new GracefulCancellationToken());
+            dataFlow.ExecutePipeline(cancellationToken);
 
         }
 
@@ -93,7 +93,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
 
         }
         
-        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable dt, int maxBatchSize)
+        protected override int IterativelyBatchLoadDataIntoDataTable(DataTable dt, int maxBatchSize,GracefulCancellationToken cancellationToken)
         {
             //there are no batches for processing
             if (!BatchesReadyForProcessing.Any())

--- a/Rdmp.Core/DataLoad/Modules/Attachers/RemoteDatabaseAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/RemoteDatabaseAttacher.cs
@@ -108,7 +108,7 @@ False - Fetch all columns in the remote table.  To use this option you will need
                     }, -1);
 
                 engine.Initialize(loadInfo);
-                engine.ExecutePipeline(new GracefulCancellationToken());
+                engine.ExecutePipeline(cancellationToken);
 
                 if (source.TotalRowsRead == 0)
                 {

--- a/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableAttacher.cs
@@ -382,7 +382,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
                 }, -1);
 
             engine.Initialize(loadInfo);
-            engine.ExecutePipeline(new GracefulCancellationToken());
+            engine.ExecutePipeline(cancellationToken);
 
             if (source.TotalRowsRead == 0 && LoadNotRequiredIfNoRowsRead)
             {


### PR DESCRIPTION
Better support for abort/cancel in
  - RemoteTableAttacher
  - ExcelAttacher
  - KVPAttacher
  - RemoteDatabaseAttacher

This PR changes the signatures of `IterativelyBatchLoadDataIntoDataTable` and `OpenFile` so may require plugin writers to update to latest NuGet package

/fixes #164 