### PR TITLE
Feature/do not alter explicit types

### DIFF
--- a/Rdmp.Core/DataLoad/Engine/Pipeline/Destinations/DataTableUploadDestination.cs
+++ b/Rdmp.Core/DataLoad/Engine/Pipeline/Destinations/DataTableUploadDestination.cs
@@ -287,6 +287,13 @@ namespace Rdmp.Core.DataLoad.Engine.Pipeline.Destinations
                 //if the SQL data type has degraded e.g. varchar(10) to varchar(50) or datetime to varchar(20)
                 if(oldSqlType != newSqlType)
                 {
+                    // Do not alter types of any columns where an explicit type was ordered
+                    if(ExplicitTypes != null && ExplicitTypes.Any(c => c.ColumnName.Equals(column.ColumnName, StringComparison.CurrentCultureIgnoreCase)))
+                    {
+                        listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Warning, "Considered resizing column '" + column + "' from '" + oldSqlType + "' to '" + newSqlType + "' but decided not to because there is an ExplicitWriteType"));
+                        continue;
+                    }
+                    
                     listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Warning, "Resizing column '" + column + "' from '" + oldSqlType + "' to '" + newSqlType + "'"));
 
                     var col = tbl.DiscoverColumn(column.ColumnName,_managedConnection.ManagedTransaction);

--- a/Rdmp.Core/DataLoad/Engine/Pipeline/Destinations/DataTableUploadDestination.cs
+++ b/Rdmp.Core/DataLoad/Engine/Pipeline/Destinations/DataTableUploadDestination.cs
@@ -315,17 +315,17 @@ namespace Rdmp.Core.DataLoad.Engine.Pipeline.Destinations
         /// <summary>
         /// Returns true if we should not be trying to do this alter after all
         /// </summary>
-        /// <param name="oldSqlType"></param>
-        /// <param name="newSqlType"></param>
-        /// <param name="reason"></param>
-        /// <returns></returns>
-        private bool AbandonAlter(string oldSqlType, string newSqlType, out string reason)
+        /// <param name="oldSqlType">The database proprietary type you are considering altering from</param>
+        /// <param name="newSqlType">The ANSI SQL type you are considering altering to</param>
+        /// <param name="reason">Null or the reason we are returning true</param>
+        /// <returns>True if the proposed alter is a bad idea and shouldn't be attempted</returns>
+        protected virtual bool AbandonAlter(string oldSqlType, string newSqlType, out string reason)
         {
             var basicallyDecimalAlready = new List<string>(){ "real","double","float","single"};
 
             var first = basicallyDecimalAlready.FirstOrDefault(c=>oldSqlType.Contains(c,CompareOptions.IgnoreCase));
 
-            if(first != null && newSqlType.Contains("decimal"))
+            if(first != null && newSqlType.Contains("decimal",CompareOptions.IgnoreCase))
             {
                 reason = $"Resizing from {first} to decimal is a bad idea and likely to fail";
                 return false;


### PR DESCRIPTION
Fixes #229 by preventing resize alter operations where there is an Explicit Write Type configured and the alter from type is floating point (double, real, float etc)

