### PR TITLE
Fixing WideMessageBox grabbing window focus

### DIFF
--- a/Rdmp.UI.Tests/WideMessageBoxTests.cs
+++ b/Rdmp.UI.Tests/WideMessageBoxTests.cs
@@ -30,6 +30,10 @@ namespace Rdmp.UI.Tests
 
             var wmb = new WideMessageBox(args);
 
+            // simulate showing the control without actually blocking/firing
+            var onShow = typeof(WideMessageBox).GetMethod("OnShown", BindingFlags.NonPublic | BindingFlags.Instance);
+            onShow.Invoke(wmb, new[] { new EventArgs() });
+
             //pretend like we launched it
             LastUserInterfaceLaunched = wmb;
 

--- a/Rdmp.UI.Tests/WideMessageBoxTests.cs
+++ b/Rdmp.UI.Tests/WideMessageBoxTests.cs
@@ -12,6 +12,8 @@ using System.Text;
 using System.Windows.Forms;
 using Rdmp.UI.SimpleDialogs;
 using WideMessageBox = Rdmp.UI.SimpleDialogs.WideMessageBox;
+using System.Reflection;
+using System;
 
 namespace Rdmp.UI.Tests
 {
@@ -56,6 +58,10 @@ namespace Rdmp.UI.Tests
             Assert.AreEqual(1_000_000, args.Message.Length);
 
             var wmb = new WideMessageBox(args);
+
+            // simulate showing the control without actually blocking/firing
+            var onShow = typeof(WideMessageBox).GetMethod("OnShown", BindingFlags.NonPublic | BindingFlags.Instance);
+            onShow.Invoke(wmb, new[] { new EventArgs()});
 
             //pretend like we launched it
             LastUserInterfaceLaunched = wmb;

--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.Designer.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.Designer.cs
@@ -30,18 +30,18 @@ namespace Rdmp.UI.SimpleDialogs
         /// </summary>
         private void InitializeComponent()
         {
-            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(Rdmp.UI.SimpleDialogs.WideMessageBox));
+            System.ComponentModel.ComponentResourceManager resources = new System.ComponentModel.ComponentResourceManager(typeof(WideMessageBox));
             this.btnOk = new System.Windows.Forms.Button();
             this.btnCopyToClipboard = new System.Windows.Forms.Button();
             this.btnViewStackTrace = new System.Windows.Forms.Button();
             this.pbIcon = new System.Windows.Forms.PictureBox();
             this.panel1 = new System.Windows.Forms.Panel();
             this.btnViewSourceCode = new System.Windows.Forms.Button();
+            this.richTextBox1 = new Rdmp.UI.RichTextBoxEx();
             this.lblMainMessage = new System.Windows.Forms.Label();
             this.panel2 = new System.Windows.Forms.Panel();
             this.ButtonsPanel = new System.Windows.Forms.Panel();
             this.btnBack = new System.Windows.Forms.Button();
-            this.richTextBox1 = new RichTextBoxEx();
             ((System.ComponentModel.ISupportInitialize)(this.pbIcon)).BeginInit();
             this.panel1.SuspendLayout();
             this.panel2.SuspendLayout();
@@ -51,9 +51,10 @@ namespace Rdmp.UI.SimpleDialogs
             // btnOk
             // 
             this.btnOk.Anchor = System.Windows.Forms.AnchorStyles.Top;
-            this.btnOk.Location = new System.Drawing.Point(211, 4);
+            this.btnOk.Location = new System.Drawing.Point(116, 5);
+            this.btnOk.Margin = new System.Windows.Forms.Padding(4);
             this.btnOk.Name = "btnOk";
-            this.btnOk.Size = new System.Drawing.Size(75, 23);
+            this.btnOk.Size = new System.Drawing.Size(88, 27);
             this.btnOk.TabIndex = 0;
             this.btnOk.Text = "Ok";
             this.btnOk.UseVisualStyleBackColor = true;
@@ -62,9 +63,10 @@ namespace Rdmp.UI.SimpleDialogs
             // btnCopyToClipboard
             // 
             this.btnCopyToClipboard.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnCopyToClipboard.Location = new System.Drawing.Point(650, 9);
+            this.btnCopyToClipboard.Location = new System.Drawing.Point(531, 5);
+            this.btnCopyToClipboard.Margin = new System.Windows.Forms.Padding(4);
             this.btnCopyToClipboard.Name = "btnCopyToClipboard";
-            this.btnCopyToClipboard.Size = new System.Drawing.Size(106, 23);
+            this.btnCopyToClipboard.Size = new System.Drawing.Size(124, 27);
             this.btnCopyToClipboard.TabIndex = 0;
             this.btnCopyToClipboard.Text = "Copy To Clipboard";
             this.btnCopyToClipboard.UseVisualStyleBackColor = true;
@@ -73,9 +75,10 @@ namespace Rdmp.UI.SimpleDialogs
             // btnViewStackTrace
             // 
             this.btnViewStackTrace.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Right)));
