### PR TITLE
Feature/mixing identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,6 +37,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Console GUI root nodes now offer sensible commands (e.g. create new Catalogue)
 - Added Value column to tree views (allows user to quickly see current arguments' values)
 - Added 'other' checkbox to 'Create Catalogue by importing a file' (for selecting custom piplelines)
+- Command SetExtractionIdentifier now supports changing the linkage identifier for specific ExtractionConfigurations only
 
 ### Fixed
 

--- a/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetExtractionIdentifierTests.cs
+++ b/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetExtractionIdentifierTests.cs
@@ -1,0 +1,93 @@
+﻿using NUnit.Framework;
+using Rdmp.Core.CommandExecution.AtomicCommands;
+using Rdmp.Core.CommandLine.Interactive.Picking;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataExport.Data;
+using System;
+
+namespace Rdmp.Core.Tests.CommandExecution
+{
+    class ExecuteCommandSetExtractionIdentifierTests : CommandCliTests
+    {
+        [Test]
+        public void TestSetExtractionIdentifier_Catalogue()
+        {
+            var ei1 = WhenIHaveA<ExtractionInformation>();
+            
+            ei1.Alias = "happyfun";
+            ei1.IsExtractionIdentifier = false;
+            ei1.SaveToDatabase();
+
+            var cmd = new ExecuteCommandSetExtractionIdentifier(GetMockActivator().Object,ei1.CatalogueItem.Catalogue,null,"happyfun");
+            cmd.Execute();
+
+            Assert.IsTrue(ei1.IsExtractionIdentifier);
+        }
+        [Test]
+        public void TestSetExtractionIdentifier_Catalogue_PickOther()
+        {
+            var ei1 = WhenIHaveA<ExtractionInformation>();
+
+            var otherCol = new ColumnInfo(Repository, "Other", "varchar", ei1.ColumnInfo.TableInfo);
+            var otherCatItem = new CatalogueItem(Repository, ei1.CatalogueItem.Catalogue,"Other");
+            var otherEi = new ExtractionInformation(Repository, otherCatItem, otherCol, "FFF");
+
+            ei1.Alias = "happyfun";
+            ei1.IsExtractionIdentifier = true;
+            ei1.SaveToDatabase();
+
+            // before we run the command the primary ei1 is the identifier
+            Assert.IsTrue(ei1.IsExtractionIdentifier);
+            Assert.IsFalse(otherEi.IsExtractionIdentifier);
+
+            // by picking the second (FFF) we should switch
+            var cmd = new ExecuteCommandSetExtractionIdentifier(GetMockActivator().Object, ei1.CatalogueItem.Catalogue, null, "FFF");
+            cmd.Execute();
+
+            // original should no longer be the extraction identifer
+            Assert.IsFalse(ei1.IsExtractionIdentifier);
+
+            // and the one picked should now be the only one
+            Assert.IsTrue(otherEi.IsExtractionIdentifier);
+        }
+        [Test]
+        public void TestSetExtractionIdentifier_Catalogue_ButColumnDoesNotExist()
+        {
+            var ei1 = WhenIHaveA<ExtractionInformation>();
+
+            ei1.Alias = "happyfun";
+            ei1.IsExtractionIdentifier = false;
+            ei1.SaveToDatabase();
+
+            var ex = Assert.Throws<Exception>(()=>
+                new ExecuteCommandSetExtractionIdentifier(GetMockActivator().Object, ei1.CatalogueItem.Catalogue, null, "trollolo")
+                .Execute());
+            Assert.AreEqual("Could not find column(s) trollolo amongst available columns (happyfun)", ex.Message);
+        }
+
+
+        [Test]
+        public void TestSetExtractionIdentifier_Configuration()
+        {
+            var ec1 = WhenIHaveA<ExtractableColumn>();
+
+            ec1.Alias = "happyfun";
+            ec1.IsExtractionIdentifier = false;
+            ec1.SaveToDatabase();
+
+            var config = Repository.GetObjectByID<ExtractionConfiguration>(ec1.ExtractionConfiguration_ID);
+               
+            var cmd = new ExecuteCommandSetExtractionIdentifier(GetMockActivator().Object, 
+                ec1.CatalogueExtractionInformation.CatalogueItem.Catalogue,
+                config
+                , "happyfun");
+            cmd.Execute();
+
+            // affects extraction specific version
+            Assert.IsTrue(ec1.IsExtractionIdentifier);
+
+            // but not master
+            Assert.IsFalse(ec1.CatalogueExtractionInformation.IsExtractionIdentifier);
+        }
+    }
+}

--- a/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
@@ -94,7 +94,7 @@ namespace Rdmp.Core.CommandExecution
                 yield return new CommandPresentation(new ExecuteCommandChangeExtractability(_activator, c),Extraction);
                 yield return new CommandPresentation(new ExecuteCommandMakeCatalogueProjectSpecific(_activator,c,null),Extraction);
                 yield return new CommandPresentation(new ExecuteCommandMakeProjectSpecificCatalogueNormalAgain(_activator, c),Extraction);
-                yield return new CommandPresentation(new ExecuteCommandSetExtractionIdentifier(_activator,c,null),Extraction);
+                yield return new CommandPresentation(new ExecuteCommandSetExtractionIdentifier(_activator,c,null,null),Extraction);
                                         
                 yield return new CommandPresentation(new ExecuteCommandExportObjectsToFile(_activator, new[] {c}),Metadata);
                 yield return new CommandPresentation(new ExecuteCommandExtractMetadata(_activator, new []{ c},null,null,null,false,null),Metadata);
@@ -349,7 +349,7 @@ namespace Rdmp.Core.CommandExecution
                 yield return new CommandPresentation(new ExecuteCommandCreateNewFilter(_activator,sds));
                 yield return new CommandPresentation(new ExecuteCommandCreateNewFilterFromCatalogue(_activator,sds));
                 yield return new CommandPresentation(new ExecuteCommandViewExtractionSql(_activator,sds));
-                yield return new CommandPresentation(new ExecuteCommandSetExtractionIdentifier(_activator, sds.GetCatalogue(), sds.ExtractionConfiguration));
+                yield return new CommandPresentation(new ExecuteCommandSetExtractionIdentifier(_activator, sds.GetCatalogue(), sds.ExtractionConfiguration,null));
             }
             
             if(Is(o, out ProjectCataloguesNode pcn))

