### PR TITLE
Added ExternalCohortDefinitionData.Orphan

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - IPluginUserInterface CustomActivate now takes IMapsDirectlyToDatabaseTable allowing custom plugin behaviour for activating any object
 - DatasetRaceway chart (depicts multiple datasets along a shared timeline) now ignores outlier values (months with count less than 1000th as many records as the average month)
 - Renamed `SelectIMapsDirectlyToDatabaseTableDialog` to `SelectDialog<T>` (now supports any object Type)
+- Changed how RDMP treats cohorts where the data has been deleted from the cohort table.  'Broken Cohort' renamed 'Orphan Cohort' and made more stable
 
 ### Removed
 

--- a/Rdmp.Core/DataExport/Data/ExternalCohortDefinitionData.cs
+++ b/Rdmp.Core/DataExport/Data/ExternalCohortDefinitionData.cs
@@ -26,6 +26,11 @@ namespace Rdmp.Core.DataExport.Data
             ExternalCohortCreationDate = ObjectToNullableDateTime(r["dtCreated"]);
         }
 
+        private ExternalCohortDefinitionData()
+        {
+
+        }
+
         /// <inheritdoc/>
         public int ExternalProjectNumber { get; set; }
 
@@ -53,5 +58,18 @@ namespace Rdmp.Core.DataExport.Data
 
             return (DateTime)o;
         }
+
+        /// <summary>
+        /// Describes the lack of available external data for an <see cref="ExtractableCohort"/> because the data has
+        /// been deleted from the cohort database
+        /// </summary>
+        public static IExternalCohortDefinitionData Orphan { get; } = new ExternalCohortDefinitionData()
+        {
+            ExternalProjectNumber = -1,
+            ExternalDescription = "Orphan Cohort",
+            ExternalVersion = -1,
+            ExternalCohortTableName = null,
+            ExternalCohortCreationDate = null,
+        };
     }
 }

--- a/Rdmp.Core/DataExport/Data/ExtractableCohort.cs
+++ b/Rdmp.Core/DataExport/Data/ExtractableCohort.cs
@@ -214,7 +214,7 @@ where
                     using (var r = getDescription.ExecuteReader())
                     {
                         if (!r.Read())
-                            throw new Exception("No records returned for Cohort OriginID " + OriginID);
+                            return ExternalCohortDefinitionData.Orphan;
 
                         return new ExternalCohortDefinitionData(r, ExternalCohortTable.Name);
                     }


### PR DESCRIPTION
This static member represents when we cannot get a ExternalCohortDefinitionData from the cohort database for a given OriginID because it was deleted

Fixes #447

![image](https://user-images.githubusercontent.com/31306100/134518535-c461b0c2-4b5c-4cd2-817a-47a1f7f27c58.png)
_After truncating the CohortDefinition table in the Cohort database_