### PR TITLE
Fixed BinderRule validating after changed events to unrelated properties

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -38,6 +38,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Generate Release Document now shows as impossible when Cohort is not defined or unreachable (e.g. if user does not have access to cohort database)
 - Fixed bug where selecting a [PipelineComponent] for which help is unavailable would leave the previously selected component's help visible
 - Fixed bug with 'Commit Cohort' storing the target cohort database for future clicks
+- Fixed a bug where editing a field like `Description` would fire validation on other properties e.g. `Name` which could slow controls down when validation is slow and change events are fired in rapid succession.
 
 ### Changed
 

--- a/Rdmp.UI/Rules/BinderRule.cs
+++ b/Rdmp.UI/Rules/BinderRule.cs
@@ -20,13 +20,18 @@ namespace Rdmp.UI.Rules
         protected readonly Func<T, object> PropertyToCheck;
         protected readonly Control Control;
 
-        protected BinderRule(IActivateItems activator, T toTest, Func<T, object> propertyToCheck, Control control)
+        /// <summary>
+        /// The member on <see cref="ToTest"/> that 
+        /// </summary>
+        protected readonly string PropertyToCheckName;
+        protected BinderRule(IActivateItems activator, T toTest, Func<T, object> propertyToCheck, Control control, string propertyToCheckName)
         {
             ErrorProvider = new ErrorProvider();
             Activator = activator;
             ToTest = toTest;
             PropertyToCheck = propertyToCheck;
             Control = control;
+            PropertyToCheckName = propertyToCheckName;
 
             activator.OnRuleRegistered(this);
 
@@ -35,6 +40,12 @@ namespace Rdmp.UI.Rules
 
         private void ToTest_PropertyChanged(object sender, PropertyChangedEventArgs e)
         {
+            // the property being changed is not ours
+            if (!string.Equals(e.PropertyName, PropertyToCheckName))
+            {
+                return;
+            }
+
             var currentValue = PropertyToCheck(ToTest);
             var typeToTest = ToTest.GetType();
 

--- a/Rdmp.UI/Rules/BinderWithErrorProviderFactory.cs
+++ b/Rdmp.UI/Rules/BinderWithErrorProviderFactory.cs
@@ -36,13 +36,13 @@ namespace Rdmp.UI.Rules
             var property = databaseObject.GetType().GetProperty(dataMember);
 
             if (property.GetCustomAttributes(typeof (UniqueAttribute), true).Any())
-                new UniqueRule<T>(_activator, databaseObject, getter, c);
+                new UniqueRule<T>(_activator, databaseObject, getter, c, dataMember);
             
             if (property.GetCustomAttributes(typeof(NotNullAttribute), true).Any())
-                new NotNullRule<T>(_activator, databaseObject, getter, c);
+                new NotNullRule<T>(_activator, databaseObject, getter, c, dataMember);
 
             if(dataMember.Equals("Name") && databaseObject is INamed)
-                new NoBadNamesRule<T>(_activator, databaseObject, getter, c);
+                new NoBadNamesRule<T>(_activator, databaseObject, getter, c, dataMember);
         }
     }
 }

--- a/Rdmp.UI/Rules/NoBadNamesRule.cs
+++ b/Rdmp.UI/Rules/NoBadNamesRule.cs
@@ -16,7 +16,7 @@ namespace Rdmp.UI.Rules
 {
     class NoBadNamesRule<T>:BinderRule<T> where T:IMapsDirectlyToDatabaseTable
     {
-        public NoBadNamesRule(IActivateItems activator, T databaseObject, Func<T, object> getter, Control control) : base(activator,databaseObject,getter,control)
+        public NoBadNamesRule(IActivateItems activator, T databaseObject, Func<T, object> getter, Control control,string propertyToCheckName) : base(activator,databaseObject,getter,control, propertyToCheckName)
         {
             
         }

--- a/Rdmp.UI/Rules/NotNullRule.cs
+++ b/Rdmp.UI/Rules/NotNullRule.cs
@@ -13,7 +13,7 @@ namespace Rdmp.UI.Rules
 {
     class NotNullRule<T> : BinderRule<T> where T : IMapsDirectlyToDatabaseTable
     {
-        public NotNullRule(IActivateItems activator, T databaseObject, Func<T, object> getter, Control control) : base(activator,databaseObject,getter,control)
+        public NotNullRule(IActivateItems activator, T databaseObject, Func<T, object> getter, Control control,string propertyToCheckName) : base(activator,databaseObject,getter,control, propertyToCheckName)
         {
             
         }

--- a/Rdmp.UI/Rules/UniqueRule.cs
+++ b/Rdmp.UI/Rules/UniqueRule.cs
@@ -16,8 +16,8 @@ namespace Rdmp.UI.Rules
     {
         private readonly string _problemDescription;
 
-        public UniqueRule(IActivateItems activator, T toTest, Func<T, object> propertyToCheck, Control control)
-            : base(activator, toTest, propertyToCheck, control)
+        public UniqueRule(IActivateItems activator, T toTest, Func<T, object> propertyToCheck, Control control, string propertyToCheckName)
+            : base(activator, toTest, propertyToCheck, control, propertyToCheckName)
         {
             _problemDescription = "Must be unique amongst all " + toTest.GetType().Name + "s";
 


### PR DESCRIPTION
Improves performance of typing in Catalogue Descriptions when there are a lot of Catalogues configured