### PR TITLE
Metadata improvements

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- Added custom metadata report tokens:
+  - $Comma (for use with formats that require seperation e.g. JSON when using the `$foreach` operation)
+  - $TimeCoverage_ExtractionInformation (the column that provides the time element of a dataset to the DQE e.g. StudyDate)
+
 ## [6.0.2] - 2021-08-26
 
 ### Changed

--- a/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
+++ b/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
@@ -555,8 +555,6 @@ Server: myserver
 Description: A cool dataset with interesting stuff", resultText);
         }
 
-        #region Loop Catalogues tests
-
         [Test]
         public void TestCustomMetadataReport_LoopCataloguesPrefix()
         {
@@ -1132,8 +1130,162 @@ some more text
             Assert.AreEqual("Error, Unexpected '$foreach CatalogueItem' on line 3.  Current section is plain text, '$foreach CatalogueItem' can only appear within a '$foreach Catalogue' block (you cannot mix and match top level loop elements)", ex.Message);
             Assert.AreEqual(3, ex.LineNumber);
         }
+        [Test]
+        public void Test_CustomMetadataElementSeperator_ThrowsWhenNotInForEach()
+        {
+            var templateCode = @"
+$Name
+$Comma";
+            Setup2Catalogues(out Catalogue c1, out Catalogue c2);
 
-        #endregion
+            var template = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "template.md"));
+            var outDir = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "outDir"));
+
+            if (outDir.Exists)
+                outDir.Delete(true);
+
+            outDir.Create();
+
+            File.WriteAllText(template.FullName, templateCode);
+
+            var cmd = new ExecuteCommandExtractMetadata(new ThrowImmediatelyActivator(RepositoryLocator), new[] { c1, c2 }, outDir, template, "Datasets.md", true, null);
+            var ex = Assert.Throws<CustomMetadataReportException>(() => cmd.Execute());
+
+            Assert.AreEqual("Unexpected use of $Comma outside of an iteration ($foreach) block", ex.Message);
+        }
+
+        [Test]
+        public void Test_CustomMetadataElementSeperator_JsonExample()
+        {
+            var templateCode = @"[
+$foreach Catalogue
+  {
+    ""Name"": ""$Name"",
+    ""Columns"": [
+$foreach CatalogueItem
+      {
+                ""Name"": ""$Name""
+      }$Comma
+$end
+    ]
+  }$Comma
+$end
+]";
+
+            Setup2Catalogues(out Catalogue c1, out Catalogue c2);
+
+            var template = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "template.md"));
+            var outDir = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "outDir"));
+
+            if (outDir.Exists)
+                outDir.Delete(true);
+
+            outDir.Create();
+
+            File.WriteAllText(template.FullName, templateCode);
+
+            var cmd = new ExecuteCommandExtractMetadata(new ThrowImmediatelyActivator(RepositoryLocator), new[] { c1, c2 }, outDir, template, "Datasets.md", true, null);
+            cmd.Execute();
+
+            var outFile = Path.Combine(outDir.FullName, "Datasets.md");
+
+            FileAssert.Exists(outFile);
+            var resultText = File.ReadAllText(outFile);
+
+            StringAssert.AreEqualIgnoringCase(@"[
+  {
+    ""Name"": ""Demog"",
+    ""Columns"": [
+{
+                ""Name"": ""Name""
+      },
+{
+                ""Name"": ""Address""
+      },
+{
+                ""Name"": ""Postcode""
+      }
+    ]
+  },
+  {
+    ""Name"": ""ffff"",
+    ""Columns"": [
+{
+                ""Name"": ""Col1""
+      },
+{
+                ""Name"": ""Col2""
+      }
+    ]
+  }
+]", resultText.TrimEnd());
+        }
+
+        [Test]
+        public void Test_CustomMetadataElementSeperator_JsonExample_SemicolonSub()
+        {
+            var templateCode = @"[
+$foreach Catalogue
+  {
+    ""Name"": ""$Name"",
+    ""Columns"": [
+$foreach CatalogueItem
+      {
+                ""Name"": ""$Name""
+      }$Comma
+$end
+    ]
+  }$Comma
+$end
+]";
+
+            Setup2Catalogues(out Catalogue c1, out Catalogue c2);
+
+            var template = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "template.md"));
+            var outDir = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "outDir"));
+
+            if (outDir.Exists)
+                outDir.Delete(true);
+
+            outDir.Create();
+
+            File.WriteAllText(template.FullName, templateCode);
+
+            var cmd = new ExecuteCommandExtractMetadata(new ThrowImmediatelyActivator(RepositoryLocator), new[] { c1, c2 }, outDir, template, "Datasets.md", true, null,";");
+            cmd.Execute();
+
+            var outFile = Path.Combine(outDir.FullName, "Datasets.md");
+
+            FileAssert.Exists(outFile);
+            var resultText = File.ReadAllText(outFile);
+
+            StringAssert.AreEqualIgnoringCase(@"[
+  {
+    ""Name"": ""Demog"",
+    ""Columns"": [
+{
+                ""Name"": ""Name""
+      };
+{
+                ""Name"": ""Address""
+      };
+{
+                ""Name"": ""Postcode""
+      }
+    ]
+  };
+  {
+    ""Name"": ""ffff"",
+    ""Columns"": [
+{
+                ""Name"": ""Col1""
+      };
+{
+                ""Name"": ""Col2""
+      }
+    ]
+  }
+]", resultText.TrimEnd());
+        }
     }
