### PR TITLE
Removed RAG smiley from ServerDatabaseTableSelector

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -26,6 +26,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Adding a Filter from Catalogue no longer opens it up in edit mode after adding
 - Command line execution (e.g. `rdmp cmd ...`) no longer supports user interactive calls (e.g. YesNo questions)
 - Removed PickOneOrCancelDialog
+- Removed RAG smiley from server connection UI.  Now errors are reported 'Connection Failed' text label
 
 ### Added
 - Added CatalogueFolder column to Select Catalogue dialog

--- a/Rdmp.UI/LocationsMenu/ChoosePlatformDatabasesUI.cs
+++ b/Rdmp.UI/LocationsMenu/ChoosePlatformDatabasesUI.cs
@@ -372,8 +372,10 @@ namespace Rdmp.UI.LocationsMenu
         {
             var dialog = new ServerDatabaseTableSelectorDialog("Catalogue Database",false,false,null);
             dialog.LockDatabaseType(DatabaseType.MicrosoftSQLServer);
-            if (dialog.ShowDialog() == DialogResult.OK)
+            if (dialog.ShowDialog() == DialogResult.OK && dialog.SelectedDatabase != null)
+            {
                 tbCatalogueConnectionString.Text = dialog.SelectedDatabase.Server.Builder.ConnectionString;
+            }
         }
 
         private void btnBrowseForDataExport_Click(object sender, EventArgs e)

--- a/Rdmp.UI/SimpleControls/ServerDatabaseTableSelector.Designer.cs
+++ b/Rdmp.UI/SimpleControls/ServerDatabaseTableSelector.Designer.cs
@@ -50,7 +50,6 @@ namespace Rdmp.UI.SimpleControls
             this.btnRefreshDatabases = new System.Windows.Forms.Button();
             this.btnRefreshTables = new System.Windows.Forms.Button();
             this.databaseTypeUI1 = new Rdmp.UI.SimpleControls.DatabaseTypeUI();
-            this.ragSmiley1 = new Rdmp.UI.ChecksUI.RAGSmiley();
             this.btnPickCredentials = new System.Windows.Forms.Button();
             ((System.ComponentModel.ISupportInitialize)(this.pbLoading)).BeginInit();
             this.SuspendLayout();
@@ -255,17 +254,6 @@ namespace Rdmp.UI.SimpleControls
             this.databaseTypeUI1.TabIndex = 168;
             this.databaseTypeUI1.DatabaseTypeChanged += new System.EventHandler(this.databaseTypeUI1_DatabaseTypeChanged);
             // 
-            // ragSmiley1
-            // 
-            this.ragSmiley1.AlwaysShowHandCursor = false;
-            this.ragSmiley1.BackColor = System.Drawing.Color.Transparent;
-            this.ragSmiley1.Cursor = System.Windows.Forms.Cursors.Arrow;
-            this.ragSmiley1.Location = new System.Drawing.Point(3, 97);
-            this.ragSmiley1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
-            this.ragSmiley1.Name = "ragSmiley1";
-            this.ragSmiley1.Size = new System.Drawing.Size(25, 25);
-            this.ragSmiley1.TabIndex = 5;
-            // 
             // btnPickCredentials
             // 
             this.btnPickCredentials.Location = new System.Drawing.Point(460, 27);
@@ -281,7 +269,6 @@ namespace Rdmp.UI.SimpleControls
             this.AutoSize = true;
             this.Controls.Add(this.btnPickCredentials);
             this.Controls.Add(this.databaseTypeUI1);
-            this.Controls.Add(this.ragSmiley1);
             this.Controls.Add(this.btnRefreshTables);
             this.Controls.Add(this.btnRefreshDatabases);
             this.Controls.Add(this.pbLoading);
@@ -326,7 +313,6 @@ namespace Rdmp.UI.SimpleControls
         private System.Windows.Forms.PictureBox pbLoading;
         private System.Windows.Forms.Button btnRefreshDatabases;
         private System.Windows.Forms.Button btnRefreshTables;
-        private RAGSmiley ragSmiley1;
         private DatabaseTypeUI databaseTypeUI1;
         private System.Windows.Forms.Button btnPickCredentials;
     }


### PR DESCRIPTION
Fixes #553 

![image](https://user-images.githubusercontent.com/31306100/135407471-2c24ac8f-3ff2-4fc2-a1b8-cbd7a4a5c325.png)
_New user interface design for failure state.  The cancellation link label is simply reused with its text changed_
