### PR TITLE
Removed Activate (open) when importing a Catalogue level filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Removed
 
 - IPluginUserInterface can no longer add items to tab menu bars (only context menus)
+- Adding a Filter from Catalogue no longer opens it up in edit mode after adding
 
 ### Added
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFilterFromCatalogue.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFilterFromCatalogue.cs
@@ -70,7 +70,6 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 _container.AddChild(import);
                 Publish((DatabaseEntity)import);
                 Emphasise((DatabaseEntity)import);
-                Activate((DatabaseEntity)import);
             }
         }
     }


### PR DESCRIPTION
This PR just removes the behaviour of opening the filter in edit mode when it is imported from Catalogues only.

I don't think we should be 'prompting for parameter values with GetText' like the associated ticket.  Parameter text can be 'T' or 'TODO', how do we know if the parameter value at Catalogue level is already good and only exists for readability or to edit in future.  Better we handle parameter population on creation later on with a specific system.  Either way the user can just double click the new filter to edit it anyway.

Fixes #117 