### PR TITLE
Fixed interfaces and abstract classes being listed by UI layer method GetType

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -18,6 +18,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed the 'filters' count column in [Catalogue] tree collection showing edit control when clicked
 - Fixed Find not working when searching by ID for [Pipeline] objects
 - Prevented showing out dated cohorts when changing Project half way through defining a cohort
+- Fixed Command Line UI showing abstract and interfaces when prompting user to pick a Type
 
 ### Changed
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewClassBasedProcessTask.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewClassBasedProcessTask.cs
@@ -55,9 +55,14 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         {
             return BasicActivator.RepositoryLocator.CatalogueRepository.MEF.GetAllTypes().
                 Where(t=>
-                typeof(IAttacher).IsAssignableFrom(t) ||
-                typeof(IDataProvider).IsAssignableFrom(t) ||
-                typeof(IMutilateDataTables).IsAssignableFrom(t)).ToArray();
+                // must not be interface or abstract
+                (!(t.IsInterface || t.IsAbstract)) &&
+                (
+                    // must implement one of these interfaces
+                    typeof(IAttacher).IsAssignableFrom(t) ||
+                    typeof(IDataProvider).IsAssignableFrom(t) ||
+                    typeof(IMutilateDataTables).IsAssignableFrom(t)
+                )).ToArray();
         }
 
         public override void Execute()

--- a/Rdmp.Core/CommandExecution/BasicActivateItems.cs
+++ b/Rdmp.Core/CommandExecution/BasicActivateItems.cs
@@ -184,11 +184,21 @@ namespace Rdmp.Core.CommandExecution
         }
 
         public abstract bool SelectEnum(string prompt, Type enumType, out Enum chosen);
-        public virtual bool SelectType(string prompt, Type baseTypeIfAny, out Type chosen)
+
+
+        public bool SelectType(string prompt, Type baseTypeIfAny, out Type chosen)
+        {
+            return SelectType(prompt, baseTypeIfAny, false, false, out chosen);
+        }
+
+        public bool SelectType(string prompt, Type baseTypeIfAny,bool allowAbstract,bool allowInterfaces, out Type chosen)
         {
             Type[] available =
             RepositoryLocator.CatalogueRepository.MEF.GetAllTypes()
-                .Where(t => baseTypeIfAny == null || baseTypeIfAny.IsAssignableFrom(t))
+                .Where(t => 
+                (baseTypeIfAny == null || baseTypeIfAny.IsAssignableFrom(t)) &&
+                (allowAbstract || !t.IsAbstract) &&
+                (allowInterfaces || !t.IsInterface))
                 .ToArray();
 
             return SelectType(prompt, available, out chosen);

--- a/Rdmp.Core/CommandExecution/IBasicActivateItems.cs
+++ b/Rdmp.Core/CommandExecution/IBasicActivateItems.cs
@@ -383,13 +383,26 @@ namespace Rdmp.Core.CommandExecution
         bool SelectEnum(string prompt, Type enumType, out Enum chosen);
 
         /// <summary>
-        /// Requests user select a <see cref="Type"/>
+        /// Requests user select a <see cref="Type"/> (optional one that is assignable to <paramref name="baseTypeIfAny"/>).
+        /// This will only offer concrete classes and not abstract classes or interfaces.  To allow picking those use the overload.
         /// </summary>
         /// <param name="prompt"></param>
         /// <param name="baseTypeIfAny">Pass a base class or interface if the Type must be an inheritor / assignable to a specific Type otherwise pass null</param>
         /// <param name="chosen"></param>
         /// <returns></returns>
         bool SelectType(string prompt, Type baseTypeIfAny, out Type chosen);
+
+
+        /// <summary>
+        /// Requests user select a <see cref="Type"/> (optional one that is assignable to <paramref name="baseTypeIfAny"/>).
+        /// </summary>
+        /// <param name="prompt"></param>
+        /// <param name="baseTypeIfAny">Pass a base class or interface if the Type must be an inheritor / assignable to a specific Type otherwise pass null</param>
+        /// <param name="allowAbstract">True to offer abstract class Types as well</param>
+        /// <param name="allowInterfaces">True to offer interface Types as well</param>
+        /// <param name="chosen"></param>
+        /// <returns></returns>
+        bool SelectType(string prompt, Type baseTypeIfAny, bool allowAbstract, bool allowInterfaces, out Type chosen);
 
         /// <summary>
         /// Requests user select one of the <paramref name="available"/> <see cref="Type"/>


### PR DESCRIPTION
API user can still call the overload if they want those to be viable options.
Fixes #659