### PR TITLE
Fixed delete many projects/packages at once in DataExportCollectionUI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -59,6 +59,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed [CohortAggregateContainer] and filter containers not showing up in Find when explicitly requested
 - Fixed deleting an [ExtractionFilter] with many parameter values configured.  Now confirmation message is shown and all objects are deleted together
 - Fixed bug saving an [ExtractionInformation] when it is an extraction transform without an alias
+- Fixed bug refreshing Data Export tree collection when deleting multiple Projects/Packages at once (deleted objects were still shown)
 
 ## [6.0.2] - 2021-08-26
 

--- a/Rdmp.UI/Collections/DataExportCollectionUI.cs
+++ b/Rdmp.UI/Collections/DataExportCollectionUI.cs
@@ -139,10 +139,7 @@ namespace Rdmp.UI.Collections
 
         public void RefreshBus_RefreshObject(object sender, RefreshObjectEventArgs e)
         {
-
-            var dataExportChildProvider = Activator.CoreChildProvider as DataExportChildProvider;
-
-            if (dataExportChildProvider != null)
+            if (Activator.CoreChildProvider is DataExportChildProvider dataExportChildProvider)
             {
                 // remove packages and projects which don't exist any more according to child provider
                 tlvDataExport.RemoveObjects(tlvDataExport.Objects.OfType<ExtractableDataSetPackage>().Except(dataExportChildProvider.AllPackages).ToArray());

--- a/Rdmp.UI/Collections/DataExportCollectionUI.cs
+++ b/Rdmp.UI/Collections/DataExportCollectionUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Linq;
 using System.Windows.Forms;
 using BrightIdeasSoftware;
 using Rdmp.Core;
@@ -138,6 +139,16 @@ namespace Rdmp.UI.Collections
 
         public void RefreshBus_RefreshObject(object sender, RefreshObjectEventArgs e)
         {
+
+            var dataExportChildProvider = Activator.CoreChildProvider as DataExportChildProvider;
+
+            if (dataExportChildProvider != null)
+            {
+                // remove packages and projects which don't exist any more according to child provider
+                tlvDataExport.RemoveObjects(tlvDataExport.Objects.OfType<ExtractableDataSetPackage>().Except(dataExportChildProvider.AllPackages).ToArray());
+                tlvDataExport.RemoveObjects(tlvDataExport.Objects.OfType<Project>().Except(dataExportChildProvider.Projects).ToArray());
+            }
+
             SetupToolStrip();
         }
 


### PR DESCRIPTION
Fixes #547

![image](https://user-images.githubusercontent.com/31306100/135817582-4a77b91a-2129-42e5-b227-31b7c1c8d4d4.png)
