### PR TITLE
DQE results behaviour when run on empty tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -41,7 +41,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed a bug where changing the server/database name could disable the Create button when selecting a database
 - Added the ability to drop onto the Core/Project folders in the 'execute extraction' window
 - Fixed a big where Yes/No close popup after running a pipeline in console gui could crash on 'No'
-
+- Fixed various issues when viewing the DQE results of a run on an empty table
 
 ## [6.0.2] - 2021-08-26
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -42,6 +42,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added the ability to drop onto the Core/Project folders in the 'execute extraction' window
 - Fixed a big where Yes/No close popup after running a pipeline in console gui could crash on 'No'
 - Fixed various issues when viewing the DQE results of a run on an empty table
+- DatasetRaceway in dashboards now shows 'Table(s) where empty for...' instead of `No DQE Evaluation for...` when the DQE was run but there was no result set
 
 ## [6.0.2] - 2021-08-26
 

--- a/Rdmp.Core.Tests/DataQualityEngine/PeriodicityStateTests.cs
+++ b/Rdmp.Core.Tests/DataQualityEngine/PeriodicityStateTests.cs
@@ -1,0 +1,49 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using NUnit.Framework;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataQualityEngine.Data;
+using Rdmp.Core.Repositories;
+using Tests.Common;
+
+namespace Rdmp.Core.Tests.DataQualityEngine
+{
+    class PeriodicityStateTests : DatabaseTests
+    {
+        [TestCase(true)]
+        [TestCase(false)]
+        public void TestGetPeriodicityForDataTableForEvaluation_EmptyEvaluation(bool pivot)
+        {
+            var cata = new Catalogue(CatalogueRepository, "MyCata");
+
+            var dqeRepo = new DQERepository(CatalogueRepository);
+
+            var eval = new Evaluation(dqeRepo, cata);
+
+            var dt = PeriodicityState.GetPeriodicityForDataTableForEvaluation(eval, "ALL", pivot);
+
+            Assert.IsNull(dt);
+        }
+
+        [Test]
+        public void GetPeriodicityCountsForEvaluation_EmptyEvaluation(bool pivot)
+        {
+            var cata = new Catalogue(CatalogueRepository, "MyCata");
+
+            var dqeRepo = new DQERepository(CatalogueRepository);
+
+            var eval = new Evaluation(dqeRepo, cata);
+
+            var dict = PeriodicityState.GetPeriodicityCountsForEvaluation(eval, true);
+
+            Assert.IsNotNull(dict);
+            Assert.IsEmpty(dict);
+
+        }
+
+    }
+}

--- a/Rdmp.Core.Tests/DataQualityEngine/PeriodicityStateTests.cs
+++ b/Rdmp.Core.Tests/DataQualityEngine/PeriodicityStateTests.cs
@@ -30,7 +30,7 @@ namespace Rdmp.Core.Tests.DataQualityEngine
         }
 
         [Test]
