### PR TITLE
Added HideEmptyTableLoadRunAudits

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- Added user setting for filtering table load logs where there are 0 inserts,updates and deletes
+
 ## [5.0.3] - 2021-06-17
 
 - Hotfix extraction/DLE progress UI layout on some Windows configurations

--- a/Rdmp.Core/Logging/PastEvents/ArchivalDataLoadInfo.cs
+++ b/Rdmp.Core/Logging/PastEvents/ArchivalDataLoadInfo.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Data.Common;
 using FAnsi.Discovery;
+using ReusableLibraryCode.Settings;
 
 namespace Rdmp.Core.Logging.PastEvents
 {
@@ -115,7 +116,18 @@ namespace Rdmp.Core.Logging.PastEvents
                 using(var cmd =  _loggingDatabase.Server.GetCommand("SELECT * FROM TableLoadRun WHERE dataLoadRunID=" +ID , con))
                     using(var r = cmd.ExecuteReader())
                         while(r.Read())
-                            toReturn.Add(new ArchivalTableLoadInfo(this,r,_loggingDatabase));
+                        {
+                            var audit = new ArchivalTableLoadInfo(this, r, _loggingDatabase);
+                        
+                            if((audit.Inserts??0) <= 0 && (audit.Updates??0) <= 0 && (audit.Deletes??0) <= 0 && UserSettings.HideEmptyTableLoadRunAudits)
+                            {
+                                continue;
+                            }
+                            else
+                            {
+                                toReturn.Add(audit);
+                            }
+                        }   
             }
 
             return toReturn;

--- a/Rdmp.UI/SimpleDialogs/UserSettingsUI.Designer.cs
+++ b/Rdmp.UI/SimpleDialogs/UserSettingsUI.Designer.cs
@@ -54,6 +54,7 @@
             this.cbShowPipelineCompletedPopup = new System.Windows.Forms.CheckBox();
             this.groupBox1 = new System.Windows.Forms.GroupBox();
             this.clbWarnings = new System.Windows.Forms.CheckedListBox();
+            this.cbHideEmptyTableLoadRunAudits = new System.Windows.Forms.CheckBox();
             this.groupBox1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -339,12 +340,25 @@
             this.clbWarnings.Size = new System.Drawing.Size(401, 363);
             this.clbWarnings.TabIndex = 1;
             // 
+            // cbHideEmptyTableLoadRunAudits
+            // 
+            this.cbHideEmptyTableLoadRunAudits.AutoSize = true;
+            this.cbHideEmptyTableLoadRunAudits.Location = new System.Drawing.Point(348, 163);
+            this.cbHideEmptyTableLoadRunAudits.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.cbHideEmptyTableLoadRunAudits.Name = "cbHideEmptyTableLoadRunAudits";
+            this.cbHideEmptyTableLoadRunAudits.Size = new System.Drawing.Size(208, 19);
+            this.cbHideEmptyTableLoadRunAudits.TabIndex = 15;
+            this.cbHideEmptyTableLoadRunAudits.Text = "Hide Empty Table Load Run Audits";
+            this.cbHideEmptyTableLoadRunAudits.UseVisualStyleBackColor = true;
+            this.cbHideEmptyTableLoadRunAudits.CheckedChanged += new System.EventHandler(this.cb_CheckedChanged);
+            // 
             // UserSettingsFileUI
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
             this.ClientSize = new System.Drawing.Size(866, 652);
             this.Controls.Add(this.groupBox1);
+            this.Controls.Add(this.cbHideEmptyTableLoadRunAudits);
             this.Controls.Add(this.cbShowPipelineCompletedPopup);
             this.Controls.Add(this.hlpIdentifiableExtractions);
             this.Controls.Add(this.cbAllowIdentifiableExtractions);
@@ -404,5 +418,6 @@
         private System.Windows.Forms.CheckBox cbShowPipelineCompletedPopup;
         private System.Windows.Forms.GroupBox groupBox1;
         private System.Windows.Forms.CheckedListBox clbWarnings;
+        private System.Windows.Forms.CheckBox cbHideEmptyTableLoadRunAudits;
     }
 }

--- a/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
+++ b/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
@@ -42,6 +42,7 @@ namespace Rdmp.UI.SimpleDialogs
             cbDebugPerformance.Checked = UserSettings.DebugPerformance;
             cbAllowIdentifiableExtractions.Checked = UserSettings.AllowIdentifiableExtractions;
             cbShowPipelineCompletedPopup.Checked = UserSettings.ShowPipelineCompletedPopup;
+            cbHideEmptyTableLoadRunAudits.Checked = UserSettings.HideEmptyTableLoadRunAudits;
 
             clbWarnings.Items.Add(WarnOnTimeoutOnExtractionChecks, UserSettings.WarnOnTimeoutOnExtractionChecks);
 
@@ -122,6 +123,9 @@ namespace Rdmp.UI.SimpleDialogs
             
             if(cb == cbShowPipelineCompletedPopup)
                 UserSettings.ShowPipelineCompletedPopup = cb.Checked;
+
+            if (cb == cbHideEmptyTableLoadRunAudits)
+                UserSettings.HideEmptyTableLoadRunAudits = cb.Checked;
         }
 
         private void ddTheme_SelectedIndexChanged(object sender, EventArgs e)

--- a/Reusable/ReusableLibraryCode/Settings/UserSettings.cs
+++ b/Reusable/ReusableLibraryCode/Settings/UserSettings.cs
@@ -235,6 +235,13 @@ namespace ReusableLibraryCode.Settings
             set { AppSettings.AddOrUpdateValue("ConsoleColorScheme", value); }
         }
 
+        public static bool HideEmptyTableLoadRunAudits
+        {
+            get { return AppSettings.GetValueOrDefault("HideEmptyTableLoadRunAudits", false); }
+            set { AppSettings.AddOrUpdateValue("HideEmptyTableLoadRunAudits", value); }
+        }
+
+
         #endregion
 
         public static bool GetTutorialDone(Guid tutorialGuid)


### PR DESCRIPTION
Fixes #424 

![image](https://user-images.githubusercontent.com/31306100/123226031-30605000-d4cb-11eb-9fa8-9d32ad6b0fb8.png)

You can set this via the UI above or call

```
./rdmp cmd SetUserSetting HideEmptyTableLoadRunAudits  true
```
