### PR TITLE
Fixed Runner execution Process output only refreshing on keystrokes

### DIFF
--- a/Tools/rdmp/CommandLine/Gui/Windows/RunnerWindows/RunEngineWindow.cs
+++ b/Tools/rdmp/CommandLine/Gui/Windows/RunnerWindows/RunEngineWindow.cs
@@ -196,7 +196,7 @@ namespace Rdmp.Core.CommandLine.Gui.Windows.RunnerWindows
                     lock(lockList)
                     {
                         consoleOutput.Insert(0,line);
-                        _results.SetNeedsDisplay();
+                        Application.MainLoop.Invoke(()=>_results.SetNeedsDisplay());   
                     }
                     
                 }


### PR DESCRIPTION
This fixes an issue where Check/Execute results were not updating in real-time (only when user hit an arrow key etc).

There is still an issue on Linux where arrow keys etc do not update the UI and instead show a console character (see the grey keystrokes in screenshot below) but I think this will be fixed by https://github.com/migueldeicaza/gui.cs/issues/1501 when it goes live.

![arrow-key-corruption](https://user-images.githubusercontent.com/31306100/141975951-8deb6512-7f33-465c-9086-2804fff5b5df.jpg)