-            this.btnViewStackTrace.Location = new System.Drawing.Point(538, 9);
+            this.btnViewStackTrace.Location = new System.Drawing.Point(399, 5);
+            this.btnViewStackTrace.Margin = new System.Windows.Forms.Padding(4);
             this.btnViewStackTrace.Name = "btnViewStackTrace";
-            this.btnViewStackTrace.Size = new System.Drawing.Size(106, 23);
+            this.btnViewStackTrace.Size = new System.Drawing.Size(124, 27);
             this.btnViewStackTrace.TabIndex = 2;
             this.btnViewStackTrace.Text = "View Stack Trace";
             this.btnViewStackTrace.UseVisualStyleBackColor = true;
@@ -83,9 +86,10 @@ namespace Rdmp.UI.SimpleDialogs
             // 
             // pbIcon
             // 
-            this.pbIcon.Location = new System.Drawing.Point(16, 16);
+            this.pbIcon.Location = new System.Drawing.Point(19, 18);
+            this.pbIcon.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.pbIcon.Name = "pbIcon";
-            this.pbIcon.Size = new System.Drawing.Size(28, 28);
+            this.pbIcon.Size = new System.Drawing.Size(33, 32);
             this.pbIcon.SizeMode = System.Windows.Forms.PictureBoxSizeMode.StretchImage;
             this.pbIcon.TabIndex = 5;
             this.pbIcon.TabStop = false;
@@ -99,8 +103,9 @@ namespace Rdmp.UI.SimpleDialogs
             this.panel1.Controls.Add(this.pbIcon);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Fill;
             this.panel1.Location = new System.Drawing.Point(0, 0);
+            this.panel1.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(759, 303);
+            this.panel1.Size = new System.Drawing.Size(659, 213);
             this.panel1.TabIndex = 6;
             // 
             // btnViewSourceCode
@@ -109,20 +114,39 @@ namespace Rdmp.UI.SimpleDialogs
             this.btnViewSourceCode.Enabled = false;
             this.btnViewSourceCode.Image = ((System.Drawing.Image)(resources.GetObject("btnViewSourceCode.Image")));
             this.btnViewSourceCode.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnViewSourceCode.Location = new System.Drawing.Point(693, 7);
+            this.btnViewSourceCode.Location = new System.Drawing.Point(587, 4);
+            this.btnViewSourceCode.Margin = new System.Windows.Forms.Padding(4);
             this.btnViewSourceCode.Name = "btnViewSourceCode";
-            this.btnViewSourceCode.Size = new System.Drawing.Size(58, 23);
+            this.btnViewSourceCode.Size = new System.Drawing.Size(68, 27);
             this.btnViewSourceCode.TabIndex = 7;
             this.btnViewSourceCode.Text = "Code";
             this.btnViewSourceCode.TextImageRelation = System.Windows.Forms.TextImageRelation.ImageBeforeText;
             this.btnViewSourceCode.UseVisualStyleBackColor = true;
             // 
+            // richTextBox1
+            // 
+            this.richTextBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
+            | System.Windows.Forms.AnchorStyles.Left) 
+            | System.Windows.Forms.AnchorStyles.Right)));
+            this.richTextBox1.BackColor = System.Drawing.SystemColors.ControlLightLight;
+            this.richTextBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
+            this.richTextBox1.Location = new System.Drawing.Point(62, 53);
+            this.richTextBox1.Margin = new System.Windows.Forms.Padding(10);
+            this.richTextBox1.Name = "richTextBox1";
+            this.richTextBox1.ReadOnly = true;
+            this.richTextBox1.Size = new System.Drawing.Size(578, 141);
+            this.richTextBox1.TabIndex = 3;
+            this.richTextBox1.Text = "";
+            this.richTextBox1.WordWrap = false;
+            this.richTextBox1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.richTextBox1_KeyDown);
+            // 
             // lblMainMessage
             // 
             this.lblMainMessage.AutoSize = true;
