### PR TITLE
Fixed RunEngineWindow to look for rdmp binary in correct location

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Bump Terminal.Gui from 1.0.0 to 1.1.1
 - Bump HIC.FAnsiSql from 1.0.6 to 1.0.7
 
+### Fixed
+
+- Fixed bug running rdmp gui (console) with a remote current directory
 
 ## [5.0.0]
 

--- a/Tools/rdmp/CommandLine/Gui/Windows/RunnerWindows/RunEngineWindow.cs
+++ b/Tools/rdmp/CommandLine/Gui/Windows/RunnerWindows/RunEngineWindow.cs
@@ -8,6 +8,7 @@ using Rdmp.Core.CommandExecution;
 using Rdmp.Core.CommandExecution.AtomicCommands.Automation;
 using Rdmp.Core.CommandLine.Options;
 using Rdmp.Core.Startup;
+using ReusableLibraryCode;
 using System;
 using System.Diagnostics;
 using System.IO;
@@ -134,7 +135,16 @@ namespace Rdmp.Core.CommandLine.Gui.Windows.RunnerWindows
         {
             ClearOutput();
 
-            var binary = "./rdmp" + (EnvironmentInfo.IsLinux ? "" : ".exe");
+            string expectedFileName = "rdmp" + (EnvironmentInfo.IsLinux ? "" : ".exe");
+
+            // try in the location we ran from 
+            var binary = Path.Combine(UsefulStuff.GetExecutableDirectory().FullName, expectedFileName);
+
+            if (!File.Exists(binary))
+            {
+                // the program that launched this code isn't rdmp.exe.  Maybe rdmp is in the current directory though
+                binary = "./" + expectedFileName;
+            }
 
             if (!File.Exists(binary))
             {


### PR DESCRIPTION
fixes #365