### PR TITLE
Added support for identifying items by properties on CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added new command 'AddPipelineComponent' for use with RDMP command line
 - Added ability to filter datasets and selected datasets by Catalogue criteria (e.g. Deprecated, Internal)
 - Added Clone, Freeze, Unfreeze and add dataset(s) ExtractionConfiguration commands to command line
+- Added support for identifying items by properties on CLI (e.g. list all Catalogues with Folder name containing 'edris')
 
 ### Fixed
 - Fixed deleting a parameter value set failing due to a database constraint

--- a/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
@@ -246,5 +246,58 @@ namespace Rdmp.Core.Tests.CommandLine
             Assert.Contains(cata1, picker[0].DatabaseEntities);
             Assert.Contains(cata2, picker[0].DatabaseEntities);
         }
+
+        [Test]
+        public void Test_PickWithPropertyQuery_CatalogueItemsByCatalogue()
+        {
+            // these two belong to the same catalogue
+            var ci = WhenIHaveA<CatalogueItem>();
+            var ci2 = new CatalogueItem(ci.CatalogueRepository, ci.Catalogue, "My item 2");
+            
+            // this one belongs to a different catalogue
+            var ci3 = WhenIHaveA<CatalogueItem>();
+
+            var cataId = ci.Catalogue.ID;
+            var picker = new CommandLineObjectPicker(new[] { $"CatalogueItem?Catalogue_ID:{cataId}" }, RepositoryLocator);
+
+            Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
+            Assert.Contains(ci, picker[0].DatabaseEntities);
+            Assert.Contains(ci2, picker[0].DatabaseEntities);
+            Assert.IsFalse(picker[0].DatabaseEntities.Contains(ci3));
+        }
+        [Test]
+        public void Test_PickWithPropertyQuery_CatalogueByFolder()
+        {
+            // Catalogues
+            var c1 = WhenIHaveA<Catalogue>();
+            var c2 = WhenIHaveA<Catalogue>();
+            var c3 = WhenIHaveA<Catalogue>();
+
+            c1.Folder = new CatalogueFolder("\\datasets\\hi\\");
+            c2.Folder = new CatalogueFolder("\\datasets\\no\\");
+            c3.Folder = new CatalogueFolder("\\datasets\\hi\\");
+
+            var picker = new CommandLineObjectPicker(new[] { $"Catalogue?Folder:*hi*" }, RepositoryLocator);
+
+            Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
+            Assert.Contains(c1, picker[0].DatabaseEntities);
+            Assert.Contains(c3, picker[0].DatabaseEntities);
+            Assert.IsFalse(picker[0].DatabaseEntities.Contains(c2));
+        }
+        [Test]
+        public void Test_PickWithPropertyQuery_PeriodicityNull()
+        {
+            // Catalogues
+            var c1 = WhenIHaveA<Catalogue>();
+            var c2 = WhenIHaveA<Catalogue>();
+
+            c1.PivotCategory_ExtractionInformation_ID = 10;
+            c2.PivotCategory_ExtractionInformation_ID = null;
+
+            var picker = new CommandLineObjectPicker(new[] { $"Catalogue?PivotCategory_ExtractionInformation_ID:null" }, RepositoryLocator);
+
+            Assert.AreEqual(1, picker[0].DatabaseEntities.Count);
+            Assert.Contains(c2, picker[0].DatabaseEntities);
+        }
     }
 }

--- a/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
@@ -299,5 +299,11 @@ namespace Rdmp.Core.Tests.CommandLine
             Assert.AreEqual(1, picker[0].DatabaseEntities.Count);
             Assert.Contains(c2, picker[0].DatabaseEntities);
         }
+        [Test]
+        public void Test_PickWithPropertyQuery_UnknownProperty()
+        {
+            var ex = Assert.Throws<Exception>(()=>new CommandLineObjectPicker(new[] { $"Catalogue?Blarg:null" }, RepositoryLocator));
+            Assert.AreEqual("Unknown property 'Blarg'.  Did not exist on Type 'Catalogue'", ex.Message);
+        }
     }
 }