-            this.lblMainMessage.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point, ((byte)(0)));
+            this.lblMainMessage.Font = new System.Drawing.Font("Tahoma", 12F, System.Drawing.FontStyle.Regular, System.Drawing.GraphicsUnit.Point);
             this.lblMainMessage.ForeColor = System.Drawing.Color.FromArgb(((int)(((byte)(0)))), ((int)(((byte)(100)))), ((int)(((byte)(200)))));
-            this.lblMainMessage.Location = new System.Drawing.Point(46, 16);
+            this.lblMainMessage.Location = new System.Drawing.Point(58, 24);
+            this.lblMainMessage.Margin = new System.Windows.Forms.Padding(4, 0, 4, 0);
             this.lblMainMessage.Name = "lblMainMessage";
             this.lblMainMessage.Size = new System.Drawing.Size(106, 19);
             this.lblMainMessage.TabIndex = 6;
@@ -135,9 +159,10 @@ namespace Rdmp.UI.SimpleDialogs
             this.panel2.Controls.Add(this.btnViewStackTrace);
             this.panel2.Controls.Add(this.btnCopyToClipboard);
             this.panel2.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel2.Location = new System.Drawing.Point(0, 303);
+            this.panel2.Location = new System.Drawing.Point(0, 213);
+            this.panel2.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.panel2.Name = "panel2";
-            this.panel2.Size = new System.Drawing.Size(759, 37);
+            this.panel2.Size = new System.Drawing.Size(659, 36);
             this.panel2.TabIndex = 7;
             // 
             // ButtonsPanel
@@ -145,9 +170,10 @@ namespace Rdmp.UI.SimpleDialogs
             this.ButtonsPanel.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.ButtonsPanel.Controls.Add(this.btnOk);
-            this.ButtonsPanel.Location = new System.Drawing.Point(66, 3);
+            this.ButtonsPanel.Location = new System.Drawing.Point(74, 0);
+            this.ButtonsPanel.Margin = new System.Windows.Forms.Padding(0);
             this.ButtonsPanel.Name = "ButtonsPanel";
-            this.ButtonsPanel.Size = new System.Drawing.Size(466, 31);
+            this.ButtonsPanel.Size = new System.Drawing.Size(321, 36);
             this.ButtonsPanel.TabIndex = 4;
             // 
             // btnBack
@@ -155,41 +181,28 @@ namespace Rdmp.UI.SimpleDialogs
             this.btnBack.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left)));
             this.btnBack.Image = ((System.Drawing.Image)(resources.GetObject("btnBack.Image")));
             this.btnBack.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
-            this.btnBack.Location = new System.Drawing.Point(3, 8);
+            this.btnBack.Location = new System.Drawing.Point(4, 5);
+            this.btnBack.Margin = new System.Windows.Forms.Padding(4);
             this.btnBack.Name = "btnBack";
-            this.btnBack.Size = new System.Drawing.Size(57, 26);
+            this.btnBack.Size = new System.Drawing.Size(66, 27);
             this.btnBack.TabIndex = 3;
             this.btnBack.Text = "Back";
             this.btnBack.TextAlign = System.Drawing.ContentAlignment.MiddleRight;
             this.btnBack.UseVisualStyleBackColor = true;
             this.btnBack.Click += new System.EventHandler(this.btnBack_Click);
             // 
