### PR TITLE
Added ContextText to DemandsInitializationAttribute

### DIFF
--- a/Rdmp.Core/Curation/Data/DemandsInitializationAttribute.cs
+++ b/Rdmp.Core/Curation/Data/DemandsInitializationAttribute.cs
@@ -36,6 +36,12 @@ namespace Rdmp.Core.Curation.Data
         /// </summary>
         public object DefaultValue { get; set; }
 
+
+        /// <summary>
+        /// A optional text value that some controls use to add more context to the input. I.e. DemandType.SQL uses this to display the clause text next to the input
+        /// </summary>
+        public string ContextText { get; set; }
+
         /// <summary>
         /// True if the public property must have a value supplied by the user.  This is compatible with <see cref="DefaultValue"/>.
         /// </summary>

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentCollectionUI.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentCollectionUI.cs
@@ -160,6 +160,7 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs
             var args = new ArgumentValueUIArgs();
             args.Parent = parent;
             args.Type = argument.GetSystemType();
+            args.ContextText = required.Demand.ContextText;
 
             try
             {

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueSqlUI.Designer.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueSqlUI.Designer.cs
@@ -28,49 +28,85 @@
         /// </summary>
         private void InitializeComponent()
         {
+            this.tableLayoutPanel1 = new System.Windows.Forms.TableLayoutPanel();
             this.btnSetSQL = new System.Windows.Forms.Button();
             this.tbSql = new System.Windows.Forms.TextBox();
+            this.lblSqlClause = new System.Windows.Forms.Label();
+            this.tableLayoutPanel1.SuspendLayout();
             this.SuspendLayout();
+            // 
+            // tableLayoutPanel1
+            // 
+            this.tableLayoutPanel1.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tableLayoutPanel1.ColumnCount = 3;
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.ColumnStyles.Add(new System.Windows.Forms.ColumnStyle());
+            this.tableLayoutPanel1.Controls.Add(this.btnSetSQL, 0, 0);
+            this.tableLayoutPanel1.Controls.Add(this.tbSql, 2, 0);
+            this.tableLayoutPanel1.Controls.Add(this.lblSqlClause, 1, 0);
+            this.tableLayoutPanel1.Location = new System.Drawing.Point(3, 2);
+            this.tableLayoutPanel1.Margin = new System.Windows.Forms.Padding(3, 0, 5, 0);
+            this.tableLayoutPanel1.Name = "tableLayoutPanel1";
+            this.tableLayoutPanel1.RowCount = 1;
+            this.tableLayoutPanel1.RowStyles.Add(new System.Windows.Forms.RowStyle(System.Windows.Forms.SizeType.Percent, 100F));
+            this.tableLayoutPanel1.Size = new System.Drawing.Size(315, 27);
+            this.tableLayoutPanel1.TabIndex = 25;
             // 
             // btnSetSQL
             // 
-            this.btnSetSQL.Location = new System.Drawing.Point(3, 3);
-            this.btnSetSQL.Margin = new System.Windows.Forms.Padding(4, 3, 2, 3);
+            this.btnSetSQL.Dock = System.Windows.Forms.DockStyle.Left;
+            this.btnSetSQL.Location = new System.Drawing.Point(0, 1);
+            this.btnSetSQL.Margin = new System.Windows.Forms.Padding(0, 1, 1, 1);
             this.btnSetSQL.Name = "btnSetSQL";
-            this.btnSetSQL.Size = new System.Drawing.Size(88, 25);
-            this.btnSetSQL.TabIndex = 21;
+            this.btnSetSQL.Size = new System.Drawing.Size(86, 25);
+            this.btnSetSQL.TabIndex = 23;
             this.btnSetSQL.Text = "Set SQL...";
             this.btnSetSQL.UseVisualStyleBackColor = true;
             this.btnSetSQL.Click += new System.EventHandler(this.btnSetSQL_Click);
             // 
             // tbSql
             // 
-            this.tbSql.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
+            this.tbSql.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Left | System.Windows.Forms.AnchorStyles.Right)));
             this.tbSql.Enabled = false;