--- a/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
@@ -94,7 +94,7 @@ namespace Rdmp.Core.CommandExecution
                 yield return new CommandPresentation(new ExecuteCommandChangeExtractability(_activator, c),Extraction);
                 yield return new CommandPresentation(new ExecuteCommandMakeCatalogueProjectSpecific(_activator,c,null),Extraction);
                 yield return new CommandPresentation(new ExecuteCommandMakeProjectSpecificCatalogueNormalAgain(_activator, c),Extraction);
-                yield return new CommandPresentation(new ExecuteCommandSetExtractionIdentifier(_activator,c),Extraction);
+                yield return new CommandPresentation(new ExecuteCommandSetExtractionIdentifier(_activator,c,null),Extraction);
                                         
                 yield return new CommandPresentation(new ExecuteCommandExportObjectsToFile(_activator, new[] {c}),Metadata);
                 yield return new CommandPresentation(new ExecuteCommandExtractMetadata(_activator, new []{ c},null,null,null,false,null),Metadata);
@@ -349,6 +349,7 @@ namespace Rdmp.Core.CommandExecution
                 yield return new CommandPresentation(new ExecuteCommandCreateNewFilter(_activator,sds));
                 yield return new CommandPresentation(new ExecuteCommandCreateNewFilterFromCatalogue(_activator,sds));
                 yield return new CommandPresentation(new ExecuteCommandViewExtractionSql(_activator,sds));