-            // richTextBox1
-            // 
-            this.richTextBox1.Anchor = ((System.Windows.Forms.AnchorStyles)((((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Bottom) 
-            | System.Windows.Forms.AnchorStyles.Left) 
-            | System.Windows.Forms.AnchorStyles.Right)));
-            this.richTextBox1.BackColor = System.Drawing.SystemColors.ControlLightLight;
-            this.richTextBox1.BorderStyle = System.Windows.Forms.BorderStyle.None;
-            this.richTextBox1.Location = new System.Drawing.Point(53, 38);
-            this.richTextBox1.Name = "richTextBox1";
-            this.richTextBox1.ReadOnly = true;
-            this.richTextBox1.Size = new System.Drawing.Size(694, 222);
-            this.richTextBox1.TabIndex = 3;
-            this.richTextBox1.Text = "";
-            this.richTextBox1.WordWrap = false;
-            this.richTextBox1.KeyDown += new System.Windows.Forms.KeyEventHandler(this.richTextBox1_KeyDown);
-            // 
             // WideMessageBox
             // 
-            this.AutoScaleDimensions = new System.Drawing.SizeF(6F, 13F);
+            this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(759, 340);
+            this.ClientSize = new System.Drawing.Size(659, 249);
             this.Controls.Add(this.panel1);
             this.Controls.Add(this.panel2);
             this.FormBorderStyle = System.Windows.Forms.FormBorderStyle.SizableToolWindow;
             this.Icon = ((System.Drawing.Icon)(resources.GetObject("$this.Icon")));
             this.KeyPreview = true;
+            this.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
+            this.MinimumSize = new System.Drawing.Size(450, 200);
             this.Name = "WideMessageBox";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Message";

--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
@@ -79,7 +79,10 @@ namespace Rdmp.UI.SimpleDialogs
 
             //if the text is too long vertically just maximise the message box
             if (this.Height > theScreen.Bounds.Height)
+            {
+                this.MaximizedBounds = theScreen.WorkingArea;
                 this.WindowState = FormWindowState.Maximized;
+            }
 
             richTextBox1.LinkClicked += richTextBox1_LinkClicked;
             btnViewSourceCode.Click += (s, e) => new ViewSourceCodeDialog((string)btnViewSourceCode.Tag).Show();

--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
@@ -72,10 +72,18 @@ namespace Rdmp.UI.SimpleDialogs
             this.Size = GetPreferredSizeOfTextControl(richTextBox1);
             this.Size = new Size(this.Size.Width + 10, this.Size.Height + 150);//leave a bit of padding
 
+            richTextBox1.LinkClicked += richTextBox1_LinkClicked;
+            btnViewSourceCode.Click += (s, e) => new ViewSourceCodeDialog((string)btnViewSourceCode.Tag).Show();
+        }
+
+        protected override void OnShown(EventArgs e)
+        {
+            base.OnShown(e);
+
             var theScreen = Screen.FromControl(this);
-            
+
             //enforce sensible max/min sizes
-            Width = Math.Min(Math.Max(600, Width),theScreen.Bounds.Width - 400);
+            Width = Math.Min(Math.Max(600, Width), theScreen.Bounds.Width - 400);
 
             //if the text is too long vertically just maximise the message box
             if (this.Height > theScreen.Bounds.Height)
@@ -83,12 +91,7 @@ namespace Rdmp.UI.SimpleDialogs
                 this.MaximizedBounds = theScreen.WorkingArea;
                 this.WindowState = FormWindowState.Maximized;
             }
-
-            richTextBox1.LinkClicked += richTextBox1_LinkClicked;
-            btnViewSourceCode.Click += (s, e) => new ViewSourceCodeDialog((string)btnViewSourceCode.Tag).Show();
         }
-
-
         protected void Setup(WideMessageBoxArgs args)
         {
             Args = args;


### PR DESCRIPTION
Attempting to resolve #747

Line 75 in Rdmp.UI.SimpleDialogs.,WideMessageBox appears to be the root cause of this problem:

`var theScreen = Screen.FromControl(this);`

Since this is only used for sizing the box correctly I've updated the WideMessageBox control layout to be a little more graceful with resizing without having to grab the screen size.

However, the related code (below) does do some useful stuff to stop the window being too big and still being accessible:
`            var theScreen = Screen.FromControl(this);
            
            //enforce sensible max/min sizes
            Width = Math.Min(Math.Max(600, Width),theScreen.Bounds.Width - 400);

            //if the text is too long vertically just maximise the message box
            if (this.Height > theScreen.Bounds.Height)
                this.WindowState = FormWindowState.Maximized;`

Not tested yet but possibly might be able to move this code to the actual "show" method if that's not too late.
