### PR TITLE
Databasesyaml

### DIFF
--- a/Application/ResearchDataManagementPlatform/Program.cs
+++ b/Application/ResearchDataManagementPlatform/Program.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.IO;
 using System.Linq;
 using System.Runtime.InteropServices;
 using CommandLine;
@@ -26,9 +27,6 @@ namespace ResearchDataManagementPlatform
         [STAThread]
         static void Main(string[] args)
         {
-            if (args.Any(a => a.Equals("--squirrel-install", StringComparison.InvariantCultureIgnoreCase)))
-                return;
-
             try
             {
                 AttachConsole(-1);
@@ -45,11 +43,14 @@ namespace ResearchDataManagementPlatform
 
         private static object RunApp(ResearchDataManagementPlatformOptions arg)
         {
+            arg.PopulateConnectionStringsFromYamlIfMissing();
+            arg.GetConnectionStrings(out var c, out var d);
+
             RDMPBootStrapper<RDMPMainForm> bootStrapper =
                 new RDMPBootStrapper<RDMPMainForm>(
                     new EnvironmentInfo(PluginFolders.Main | PluginFolders.Windows),
-                    arg.CatalogueConnectionString,
-                    arg.DataExportConnectionString);
+                    c?.ConnectionString,
+                    d?.ConnectionString);
 
             bootStrapper.Show(false);
             return 0;

--- a/Application/ResearchDataManagementPlatform/ResearchDataManagementPlatformOptions.cs
+++ b/Application/ResearchDataManagementPlatform/ResearchDataManagementPlatformOptions.cs
@@ -4,32 +4,18 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
-using System.Collections.Generic;
-using CommandLine;
-using CommandLine.Text;
+using Rdmp.Core.CommandLine.Options;
 
 namespace ResearchDataManagementPlatform
 {
     /// <summary>
     /// Defines the command line arguments of ResearchDataManagementPlatform.exe when run from the command line / shortcut
     /// </summary>
-    public class ResearchDataManagementPlatformOptions
+    public class ResearchDataManagementPlatformOptions : RDMPCommandLineOptions
     {
-        [Option('c', Required = false, HelpText = @"Connection string to the main Catalogue RDMP database")]
-        public string CatalogueConnectionString { get; set; }
-
-        [Option('d', Required = false, HelpText = @"Connection string to the main DataExport RDMP database")]
-        public string DataExportConnectionString { get; set; }
-
-
-        [Usage]
-        public static IEnumerable<Example> Examples
+        protected override bool ShouldLoadHelp()
         {
-            get
-            {
-                yield return new Example("Load Default User Connection String Settings", new ResearchDataManagementPlatformOptions());
-                yield return new Example("Use These Connection Strings", new ResearchDataManagementPlatformOptions { CatalogueConnectionString = @"Data Source=localhost\sqlexpress;Initial Catalog=RDMP_Catalogue;Integrated Security=True", DataExportConnectionString = @"Data Source=localhost\sqlexpress;Initial Catalog=RDMP_DataExport;Integrated Security=True" });
-            }
+            return true;
         }
     }
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,6 +21,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Enabled Expand/Collapse all when right clicking whitespace in a tree collection
 - Added title to graph charts
 - Added a user setting for hiding Series in which all cells are 0/null
+- Support for specifying `--ConnectionStringsFile somefile.yaml` when starting RDMP (gui client or CLI)
 
 ### Fixed
 

--- a/Plugins/Plugin.UI/Plugin.UI.nuspec
+++ b/Plugins/Plugin.UI/Plugin.UI.nuspec
@@ -41,6 +41,7 @@
             <dependency id="System.Resources.Extensions" version="4.6.0" />
             <dependency id="HIC.System.Windows.Forms.DataVisualization" version="1.0.1" />
             <dependency id="ReadLine" version="2.0.1" />
+            <dependency id="YamlDotNet" version="11.2.1" />
         </dependencies>
     </metadata>
   <files>

--- a/Plugins/Plugin/Plugin.nuspec
+++ b/Plugins/Plugin/Plugin.nuspec
@@ -35,6 +35,7 @@
             <dependency id="System.Net.Primitives" version="4.3.1" /> 
             <dependency id="System.Resources.Extensions" version="4.6.0" />
             <dependency id="ReadLine" version="2.0.1" />
+            <dependency id="YamlDotNet" version="11.2.1" />
         </dependencies>
     </metadata>
   <files>

--- a/Rdmp.Core/Rdmp.Core.csproj
+++ b/Rdmp.Core/Rdmp.Core.csproj
@@ -278,6 +278,7 @@
     <PackageReference Include="System.Runtime.Loader" Version="4.3.0" />
     <PackageReference Include="SSH.NET" Version="2020.0.1" />
     <PackageReference Include="System.Threading.ThreadPool" Version="4.3.0" />
+    <PackageReference Include="YamlDotNet" Version="11.2.1" />
   </ItemGroup>
   <ItemGroup>
     <ProjectReference Include="..\Reusable\MapsDirectlyToDatabaseTable\MapsDirectlyToDatabaseTable.csproj" />

--- a/Tools/rdmp/Program.cs
+++ b/Tools/rdmp/Program.cs
@@ -186,7 +186,7 @@ namespace Rdmp.Core
             ImplementationManager.Load<OracleImplementation>();
             ImplementationManager.Load<PostgreSqlImplementation>();
 
-            PopulateConnectionStringsFromYamlIfMissing(opts);
+            opts.PopulateConnectionStringsFromYamlIfMissing();
 
             // where RDMP objects are stored
             var repositoryLocator = opts.GetRepositoryLocator();
@@ -242,7 +242,7 @@ namespace Rdmp.Core
             ImplementationManager.Load<OracleImplementation>();
             ImplementationManager.Load<PostgreSqlImplementation>();
 
-            PopulateConnectionStringsFromYamlIfMissing(opts);
+            opts.PopulateConnectionStringsFromYamlIfMissing();
 
             var repo = opts.GetRepositoryLocator();
 
@@ -303,62 +303,6 @@ namespace Rdmp.Core
             }
 
             return true;
-        }
-
-        private static void PopulateConnectionStringsFromYamlIfMissing(RDMPCommandLineOptions opts)
-        {
-            var logger = LogManager.GetCurrentClassLogger();
-
-                        
-            if(!opts.NoConnectionStringsSpecified())
-            {
-                logger.Info("Connection string options have been specified on command line, yaml config values will be ignored");
-                return;
-            }
-
-            string assemblyFolder = Path.GetDirectoryName(Assembly.GetExecutingAssembly().Location);
-            var yaml = Path.Combine(assemblyFolder,"Databases.yaml");
-
-            if(File.Exists(yaml))
-            {
-                try
-                {
-                    // Setup the input
-                    using(var input = new StreamReader(yaml))
-                    {
-                        // Load the stream
-                        var yamlStream = new YamlStream();
-                        yamlStream.Load(input);
-                    
-                        // Examine the stream
-                        var mapping = (YamlMappingNode)yamlStream.Documents[0].RootNode;
-
-                    
-                        foreach (var entry in mapping.Children)
-                        {
-                            string key = ((YamlScalarNode)entry.Key).Value;
-                            string value = ((YamlScalarNode)entry.Value).Value;
-
-
-                            try
-                            {
-                                var prop = typeof(RDMPCommandLineOptions).GetProperty(key);
-                                prop.SetValue(opts,value);
-                                logger.Info("Setting yaml config value for " + key);
-                            }
-                            catch (Exception)
-                            {
-                                logger.Error("Could not set property called " + key);
-                            }
-                        }
-                    }
-                }
-                catch (Exception ex)
-                {
-                    logger.Error(ex, "Failed to read yaml file '" + yaml +"'");
-                }
-                
-            }
         }
     }
 }


### PR DESCRIPTION
Fixes #727

Can now specify command line options for the main gui app in a file called `Databases.yaml`:

```
CatalogueConnectionString: Server=(localdb)\MSSQLLocalDB;Database=RDMP_Catalogue;Trusted_Connection=True;
DataExportConnectionString: Server=(localdb)\MSSQLLocalDB;Database=RDMP_DataExport;Trusted_Connection=True;
```
_Databases.yaml_

Can also specify a custom file to load e.g.

```
./ResearchDataManagementPlatform --ConnectionStringsFile ./SHAREDbs.yaml
```