### PR TITLE
Fixed ExtractionSubdirectoryPattern 

### DIFF
--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExecuteDatasetExtractionFlatFileDestination.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExecuteDatasetExtractionFlatFileDestination.cs
@@ -57,7 +57,7 @@ namespace Rdmp.Core.DataExport.DataExtraction.Pipeline.Destinations
             switch (FlatFileType)
             {
                 case ExecuteExtractionToFlatFileType.CSV:
-                    OutputFile = Path.Combine(DirectoryPopulated.FullName, GetFilename() + ".csv");
+                    OutputFile = Path.Combine(GetDirectoryFor(_request).FullName, GetFilename() + ".csv");
                     if (request.Configuration != null)
                         _output = new CSVOutputFormat(OutputFile, request.Configuration.Separator, DateFormat);
                     else

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/IExecuteDatasetExtractionDestination.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/IExecuteDatasetExtractionDestination.cs
@@ -72,5 +72,13 @@ namespace Rdmp.Core.DataExport.DataExtraction.Pipeline.Destinations
         /// <param name="globalToCheck"></param>
         /// <returns></returns>
         GlobalReleasePotential GetGlobalReleasabilityEvaluator(IRDMPPlatformRepositoryServiceLocator repositoryLocator, ISupplementalExtractionResults globalResult, IMapsDirectlyToDatabaseTable globalToCheck);
+
+
+        /// <summary>
+        /// Returns where the output files will be generated including any pipeline level changes (i.e. overrides).
+        /// </summary>
+        /// <param name="request"></param>
+        /// <returns></returns>
+        DirectoryInfo GetDirectoryFor(IExtractCommand request);
     }
 }

--- a/Rdmp.Core/Reports/ExtractionTime/WordDataWriter.cs
+++ b/Rdmp.Core/Reports/ExtractionTime/WordDataWriter.cs
@@ -43,9 +43,6 @@ namespace Rdmp.Core.Reports.ExtractionTime
             Executer = executer;
 
             _destination = Executer.Destination;
-
-            if(_destination == null)
-                throw new NotSupportedException(GetType().FullName + " only supports destinations which are " + typeof(ExecuteDatasetExtractionFlatFileDestination).FullName);
         }
         
         private static object oLockOnWordUsage = new object();
@@ -60,7 +57,9 @@ namespace Rdmp.Core.Reports.ExtractionTime
         {
             lock (oLockOnWordUsage)
             {
-                using (var document = GetNewDocFile(new FileInfo(Path.Combine(_destination.DirectoryPopulated.FullName, _destination.GetFilename() + ".docx"))))
+                var destDir = _destination.GetDirectoryFor(Executer.ExtractCommand);
+
+                using (var document = GetNewDocFile(new FileInfo(Path.Combine(destDir.FullName, _destination.GetFilename() + ".docx"))))
                 {
                     InsertHeader(document,Executer.Source.Request.DatasetBundle.DataSet + " Meta Data");
 


### PR DESCRIPTION
Fixes #586

Lots more refactoring is needed but this is the start.  Basic problem is that `IExtractionDirectory` is just a default (recommended) output dir.  It is set and relied on across RDMP for checking and release BUT it doesn't require a Pipeline to use.

That means that the pipeline 'override' `ExtractionSubdirectoryPattern`  will be difficult to implement/fix elegantly 