-        public void GetPeriodicityCountsForEvaluation_EmptyEvaluation(bool pivot)
+        public void GetPeriodicityCountsForEvaluation_EmptyEvaluation()
         {
             var cata = new Catalogue(CatalogueRepository, "MyCata");
 

--- a/Rdmp.Core/DataQualityEngine/Data/PeriodicityState.cs
+++ b/Rdmp.Core/DataQualityEngine/Data/PeriodicityState.cs
@@ -144,6 +144,12 @@ namespace Rdmp.Core.DataQualityEngine.Data
                         DataTable dt = new DataTable();
                         da.Fill(dt);
 
+                        // if there are no rows (table is empty) return null instead
+                        if(dt.Columns.Count == 0)
+                        {
+                            return null;
+                        }
+
                         if(pivot)
                         {
                             dt.Columns["Correct"].SetOrdinal(3);

--- a/Rdmp.Core/DataQualityEngine/Data/PeriodicityState.cs
+++ b/Rdmp.Core/DataQualityEngine/Data/PeriodicityState.cs
@@ -123,6 +123,15 @@ namespace Rdmp.Core.DataQualityEngine.Data
            return toReturn;
        }
        
+        /// <summary>
+        /// Returns a table describing the number of records over time optionally only those where the pivot column in the rows
+        /// had the value of <paramref name="pivotCategoryValue"/>.  Returns null if no rows were present in the table at the
+        /// time the <paramref name="evaluation"/> was run.
+        /// </summary>
+        /// <param name="evaluation"></param>
+        /// <param name="pivotCategoryValue"></param>
+        /// <param name="pivot"></param>
+        /// <returns></returns>
         public static DataTable GetPeriodicityForDataTableForEvaluation(Evaluation evaluation, string pivotCategoryValue, bool pivot)
         {
             using (var con = evaluation.DQERepository.GetConnection())
@@ -145,7 +154,7 @@ namespace Rdmp.Core.DataQualityEngine.Data
                         da.Fill(dt);
 
                         // if there are no rows (table is empty) return null instead
-                        if(dt.Columns.Count == 0)
+                        if(dt.Columns.Count == 0 || dt.Rows.Count == 0)
                         {
                             return null;
                         }

--- a/Rdmp.Core/Repositories/IDQERepository.cs
+++ b/Rdmp.Core/Repositories/IDQERepository.cs
@@ -1,0 +1,45 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataQualityEngine.Data;
+using System.Collections.Generic;
+
+namespace Rdmp.Core.Repositories
+{
+    /// <summary>
+    /// A place to store DQE results (typically a database).  See <see cref="DQERepository"/>
+    /// </summary>
+    public interface IDQERepository
+    {
+        /// <summary>
+        /// The Catalogue database to which the IDs in <see cref="Evaluation"/> refer to.  Each DQE repo can serve
+        /// only a single RDMP Catalogue database
+        /// </summary>
+        ICatalogueRepository CatalogueRepository { get; }
+
+        /// <summary>
+        /// Returns the most recently run DQE results for <paramref name="c"/> or null
+        /// </summary>
+        /// <param name="c"></param>
+        /// <returns></returns>
+        Evaluation GetMostRecentEvaluationFor(ICatalogue c);
+
+        /// <summary>
+        /// Returns all DQE results ever run on <paramref name="catalogue"/>
+        /// </summary>
+        /// <param name="catalogue"></param>
+        /// <returns></returns>
+        IEnumerable<Evaluation> GetAllEvaluationsFor(ICatalogue catalogue);
+
+        /// <summary>
+        /// Returns true if there are DQE results available for <paramref name="catalogue"/>
+        /// </summary>
+        /// <param name="catalogue"></param>
+        /// <returns></returns>
+        bool HasEvaluations(ICatalogue catalogue);
+    }
+}

--- a/Rdmp.UI/CatalogueSummary/DataQualityReporting/TimePeriodicityChart.cs
+++ b/Rdmp.UI/CatalogueSummary/DataQualityReporting/TimePeriodicityChart.cs
@@ -64,6 +64,14 @@ namespace Rdmp.UI.CatalogueSummary.DataQualityReporting
 
             chart1.Visible = false;
             var dt = PeriodicityState.GetPeriodicityForDataTableForEvaluation(evaluation, pivotCategoryValue, true);
+
+            if(dt == null)
+            {
+                ClearGraph();
+                chart1.Visible = true;
+                return;
+            }
+
             chart1.DataSource = dt;
             dataGridView1.DataSource = dt;
 
@@ -175,8 +183,13 @@ namespace Rdmp.UI.CatalogueSummary.DataQualityReporting
             var pointEndX = chart1.ChartAreas[0].AxisX.PixelPositionToValue(e.X);
             var pointEndY = chart1.ChartAreas[0].AxisY.PixelPositionToValue(e.Y);
 
-          
-            TypeTextOrCancelDialog inputBox = new TypeTextOrCancelDialog("Enter Annotation Text", "Type some annotation text (will be saved to the database for other data analysts to see)",500);
+            // don't let them annotate emptiness!
+            if(double.IsNaN(pointEndX) || double.IsNaN(pointEndY))
+            {
+                return;
+            }
+
+                TypeTextOrCancelDialog inputBox = new TypeTextOrCancelDialog("Enter Annotation Text", "Type some annotation text (will be saved to the database for other data analysts to see)",500);
             if (DialogResult.OK == inputBox.ShowDialog())
             {
                 //create new annotation in the database
@@ -222,7 +235,10 @@ namespace Rdmp.UI.CatalogueSummary.DataQualityReporting
 
         private void cbShowGaps_CheckedChanged(object sender, EventArgs e)
         {
-            ReGenerateAnnotations();
+            if(chart1.DataSource != null)
+            {
+                ReGenerateAnnotations();
+            }
         }
     }
 }

--- a/Rdmp.UI/Raceway/RacewayRenderAreaUI.cs
+++ b/Rdmp.UI/Raceway/RacewayRenderAreaUI.cs
@@ -318,10 +318,16 @@ namespace Rdmp.UI.Raceway
                         DrawErrorText("No DQE data exists for 'Show Period'",false, e, startDrawingLaneAtY, eachRaceLaneHasThisMuchYSpace, middleLineOfCatalogueLabelY);
                     }
                     else
-                        if (dictionary == null || !dictionary.Any())
+                        if (dictionary == null)
                     {
                         var textWidth = DrawErrorText("No DQE Evaluation for " + catalogue,true,e, startDrawingLaneAtY, eachRaceLaneHasThisMuchYSpace, middleLineOfCatalogueLabelY);
                         rectNoDQE.Add(new Rectangle(0, (int)startDrawingLaneAtY, (int)textWidth, (int)eachRaceLaneHasThisMuchYSpace),kvp.Key);
+                    }
+                    else
+                       if (!dictionary.Any())
+                    {
+                        var textWidth = DrawErrorText("Table(s) were empty for " + catalogue, true, e, startDrawingLaneAtY, eachRaceLaneHasThisMuchYSpace, middleLineOfCatalogueLabelY);
+                        rectNoDQE.Add(new Rectangle(0, (int)startDrawingLaneAtY, (int)textWidth, (int)eachRaceLaneHasThisMuchYSpace), kvp.Key);
                     }
                     else
                     {


### PR DESCRIPTION
Fixes #520 

This PR fixes some global errors appearing and general breakdown of the view results UI when the evaluation(s) are of tables that had no rows at the time the DQE was run.

![image](https://user-images.githubusercontent.com/31306100/134499753-e316abe0-9cd9-4803-b99b-d5aa4937e9f0.png)

Also included in this PR is the following hot new feature:

### Raceway custom message
Now the message 'Tables were empty' gets shown in the raceway instead of 'No DQE runs'

![image](https://user-images.githubusercontent.com/31306100/134499555-13d31252-b474-4ce6-a589-3e56e0f6ee0c.png)
