### PR TITLE
Obj scope

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,7 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ExecuteCommandAlterColumnType` now automatically alters \_Archive table too without asking for confirmation
 - When foreign key values are missing from lookups, the 'Missing' status is now attributed to the `_Desc` field (previously to the foreign key field)
-- Referencing an object by name in a script file now returns the latest when there are collisions e.g. `ExtractableCohort` would return the latest one (created during the script execution session)
+- Referencing an object by name in a script file now returns the latest when there are collisions e.g. "[ExtractableCohort]" would return the latest one (created during the script execution session)
 
 ## Fixed
 
@@ -849,3 +849,4 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [Lookup]: ./Documentation/CodeTutorials/Glossary.md#Lookup
 [CohortIdentificationConfiguration]: ./Documentation/CodeTutorials/Glossary.md#CohortIdentificationConfiguration
 [LoadMetadata]: ./Documentation/CodeTutorials/Glossary.md#LoadMetadata
+[ExtractableCohort]: ./Documentation/CodeTutorials/Glossary.md#ExtractableCohort

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - `ExecuteCommandAlterColumnType` now automatically alters \_Archive table too without asking for confirmation
 - When foreign key values are missing from lookups, the 'Missing' status is now attributed to the `_Desc` field (previously to the foreign key field)
+- Referencing an object by name in a script file now returns the latest when there are collisions e.g. `ExtractableCohort` would return the latest one (created during the script execution session)
 
 ## Fixed
 

--- a/Rdmp.Core.Tests/CommandLine/NewObjectPoolTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/NewObjectPoolTests.cs
@@ -1,4 +1,10 @@
-﻿using MapsDirectlyToDatabaseTable;
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using MapsDirectlyToDatabaseTable;
 using NUnit.Framework;
 using Rdmp.Core.CommandLine.Interactive.Picking;
 using Rdmp.Core.Curation.Data;

--- a/Rdmp.Core.Tests/CommandLine/NewObjectPoolTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/NewObjectPoolTests.cs
@@ -1,0 +1,57 @@
+﻿using MapsDirectlyToDatabaseTable;
+using NUnit.Framework;
+using Rdmp.Core.CommandLine.Interactive.Picking;
+using Rdmp.Core.Curation.Data;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using Tests.Common;
+
+namespace Rdmp.Core.Tests.CommandLine
+{
+    class NewObjectPoolTests : UnitTests
+    {
+        [Test]
+        public void TwoCataloguesWithSameName_NoSession()
+        {
+            SetupMEF();
+
+            var cata1 = new Catalogue(Repository,"Hey");
+
+            // When there is only one object we can pick it by name
+            var picker = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+            Assert.IsTrue(picker.HasArgumentOfType(0, typeof(Catalogue)));
+            Assert.AreEqual(cata1, picker.Arguments.First().GetValueForParameterOfType(typeof(Catalogue)));
+
+            // But when there are 2 objects we don't know which to pick so cannot pick a Catalogue
+            new Catalogue(Repository, "Hey");
+            var picker2 = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+            Assert.IsFalse(picker2.HasArgumentOfType(0, typeof(Catalogue)));
+        }
+
+        [Test]
+        public void TwoCataloguesWithSameName_WithSession()
+        {
+            SetupMEF();
+
+            using(NewObjectPool.StartSession())
+            {
+                var cata1 = new Catalogue(Repository, "Hey");
+
+                // When there is only one object we can pick it by name
+                var picker = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+                Assert.IsTrue(picker.HasArgumentOfType(0, typeof(Catalogue)));
+                Assert.AreEqual(cata1, picker.Arguments.First().GetValueForParameterOfType(typeof(Catalogue)));
+
+                // There are now 2 objects with the same name but because we are in a session we can pick the latest
+                var cata2 = new Catalogue(Repository, "Hey");
+                var picker2 = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+
+                Assert.IsTrue(picker2.HasArgumentOfType(0, typeof(Catalogue)));
+                Assert.AreEqual(cata2, picker2.Arguments.First().GetValueForParameterOfType(typeof(Catalogue)));
+            }
+        }
+    }
+}

--- a/Rdmp.Core/CommandLine/Interactive/Picking/CommandLineObjectPickerArgumentValue.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/CommandLineObjectPickerArgumentValue.cs
@@ -173,8 +173,14 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
 
             if(DatabaseEntities.Count != 1)
             {
-                _logger.Warn($"Pattern matched {DatabaseEntities.Count} objects '{RawValue}':{Environment.NewLine} {string.Join(Environment.NewLine,DatabaseEntities)}");
-                return null;
+                var latest = NewObjectPool.Latest(DatabaseEntities.Where(d => d is T));
+
+                if (latest == null)
+                {
+                    _logger.Warn($"Pattern matched {DatabaseEntities.Count} objects '{RawValue}':{Environment.NewLine} {string.Join(Environment.NewLine, DatabaseEntities)}");
+                }
+                    
+                return latest;
             }   
 
             //return the single object as the type you want e.g. ICheckable

--- a/Rdmp.Core/CommandLine/Options/RdmpScript.cs
+++ b/Rdmp.Core/CommandLine/Options/RdmpScript.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.CommandLine.Runners;
 
 namespace Rdmp.Core.CommandLine.Options
@@ -18,5 +19,11 @@ namespace Rdmp.Core.CommandLine.Options
         /// </summary>
         /// <value></value>
         public string[] Commands {get;set;}
+
+        /// <summary>
+        /// True (default) to use a <see cref="NewObjectPool"/> to track objects created as the script is run
+        /// to improve argument matching when there are multiple objects that match a parameter e.g. CatalogueItem:chi
+        /// </summary>
+        public bool UseScope { get; set; } = true;
     }
 }

--- a/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Globalization;
 using System.Linq;
 using System.Text;
+using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.CommandExecution;
 using Rdmp.Core.CommandExecution.AtomicCommands;
 using Rdmp.Core.CommandLine.Interactive;
@@ -149,18 +150,22 @@ namespace Rdmp.Core.CommandLine.Runners
             if((script.Commands?.Length ?? 0) == 0)
                 throw new ArgumentException("script was empty",nameof(script));
 
-            foreach(string s in script.Commands)
+            using (script.UseScope ? NewObjectPool.StartSession() : null)
             {
-                try
+                foreach (string s in script.Commands)
                 {
-                    var cmd = GetCommandAndPickerFromLine(s,out _picker,repositoryLocator);
-                    RunCommand(cmd);
-                }
-                catch(Exception ex)
-                {
-                    throw new Exception($"Error executing script.  Problem line was '{s}':{ex.Message}",ex);
+                    try
+                    {
+                        var cmd = GetCommandAndPickerFromLine(s, out _picker, repositoryLocator);
+                        RunCommand(cmd);
+                    }
+                    catch (Exception ex)
+                    {
+                        throw new Exception($"Error executing script.  Problem line was '{s}':{ex.Message}", ex);
+                    }
                 }
             }
+                
         }
 
         public static IEnumerable<string> SplitCommandLine(string commandLine)

--- a/Reusable/MapsDirectlyToDatabaseTable/MemoryRepository.cs
+++ b/Reusable/MapsDirectlyToDatabaseTable/MemoryRepository.cs
@@ -50,6 +50,8 @@ namespace MapsDirectlyToDatabaseTable
             Objects.Add(toCreate);
 
             toCreate.PropertyChanged += toCreate_PropertyChanged;
+
+            NewObjectPool.Add(toCreate);
         }
 
         protected virtual void SetValue<T>(T toCreate, PropertyInfo prop, string strVal, object val) where T : IMapsDirectlyToDatabaseTable

--- a/Reusable/MapsDirectlyToDatabaseTable/NewObjectPool.cs
+++ b/Reusable/MapsDirectlyToDatabaseTable/NewObjectPool.cs
@@ -1,0 +1,81 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+
+namespace MapsDirectlyToDatabaseTable
+{
+    public static class NewObjectPool
+    {
+        private static Scope CurrentScope;
+        private static object currentScopeLock = new object();
+
+        public static void Add(IMapsDirectlyToDatabaseTable toCreate)
+        {
+            lock(currentScopeLock)
+            {
+                CurrentScope?.Objects.Add(toCreate);
+            }
+        }
+
+        /// <summary>
+        /// Returns the latest object in <paramref name="from"/> that was created during this session or null.
+        /// Objects are ordered by creation time so that the return value always reflects the most recent (if
+        /// there are multiple matches)
+        /// </summary>
+        /// <param name="from"></param>
+        /// <returns></returns>
+        public static IMapsDirectlyToDatabaseTable Latest(IEnumerable<IMapsDirectlyToDatabaseTable> from)
+        {
+            lock (currentScopeLock)
+            {
+                //prevent multiple enumeration
+                var fromArray = from.ToArray();
+
+                return CurrentScope?.Objects.AsEnumerable().Reverse().FirstOrDefault(fromArray.Contains);
+            }
+        }
+
+        /// <summary>
+        /// Starts a new session tracking all new objects created.  Make sure you wrap the
+        /// returned session in a using statement.  
+        /// </summary>
+        /// <exception cref="Exception">If there is already a session ongoing</exception>
+        /// <returns></returns>
+        public static IDisposable StartSession()
+        {
+            lock (currentScopeLock)
+            {
+                if (CurrentScope != null)
+                    throw new Exception("An existing session is already underway");
+
+                return CurrentScope = new Scope();
+            }
+        }
+
+        private static void EndSession()
+        {
+            lock (currentScopeLock)
+            {
+                CurrentScope = null;
+            }
+        }
+
+        private class Scope : IDisposable
+        {
+            public List<IMapsDirectlyToDatabaseTable> Objects { get; set; } = new List<IMapsDirectlyToDatabaseTable>();
+
+
+            public void Dispose()
+            {
+                Objects.Clear();
+                NewObjectPool.EndSession();
+            }
+        }
+    }
+}

--- a/Reusable/MapsDirectlyToDatabaseTable/TableRepository.cs
+++ b/Reusable/MapsDirectlyToDatabaseTable/TableRepository.cs
@@ -718,6 +718,7 @@ namespace MapsDirectlyToDatabaseTable
 
             toCreate.Repository = actual.Repository;
 
+            NewObjectPool.Add(toCreate);
         }
 
         private object ongoingConnectionsLock = new object();


### PR DESCRIPTION
\fixes #420

Support for scripts like:

```yaml
Commands:
  - NewObject Catalogue Hey
  - Set Catalogue:Hey Description "This is the first catalogue called this"
  - NewObject Catalogue Hey
# Automatically refers to the last one created
  - Set Catalogue:Hey Description "This is the second catalogue with the same name!"
# You can also just specify the object Type!
  - NewObject Catalogue Hey
  - Set Catalogue Description "This is the third catalogue with the same name!!!"
```

To run this script run:

```bash
./rdmp cmd -f Z:\Repos\RDMP\Tools\rdmp\bin\Debug\net5.0\testScript.yaml
```

Disable this behaviour by specifying `UseScope: false`

```yaml
UseScope: false
Commands:
  - NewObject Catalogue Hey
  - Set Catalogue:Hey Description "This is the first catalogue called this"
  - NewObject Catalogue Hey
# Script will crash here
  - Set Catalogue:Hey Description "This is the second catalogue with the same name!"
```