-            this.tbSql.Location = new System.Drawing.Point(93, 4);
-            this.tbSql.Margin = new System.Windows.Forms.Padding(0, 3, 4, 3);
+            this.tbSql.Location = new System.Drawing.Point(160, 2);
+            this.tbSql.Margin = new System.Windows.Forms.Padding(1, 0, 0, 0);
             this.tbSql.Name = "tbSql";
-            this.tbSql.Size = new System.Drawing.Size(541, 23);
-            this.tbSql.TabIndex = 22;
+            this.tbSql.Size = new System.Drawing.Size(155, 23);
+            this.tbSql.TabIndex = 27;
+            // 
+            // lblSqlClause
+            // 
+            this.lblSqlClause.Anchor = System.Windows.Forms.AnchorStyles.Left;
+            this.lblSqlClause.AutoSize = true;
+            this.lblSqlClause.Font = new System.Drawing.Font("Segoe UI", 9F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);
+            this.lblSqlClause.ForeColor = System.Drawing.SystemColors.Highlight;
+            this.lblSqlClause.Location = new System.Drawing.Point(87, 6);
+            this.lblSqlClause.Margin = new System.Windows.Forms.Padding(0);
+            this.lblSqlClause.Name = "lblSqlClause";
+            this.lblSqlClause.Size = new System.Drawing.Size(72, 15);
+            this.lblSqlClause.TabIndex = 24;
+            this.lblSqlClause.Text = "lblSqlClause";
             // 
             // ArgumentValueSqlUI
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.Controls.Add(this.tbSql);
-            this.Controls.Add(this.btnSetSQL);
+            this.Controls.Add(this.tableLayoutPanel1);
             this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.Name = "ArgumentValueSqlUI";
-            this.Size = new System.Drawing.Size(638, 32);
+            this.Size = new System.Drawing.Size(323, 32);
+            this.tableLayoutPanel1.ResumeLayout(false);
+            this.tableLayoutPanel1.PerformLayout();
             this.ResumeLayout(false);
-            this.PerformLayout();
 
         }
 
         #endregion
-
+        private System.Windows.Forms.TableLayoutPanel tableLayoutPanel1;
         private System.Windows.Forms.Button btnSetSQL;
+        private System.Windows.Forms.Label lblSqlClause;
         private System.Windows.Forms.TextBox tbSql;
     }
 }

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueSqlUI.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueSqlUI.cs
@@ -44,6 +44,7 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs.ArgumentValueControls
             _args = args;
 
             tbSql.Text = FormatSqlForTextbox(args.InitialValue);
+            lblSqlClause.Text = args.ContextText?.ToUpper();
         }
 
         private void btnSetSQL_Click(object sender, System.EventArgs e)

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueSqlUI.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueSqlUI.cs
@@ -44,7 +44,7 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs.ArgumentValueControls
             _args = args;
 
             tbSql.Text = FormatSqlForTextbox(args.InitialValue);
-            lblSqlClause.Text = args.ContextText?.ToUpper();
+            lblSqlClause.Text = args.ContextText;
         }
 
         private void btnSetSQL_Click(object sender, System.EventArgs e)

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueUIArgs.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueUIArgs.cs
@@ -19,6 +19,7 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs.ArgumentValueControls
         public IArgumentHost Parent { get; set; }
 
         public object InitialValue { get; set; }
+        public string ContextText { get; set; }
         public Type Type { get; set; }
         public RequiredPropertyInfo Required { get; set; }
         public ICatalogueRepository CatalogueRepository { get; set; }
@@ -38,6 +39,7 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs.ArgumentValueControls
             var newInstance = new ArgumentValueUIArgs();
             newInstance.Parent = Parent;
             newInstance.InitialValue = InitialValue;
+            newInstance.ContextText = ContextText;
             newInstance.Type = Type;
             newInstance.Required = Required;
             newInstance.CatalogueRepository = CatalogueRepository;


### PR DESCRIPTION
Updated ArgumentCollectionUI to support ContextText so a clause (like "WHERE") can be put next to the SQL input box.

For example, adding the collowing ContextText
![image](https://user-images.githubusercontent.com/5470814/144218672-54d47de6-a7c3-406a-b731-614aeb885b1b.png)

![image](https://user-images.githubusercontent.com/5470814/144218760-7a1707bf-9361-42c2-b187-71b7c5027b94.png)

Could be useful for other controls as well to allow some customisation of the input box from the pipeline component level
