### PR TITLE
Feature/kee extractionui sync

### DIFF
--- a/Application/ResearchDataManagementPlatform/WindowManagement/ActivateItems.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/ActivateItems.cs
@@ -193,6 +193,8 @@ namespace ResearchDataManagementPlatform.WindowManagement
             else
                 CoreChildProvider.UpdateTo(temp);
 
+            RefreshBus.ChildProvider = CoreChildProvider;
+
             return CoreChildProvider;
         }
         

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -54,6 +54,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed DQE graph when data has dates before the year 1,000
 - Fixed `ExecuteCommandCreateNewCatalogueByImportingFile` when using blank constructor and from CLI GUI
 - Fixed extraction UI showing "WaitingForSQLServer" when DBMS might not be (now says "WaitingForDatabase").
+- Fixed bug where some UI tabs would not update when changes were made to child objects (e.g. deleting a dataset from an extraction using another window in the client)
 
 ### Changed
 

--- a/Rdmp.UI/Refreshing/RefreshBus.cs
+++ b/Rdmp.UI/Refreshing/RefreshBus.cs
@@ -52,6 +52,7 @@ namespace Rdmp.UI.Refreshing
 
                     //refresh it from the child provider
                     if (e.Exists)
+                    {
                         if (ChildProvider != null)
                         {
                             var fresh = ChildProvider.GetLatestCopyOf(e.Object);
@@ -63,6 +64,14 @@ namespace Rdmp.UI.Refreshing
                         }
                         else
                             e.Object.RevertToDatabaseState();
+                    }
+                    else
+                    {
+                        if(ChildProvider != null && e.DeletedObjectDescendancy == null)
+                        {
+                            e.DeletedObjectDescendancy = ChildProvider.GetDescendancyListIfAnyFor(e.Object);
+                        }
+                    }                        
 
                     RefreshObject?.Invoke(sender, e);
                 }


### PR DESCRIPTION
/fixes #312

Refreshing was not working properly for parents of deleted objects.  It seems `ChildProvider` in `RefreshBus` was never set so it would never properly notify parents when changes were made to objects below them.