### PR TITLE
Added KeepAlive and KeepAliveIntervalMilliseconds

### DIFF
--- a/Rdmp.Core/DataLoad/Modules/FTP/FTPDownloader.cs
+++ b/Rdmp.Core/DataLoad/Modules/FTP/FTPDownloader.cs
@@ -60,6 +60,9 @@ namespace Rdmp.Core.DataLoad.Modules.FTP
         [DemandsInitialization("The directory on the FTP server that you want to download files from")]
         public string RemoteDirectory { get; set; }
 
+        [DemandsInitialization("True to set keep alive", DefaultValue = true)]
+        public bool KeepAlive { get; set; }
+
 
         public void Initialize(ILoadDirectory directory, DiscoveredDatabase dbInfo)
         {
@@ -187,7 +190,8 @@ namespace Rdmp.Core.DataLoad.Modules.FTP
                 reqFTP.Credentials = new NetworkCredential(_username, _password);
                 reqFTP.Method = WebRequestMethods.Ftp.ListDirectory;
                 reqFTP.Timeout = TimeoutInSeconds*1000;
-
+                reqFTP.KeepAlive = KeepAlive;
+                
                 reqFTP.Proxy = null;
                 reqFTP.KeepAlive = false;
                 reqFTP.UsePassive = true;

--- a/Rdmp.Core/DataLoad/Modules/FTP/SFTPDownloader.cs
+++ b/Rdmp.Core/DataLoad/Modules/FTP/SFTPDownloader.cs
@@ -9,6 +9,7 @@ using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using Rdmp.Core.Curation;
+using Rdmp.Core.Curation.Data;
 using Renci.SshNet;
 using ReusableLibraryCode.Progress;
 
@@ -22,6 +23,10 @@ namespace Rdmp.Core.DataLoad.Modules.FTP
     /// </summary>
     public class SFTPDownloader:FTPDownloader
     {
+
+        [DemandsInitialization("The keep-alive interval.  In milliseconds.  Requires KeepAlive to be set to take effect.")]
+        public int KeepAliveIntervalMilliseconds { get; set; }
+
         protected override void Download(string file, ILoadDirectory destination,IDataLoadEventListener job)
         {
             if (file.Contains("/") || file.Contains("\\"))
@@ -32,6 +37,11 @@ namespace Rdmp.Core.DataLoad.Modules.FTP
             
             using(var sftp = new SftpClient(_host,_username,_password))
             {
+                if (KeepAlive)
+                {
+                    sftp.KeepAliveInterval =   TimeSpan.FromMilliseconds(KeepAliveIntervalMilliseconds);
+                }
+
                 sftp.ConnectionInfo.Timeout = new TimeSpan(0, 0, 0, TimeoutInSeconds);
                 sftp.Connect();
                 

--- a/Rdmp.Core/DataLoad/Modules/FTP/SFTPDownloader.cs
+++ b/Rdmp.Core/DataLoad/Modules/FTP/SFTPDownloader.cs
@@ -37,7 +37,7 @@ namespace Rdmp.Core.DataLoad.Modules.FTP
             
             using(var sftp = new SftpClient(_host,_username,_password))
             {
-                if (KeepAlive)
+                if (KeepAlive && KeepAliveIntervalMilliseconds > 0)
                 {
                     sftp.KeepAliveInterval =   TimeSpan.FromMilliseconds(KeepAliveIntervalMilliseconds);
                 }


### PR DESCRIPTION
/Fixes #336


SFTPDownloader inherits from FTPDownloader.

Previous behaviour:
- FTPDownloader client class has KeepAlive property which defaults to true
- SFTPDownloader has no KeepAlive property only an interval which defaults to -1 (no keep alive).

So I have added a bool property KeepAlive in the base class which defaults to true (keeping original behaviour for FTPDownloader)

And a property KeepAliveIntervalMilliseconds that defaults to 0 which when set to a postive number and combined with KeepAlive will populate the requisite setting in the SFTPDownloader client (preserving previous behaviour of SFTPDownloader)