### PR TITLE
Fixed -g false not working in release CLI args

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+## Fixed
+
+- Fixed release engine not respecting `-g false` (do not release Globals)
+
 ## [5.0.3] - 2021-06-17
 
 - Hotfix extraction/DLE progress UI layout on some Windows configurations

--- a/Rdmp.Core/CommandLine/Options/ReleaseOptions.cs
+++ b/Rdmp.Core/CommandLine/Options/ReleaseOptions.cs
@@ -26,6 +26,6 @@ namespace Rdmp.Core.CommandLine.Options
         public IEnumerable<int> SelectedDataSets { get; set; }
 
         [Option('g', "Globals", HelpText = "True to release extracted globals (default) or false to skip them", Default = true)]
-        public bool ReleaseGlobals { get; set; }
+        public bool? ReleaseGlobals { get; set; }
     }
 }

--- a/Rdmp.Core/CommandLine/Runners/ReleaseRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ReleaseRunner.cs
@@ -85,7 +85,7 @@ namespace Rdmp.Core.CommandLine.Runners
 
             List<ICheckable> toReturn = new List<ICheckable>();
 
-            if (_options.ReleaseGlobals)
+            if (_options.ReleaseGlobals ?? true)
             {
                 toReturn.Add(new GlobalsReleaseChecker(RepositoryLocator, _configurations));
                 toReturn.AddRange(_configurations.First()
@@ -208,7 +208,7 @@ namespace Rdmp.Core.CommandLine.Runners
                 data.SelectedDatasets.Add(configuration, GetSelectedDataSets(configuration));
             }
 
-            data.ReleaseGlobals = _options.ReleaseGlobals;
+            data.ReleaseGlobals = _options.ReleaseGlobals ?? true;
 
             var allDdatasets = _configurations.SelectMany(ec => ec.GetAllExtractableDataSets()).ToList();
             var selectedDatasets = data.SelectedDatasets.Values.SelectMany(sd => sd.ToList()).ToList();


### PR DESCRIPTION
Fixes  #418

If you want to run a release without globals use:

```
release --Configurations 4 --command check --MaxConcurrentExtractions 3 --Pipeline 9 -g false
```