### PR TITLE
Fixed a bug in rc1 where PruneFile was allwasy called on plugins even…

### DIFF
--- a/Rdmp.Core/CommandLine/Runners/PackPluginRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/PackPluginRunner.cs
@@ -84,7 +84,10 @@ namespace Rdmp.Core.CommandLine.Runners
                     rdmpDependencyVersion = new Version(versionSuffix.Replace(rdmpDependencyNode.Attribute("version").Value, ""));
                 }
 
-                PruneFile(toCommit,zf, checkNotifier);
+                if (_packOpts.Prune)
+                {
+                    PruneFile(toCommit, zf, checkNotifier);
+                }
             }
 
             var runningSoftwareVersion = new Version(FileVersionInfo.GetVersionInfo(Assembly.GetExecutingAssembly().Location).FileVersion);


### PR DESCRIPTION
… when the optional flag was not set