### PR TITLE
Changed back tab title so project number is at the start

### DIFF
--- a/Rdmp.Core/DataExport/Data/ExtractionConfiguration.cs
+++ b/Rdmp.Core/DataExport/Data/ExtractionConfiguration.cs
@@ -328,8 +328,8 @@ namespace Rdmp.Core.DataExport.Data
         public string GetProjectHint(bool shortString)
         {
             return 
-                shortString ? $"(P { Project.ProjectNumber})" :
-                $"'{Project.Name}'(P { Project.ProjectNumber})";
+                shortString ? $"({ Project.ProjectNumber})" :
+                $"'{Project.Name}' (PNo. { Project.ProjectNumber})";
         }
 
         /// <summary>

--- a/Rdmp.UI/ProjectUI/ExecuteExtractionUI.cs
+++ b/Rdmp.UI/ProjectUI/ExecuteExtractionUI.cs
@@ -394,7 +394,7 @@ namespace Rdmp.UI.ProjectUI
 
         public override string GetTabName()
         {
-            return $"{base.GetTabName()} {_extractionConfiguration.GetProjectHint(true)}";
+            return $"{_extractionConfiguration.GetProjectHint(true)} {base.GetTabName()}";
         }
         public override string GetTabToolTip()
         {

--- a/Rdmp.UI/ProjectUI/ExtractionConfigurationUI.cs
+++ b/Rdmp.UI/ProjectUI/ExtractionConfigurationUI.cs
@@ -212,7 +212,7 @@ namespace Rdmp.UI.ProjectUI
 
         public override string GetTabName()
         {
-            return $"{base.GetTabName()} {_extractionConfiguration.GetProjectHint(true)}";
+            return $"{_extractionConfiguration.GetProjectHint(true)} {base.GetTabName()}";
         }
         public override string GetTabToolTip()
         {


### PR DESCRIPTION
Fixes regression in tab titles for extraction projects so that the number is at the start (per user requirements)

![image](https://user-images.githubusercontent.com/5470814/143589107-81aea2e7-02ee-4961-9487-b53785bcc316.png)

closes #621