### PR TITLE
Fixed stale help when selecting a `PipelineComponent` with no help

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -25,6 +25,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug in Console Gui where edit window showed value set directly instead of passing through Property Setters
 - Fixed bug in Console Gui where password properties showed (encrypted) HEX binary value instead of ****
 - Fixed Command Line UI showing abstract and interfaces when prompting user to pick a Type
+- Fixed bug where selecting a [PipelineComponent] for which help is unavailable would leave the previously selected component's help visible
 
 ### Changed
 

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentCollectionUI.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentCollectionUI.cs
@@ -74,9 +74,11 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs
                 btnViewSourceCode.Left = helpIcon1.Right;
 
                 var summary = catalogueRepository.CommentStore.GetTypeDocumentationIfExists(argumentsAreForUnderlyingType);
-                
-                if(summary != null)
+
+                if (summary != null)
                     helpIcon1.SetHelpText(_argumentsAreFor.Name, summary);
+                else
+                    helpIcon1.ClearHelpText();
 
                 RefreshArgumentList();
             }

--- a/Rdmp.UI/SimpleControls/HelpIcon.cs
+++ b/Rdmp.UI/SimpleControls/HelpIcon.cs
@@ -57,6 +57,10 @@ namespace Rdmp.UI.SimpleControls
             tt.SetToolTip(this, _hoverText);
             Cursor = Cursors.Hand;
         }
+        public void ClearHelpText()
+        {
+            SetHelpText(null, null);
+        }
 
         private string GetShortText(string hoverText)
         {


### PR DESCRIPTION
Fixes #708