+                yield return new CommandPresentation(new ExecuteCommandSetExtractionIdentifier(_activator, sds.GetCatalogue(), sds.ExtractionConfiguration));
             }
             
             if(Is(o, out ProjectCataloguesNode pcn))

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetExtractionIdentifier.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetExtractionIdentifier.cs
@@ -98,7 +98,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         {
             var cols = _alreadyMarked ?? _alreadyMarkedInConfiguration;
 
-            if (cols.Length == 0)
+            if (cols == null || cols.Length == 0)
                 return base.GetCommandName();
 
             return base.GetCommandName() + "(" + string.Join(",", cols.Select(e=>e.GetRuntimeName())) + ")";

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetExtractionIdentifier.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetExtractionIdentifier.cs
@@ -4,40 +4,90 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Drawing;
 using System.Linq;
 using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataExport.Data;
 using Rdmp.Core.Icons.IconProvision;
 using ReusableLibraryCode.Icons.IconProvision;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands
 {
+    /// <summary>
+    /// Change which column is used to perform linkage against a cohort.  This command supports both changing the global setting on a <see cref="Catalogue"/>
+    /// or changing it only for a specific <see cref="ExtractionConfiguration"/>
+    /// </summary>
     public class ExecuteCommandSetExtractionIdentifier : BasicCommandExecution, IAtomicCommand
     {
-        private Catalogue _catalogue;
+        private ICatalogue _catalogue;
         private ExtractionInformation[] _extractionInformations;
         private ExtractionInformation[] _alreadyMarked;
 
-        public ExecuteCommandSetExtractionIdentifier(IBasicActivateItems activator,Catalogue catalogue):base(activator)
+        private readonly IExtractionConfiguration _inConfiguration;
+        private ConcreteColumn[] _selectedDataSetColumns;
+        private ConcreteColumn[] _alreadyMarkedInConfiguration;
+
+        /// <summary>
+        /// Change which column is the linkage identifier in a <see cref="Catalogue"/> either at a global level or for a specific <paramref name="inConfiguration"/>
+        /// </summary>
+        /// <param name="activator"></param>
+        /// <param name="catalogue"></param>
+        /// <param name="inConfiguration"></param>
+        public ExecuteCommandSetExtractionIdentifier(IBasicActivateItems activator,
+            [DemandsInitialization("The dataset you want to change the extraction identifier for")]
+            ICatalogue catalogue,
+
+            [DemandsInitialization("The specific extraction you want the change made in or Null for the Catalogue itself (will affect all future extractions)")]
+            IExtractionConfiguration inConfiguration):base(activator)
         {
             _catalogue = catalogue;
-
+            _inConfiguration = inConfiguration;
             _catalogue.ClearAllInjections();
 
-            _extractionInformations = _catalogue.GetAllExtractionInformation(ExtractionCategory.Any);
+            if(inConfiguration != null)
+            {
+                var allEds = inConfiguration.GetAllExtractableDataSets();
+                var eds = allEds.FirstOrDefault(sds => sds.Catalogue_ID == _catalogue.ID);
+                if(eds == null)
+                {
+                    SetImpossible($"Catalogue '{_catalogue}' is not part of ExtractionConfiguration '{inConfiguration}'");
+                    return;
+                }
 
-            if(_extractionInformations.Length == 0)
-                SetImpossible("Catalogue does not have any extractable columns");
+                _selectedDataSetColumns = inConfiguration.GetAllExtractableColumnsFor(eds);
 
-            _alreadyMarked = _extractionInformations.Where(ei => ei.IsExtractionIdentifier).ToArray();
+                if (_selectedDataSetColumns.Length == 0)
+                {
+                    SetImpossible($"Catalogue '{_catalogue}' in '{inConfiguration}' does not have any extractable columns");
+                    return;
+                }
+
+                _alreadyMarkedInConfiguration = _selectedDataSetColumns.Where(ei => ei.IsExtractionIdentifier).ToArray();
+            }
+            else
+            {
+                _extractionInformations = _catalogue.GetAllExtractionInformation(ExtractionCategory.Any);
+
+                if (_extractionInformations.Length == 0)
+                {
+                    SetImpossible("Catalogue does not have any extractable columns");
+                    return;
+                }
+
+                _alreadyMarked = _extractionInformations.Where(ei => ei.IsExtractionIdentifier).ToArray();
+            }
+
         }
 
         public override string GetCommandName()
         {
-            if(_alreadyMarked.Length == 0)
+            var cols = _alreadyMarked ?? _alreadyMarkedInConfiguration;
+
+            if (cols.Length == 0)
                 return base.GetCommandName();
 
-            return base.GetCommandName() + "(" + string.Join(",", _alreadyMarked.Select(e=>e.GetRuntimeName())) + ")";
+            return base.GetCommandName() + "(" + string.Join(",", cols.Select(e=>e.GetRuntimeName())) + ")";
         }
 
         public override Image GetImage(IIconProvider iconProvider)
@@ -54,31 +104,44 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         {
             base.Execute();
 
-            string initialSearchText = _alreadyMarked.Length == 1 ? _alreadyMarked[0].GetRuntimeName():null;
+            var oldCols = _alreadyMarked ?? _alreadyMarkedInConfiguration;
 
-            if (SelectMany(_extractionInformations, out ExtractionInformation[] selected, initialSearchText))
+            string initialSearchText = oldCols.Length == 1 ? oldCols[0].GetRuntimeName():null;
+
+            if(_inConfiguration != null)
             {
-                if(selected.Length == 0)
-                    if(!YesNo("Do you want to clear the Extraction Identifier?", "Clear Extraction Identifier?"))
+                ChangeFor(initialSearchText, _selectedDataSetColumns);
+                Publish(_inConfiguration);
+            }
+            else
+            {
+                ChangeFor(initialSearchText, _extractionInformations);
+                Publish(_catalogue);
+            }
+
+        }
+        private void ChangeFor(string initialSearchText,ConcreteColumn[] allColumns)
+        {
+            if (SelectMany(allColumns, out ConcreteColumn[] selected, initialSearchText))
+            {
+                if (selected.Length == 0)
+                    if (!YesNo("Do you want to clear the Extraction Identifier?", "Clear Extraction Identifier?"))
                         return;
 
                 if (selected.Length > 1)
                     if (!YesNo("Are you sure you want multiple linkable extraction identifier columns (most datasets only have 1 person ID column in them)?", "Multiple IsExtractionIdentifier columns?"))
                         return;
 
-                foreach(var ei in _extractionInformations)
+                foreach (var ec in allColumns)
                 {
-                    bool newValue = selected.Contains(ei);
+                    bool newValue = selected.Contains(ec);
 
-                    if(ei.IsExtractionIdentifier != newValue)
+                    if (ec.IsExtractionIdentifier != newValue)
                     {
-                        ei.IsExtractionIdentifier = newValue;
-                        ei.SaveToDatabase();
+                        ec.IsExtractionIdentifier = newValue;
+                        ec.SaveToDatabase();
                     }
                 }
-
-
-                Publish(_catalogue);
             }
         }
     }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetExtractionIdentifier.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetExtractionIdentifier.cs
@@ -138,7 +138,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         {
             ConcreteColumn[] selected = null;
 
-            if (toPick.Length > 0)
+            if (toPick != null && toPick.Length > 0)
             {
                 selected = allColumns.Where(a => toPick.Contains(a.GetRuntimeName())).ToArray();
 

--- a/Rdmp.Core/QueryBuilding/ReleaseIdentifierSubstitution.cs
+++ b/Rdmp.Core/QueryBuilding/ReleaseIdentifierSubstitution.cs
@@ -108,9 +108,9 @@ namespace Rdmp.Core.QueryBuilding
 
                     //but replace all instances of CHI with PROCHI (or Barcode, or whatever)
                     if(!Alias.Contains(toReplace) || Regex.Matches(Alias,Regex.Escape(toReplace)).Count > 1)
-                        throw new Exception("Expected OriginalDatasetColumn " + OriginalDatasetColumn.Alias + " to have the text \"" + toReplace + "\" appearing once (and only once in it's name)," +
-                                            "we planned to replace that text with:" + toReplaceWith);
-
+                    {
+                        throw new Exception($"Failed to resolve multiple extraction identifiers in dataset.  Either mark a single column as the IsExtractionIdentifier for this extraction or ensure all columns are of compatible type and have the text \"" + toReplace + "\" appearing once (and only once in it's name)");
+                    }
                    
                    Alias = Alias.Replace(toReplace,toReplaceWith);
                 }

--- a/Rdmp.Core/QueryBuilding/ReleaseIdentifierSubstitution.cs
+++ b/Rdmp.Core/QueryBuilding/ReleaseIdentifierSubstitution.cs
@@ -109,7 +109,8 @@ namespace Rdmp.Core.QueryBuilding
                     //but replace all instances of CHI with PROCHI (or Barcode, or whatever)
                     if(!Alias.Contains(toReplace) || Regex.Matches(Alias,Regex.Escape(toReplace)).Count > 1)
                     {
-                        throw new Exception($"Failed to resolve multiple extraction identifiers in dataset.  Either mark a single column as the IsExtractionIdentifier for this extraction or ensure all columns are of compatible type and have the text \"" + toReplace + "\" appearing once (and only once in it's name)");
+                        throw new Exception(
+                            $"Failed to resolve multiple extraction identifiers in dataset.  Either mark a single column as the IsExtractionIdentifier for this extraction or ensure all columns are of compatible type and have the text \"{toReplace}\" appearing once (and only once in its name)");
                     }
                    
                    Alias = Alias.Replace(toReplace,toReplaceWith);

--- a/Tests.Common/UnitTests.cs
+++ b/Tests.Common/UnitTests.cs
@@ -443,8 +443,8 @@ namespace Tests.Common
             {
                 var eds = WhenIHaveA<ExtractableDataSet>();
                 var config = WhenIHaveA<ExtractionConfiguration>();
-                               
-                foreach(var ei in eds.Catalogue.GetAllExtractionInformation(ExtractionCategory.Any))
+
+                foreach (var ei in eds.Catalogue.GetAllExtractionInformation(ExtractionCategory.Any))
                 {
                     var ec = new ExtractableColumn(Repository, eds, config,ei,ei.Order,ei.SelectSQL);
                 }
@@ -511,7 +511,9 @@ namespace Tests.Common
 
                 var eds = new ExtractableDataSet(Repository, ei.CatalogueItem.Catalogue);
                 var config  = WhenIHaveA<ExtractionConfiguration>();
-                return (T)(object)new ExtractableColumn(Repository,eds,config,ei,0,ei.SelectSQL);
+                config.AddDatasetToConfiguration(eds);
+
+                return (T)(object) config.GetAllExtractableColumnsFor(eds).Single();
             }
             
             if (typeof (T) == typeof(FilterContainer))


### PR DESCRIPTION
/fixes  #315

![image](https://user-images.githubusercontent.com/31306100/115225320-dc6d6f80-a105-11eb-8c27-a646ffa6141b.png)
_Pick a specific column to use for linkage/extraction this time only_

```bash
PS Z:\Repos\RDMP\Tools\rdmp\bin\Debug\net5.0> dotnet rdmp.dll cmd describecommand SetExtractionIdentifier
Name: ExecuteCommandSetExtractionIdentifier

Description:
Change which column is used to perform linkage against a cohort. This command supports both changing the global setting on a Catalogue or changing it only for a specific ExtractionConfiguration

USAGE:
./rdmp.exe cmd SetExtractionIdentifier <catalogue> <inConfiguration> <column>

PARAMETERS:
catalogue       ICatalogue               The dataset you want to change the extraction identifier for
inConfiguration IExtractionConfiguration Optional - The specific extraction you want the change made in or Null for the
                                         Catalogue itself (will affect all future extractions)
column          String                   Optional - The Column name(s) you want to select as the new linkage
                                         identifier(s).  Comma seperate multiple entries if needed

PS Z:\Repos\RDMP\Tools\rdmp\bin\Debug\net5.0> dotnet rdmp.dll cmd SetExtractionIdentifier Catalogue:CT_ImageTable ExtractionConfiguration:*imag* PatientID
2021-04-19 11:49:03.4683 DEBUG Save,ExtractableColumn,287,Boolean IsExtractionIdentifier,False,True .
2021-04-19 11:49:03.4739 DEBUG Save,ExtractableColumn,288,Boolean IsExtractionIdentifier,True,False .
Command Completed
2021-04-19 11:49:03.5160 INFO Exiting with code 0 .
```