-
 }

--- a/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
+++ b/Rdmp.Core.Tests/Reports/CustomMetadataReportTests.cs
@@ -132,6 +132,13 @@ namespace Rdmp.Core.Tests.Reports
             cata.Description = null;
             cata.SaveToDatabase();
 
+            var ei = WhenIHaveA<ExtractionInformation>();
+            ei.SelectSQL = "[blah]..[mydate]";
+            ei.SaveToDatabase();
+
+            cata.TimeCoverage_ExtractionInformation_ID = ei.ID;
+            cata.SaveToDatabase();
+
             var template = new FileInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "template.md"));
             var outDir = new DirectoryInfo(Path.Combine(TestContext.CurrentContext.WorkDirectory, "outDir"));
 
@@ -141,8 +148,8 @@ namespace Rdmp.Core.Tests.Reports
             outDir.Create();
 
             File.WriteAllText(template.FullName,
-                @"| Name | Desc| StartYear | EndYear | StartMonth | EndMonth | StartDay | EndDay | Range
-| $Name | $Description | $DQE_StartYear | $DQE_EndYear | $DQE_StartMonth | $DQE_EndMonth | $DQE_StartDay | $DQE_EndDay | $DQE_StartYear-$DQE_EndYear |");
+                @"| Name | Desc| StartYear | EndYear | StartMonth | EndMonth | StartDay | EndDay | Range | TimeField |
+| $Name | $Description | $DQE_StartYear | $DQE_EndYear | $DQE_StartMonth | $DQE_EndMonth | $DQE_StartDay | $DQE_EndDay | $DQE_StartYear-$DQE_EndYear | $TimeCoverage_ExtractionInformation |");
 
 
             var reporter = new CustomMetadataReport(RepositoryLocator)
@@ -165,8 +172,8 @@ namespace Rdmp.Core.Tests.Reports
             FileAssert.Exists(outFile);
             var resultText = File.ReadAllText(outFile);
 
-            StringAssert.AreEqualIgnoringCase(@"| Name | Desc| StartYear | EndYear | StartMonth | EndMonth | StartDay | EndDay | Range
-| ffff |  | 2001 | 2002 | 02 | 04 | 01 | 03 | 2001-2002 |", resultText.TrimEnd());
+            StringAssert.AreEqualIgnoringCase(@"| Name | Desc| StartYear | EndYear | StartMonth | EndMonth | StartDay | EndDay | Range | TimeField |
+| ffff |  | 2001 | 2002 | 02 | 04 | 01 | 03 | 2001-2002 | mydate |", resultText.TrimEnd());
         }
 
         [TestCase(true)]

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandExtractMetadata.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandExtractMetadata.cs
@@ -26,6 +26,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         private readonly string _fileNaming;
         private readonly bool _oneFile;
         private readonly string _newlineSub;
+        private readonly string _commaSub;
 
         public ExecuteCommandExtractMetadata(IBasicActivateItems basicActivator, 
             Catalogue[] catalogues, 
@@ -39,7 +40,9 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             [DemandsInitialization("True to append all ouputs into a single file.  False to output a new file for every Catalogue")]
             bool oneFile, 
             [DemandsInitialization("Optional, specify a replacement for newlines when found in fields e.g. <br/>.  Leave as null to leave newlines intact.")]
-            string newlineSub):base(basicActivator)
+            string newlineSub,
+            [DemandsInitialization("Optional, specify a replacement for the token $Comma (defaults to ',')",DefaultValue = ",")]
+            string commaSub = ","):base(basicActivator)
         {
             _catalogues = catalogues;
             _outputDirectory = outputDirectory;
@@ -47,6 +50,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             _fileNaming = fileNaming;
             _oneFile = oneFile;
             _newlineSub = newlineSub;
+            _commaSub = commaSub;
         }
 
         public override void Execute()
@@ -87,7 +91,8 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
             var reporter = new CustomMetadataReport(BasicActivator.RepositoryLocator)
             {
-                NewlineSubstitution = _newlineSub
+                NewlineSubstitution = _newlineSub,
+                CommaSubstitution = _commaSub
             };
             reporter.GenerateReport(catas.Cast<Catalogue>().OrderBy(c=>c.Name).ToArray(),outputDir,template, fileNaming, _oneFile);
         }

--- a/Rdmp.Core/Reports/CustomMetadataReport.cs
+++ b/Rdmp.Core/Reports/CustomMetadataReport.cs
@@ -527,6 +527,11 @@ namespace Rdmp.Core.Reports
         /// <returns></returns>
         private string ValueToString(object v)
         {
+            if(v is ExtractionInformation ei)
+            {
+                return ei.GetRuntimeName();
+            }
+
             return ReplaceNewlines(v?.ToString() ?? "");
         }
 


### PR DESCRIPTION
- Added custom metadata report tokens:
  - $Comma (for use with formats that require seperation e.g. JSON when using the `$foreach` operation)
  - $TimeCoverage_ExtractionInformation (the column that provides the time element of a dataset to the DQE e.g. StudyDate)


Closes #495 
Closes #489