--- a/Rdmp.Core/CommandLine/Interactive/Picking/CommandLineObjectPicker.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/CommandLineObjectPicker.cs
@@ -36,6 +36,7 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
         {
             _pickers.Add(new PickObjectByID(repositoryLocator));
             _pickers.Add(new PickObjectByName(repositoryLocator));
+            _pickers.Add(new PickObjectByQuery(repositoryLocator));
             _pickers.Add(new PickDatabase());
             _pickers.Add(new PickTable());
             _pickers.Add(new PickType(repositoryLocator));

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
@@ -24,7 +24,7 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
         public override string Format => "{Type}?{Property}:{PropertyValue}";
         public override string Help =>
             @"Type: must be an RDMP object type e.g. Catalogue, Project etc.
-Propety: must be a property of the Type class.
+Property: must be a property of the Type class.
 NamePattern: must be a value that could appear for the given Property.  Comparison will be via ToString on property value.";
         
         public override IEnumerable<string> Examples => new []

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
@@ -1,0 +1,84 @@
+// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Reflection;
+using System.Text.RegularExpressions;
+using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Providers;
+using Rdmp.Core.Repositories;
+
+namespace Rdmp.Core.CommandLine.Interactive.Picking
+{
+    /// <summary>
+    /// Determines if a command line argument provided was a reference to one or more <see cref="DatabaseEntity"/> matching based on property (e.g. "Catalogue?CatalogueFolder:*edris*")
+    /// </summary>
+    public class PickObjectByQuery: PickObjectBase
+    {
+        public override string Format => "{Type}?{Property}:{PropertyValue}";
+        public override string Help =>
+            @"Type: must be an RDMP object type e.g. Catalogue, Project etc.
+Propety: must be a property of the Type class.
+NamePattern: must be a value that could appear for the given Property.  Comparison will be via ToString on property value.";
+        
+        public override IEnumerable<string> Examples => new []
+        {
+            "CatalogueItem?Catalogue_ID:55", 
+            "Catalogue?Folder:*edris*"
+        };
+
+        public PickObjectByQuery(IRDMPPlatformRepositoryServiceLocator repositoryLocator) :
+            base(repositoryLocator,
+            new Regex(@"^(\w+)\?(\w+):([^:]+)$", RegexOptions.IgnoreCase))
+        {
+        }
+        public override bool IsMatch(string arg, int idx)
+        {
+            var baseMatch = base.IsMatch(arg, idx);
+
+            //only considered  match if the first letter is an Rdmp Type e.g. "Catalogue:fish" but not "C:\fish"
+            return baseMatch && IsDatabaseObjectType(Regex.Match(arg).Groups[1].Value,out _);        
+        }
+
+        public override CommandLineObjectPickerArgumentValue Parse(string arg, int idx)
+        {
+            if (IsDatabaseObjectType(arg, out Type t))
+            {
+                return new CommandLineObjectPickerArgumentValue(arg,idx,GetAllObjects(t).ToArray());
+            }
+
+            var objByToString = MatchOrThrow(arg, idx);
+            
+            string objectType = objByToString.Groups[1].Value;
+            string propertyName = objByToString.Groups[2].Value;
+            string objectToString = objByToString.Groups[3].Value;
+
+            Type dbObjectType = ParseDatabaseEntityType(objectType, arg, idx);
+
+            var property = dbObjectType.GetProperty(propertyName);
+
+            if(property == null)
+            {
+                throw new Exception($"Unknown property '{propertyName}'.  Did not exist on Type '{dbObjectType}'");
+            }
+
+            var objs = GetObjectByToString(dbObjectType,property,objectToString);
+            return new CommandLineObjectPickerArgumentValue(arg,idx,objs.Cast<IMapsDirectlyToDatabaseTable>().ToArray());
+        }
+
+        private IEnumerable<object> GetObjectByToString(Type dbObjectType, PropertyInfo property, string str)
+        {
+            return GetAllObjects(dbObjectType).Where(o =>
+            {
+                    var value = property.GetValue(o)?.ToString() ?? "Null";
+                    return FilterByPattern(value, str);
+            });
+        }
+    }
+}

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
@@ -17,7 +17,7 @@ using Rdmp.Core.Repositories;
 namespace Rdmp.Core.CommandLine.Interactive.Picking
 {
     /// <summary>
-    /// Determines if a command line argument provided was a reference to one or more <see cref="DatabaseEntity"/> matching based on property (e.g. "Catalogue?CatalogueFolder:*edris*")
+    /// Determines if a command line argument provided was a reference to one or more <see cref="DatabaseEntity"/> matching based on property (e.g. "Catalogue?Folder:*edris*")
     /// </summary>
     public class PickObjectByQuery: PickObjectBase
     {
@@ -65,7 +65,7 @@ NamePattern: must be a value that could appear for the given Property.  Comparis
 
             if(property == null)
             {
-                throw new Exception($"Unknown property '{propertyName}'.  Did not exist on Type '{dbObjectType}'");
+                throw new Exception($"Unknown property '{propertyName}'.  Did not exist on Type '{dbObjectType.Name}'");
             }
 
             var objs = GetObjectByToString(dbObjectType,property,objectToString);


### PR DESCRIPTION
Fixes #521

```
PS Z:\Repos\RDMP\Tools\rdmp\bin\Debug\net5.0> ./rdmp cmd list Catalogue?Folder:*admissions*
2021-09-28 09:17:14.3378 INFO Dotnet Version:5.0.3 .
2021-09-28 09:17:14.3587 INFO RDMP Version:6.0.2.0 .
2021-09-28 09:17:14.5030 INFO Setting yaml config value for CatalogueConnectionString .
2021-09-28 09:17:14.5030 INFO Setting yaml config value for DataExportConnectionString .
4:HospitalAdmissions
5:vConditions
6:vOperations
```