### PR TITLE
Added event handlers to stop scroll wheel working on combobox

### DIFF
--- a/Rdmp.UI/AggregationUIs/Advanced/AggregateEditorUI.cs
+++ b/Rdmp.UI/AggregationUIs/Advanced/AggregateEditorUI.cs
@@ -80,6 +80,10 @@ namespace Rdmp.UI.AggregationUIs.Advanced
         public AggregateEditorUI()
         {
             InitializeComponent();
+
+            //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
+            ddAxisDimension.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+            ddPivotDimension.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
             
             if(VisualStudioDesignMode)
                 return;

--- a/Rdmp.UI/AggregationUIs/Advanced/AggregateEditorUI.cs
+++ b/Rdmp.UI/AggregationUIs/Advanced/AggregateEditorUI.cs
@@ -82,8 +82,8 @@ namespace Rdmp.UI.AggregationUIs.Advanced
             InitializeComponent();
 
             //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
-            ddAxisDimension.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
-            ddPivotDimension.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+            RDMPControlCommonFunctionality.DisableMouseWheel(ddAxisDimension);
+            RDMPControlCommonFunctionality.DisableMouseWheel(ddPivotDimension);
             
             if(VisualStudioDesignMode)
                 return;

--- a/Rdmp.UI/AggregationUIs/Advanced/AggregateTopXUI.cs
+++ b/Rdmp.UI/AggregationUIs/Advanced/AggregateTopXUI.cs
@@ -12,6 +12,7 @@ using Rdmp.Core.QueryBuilding.Options;
 using Rdmp.UI.ItemActivation;
 using Rdmp.UI.Refreshing;
 using Rdmp.UI.TestsAndSetup.ServicePropogation;
+using System.Windows.Forms;
 
 namespace Rdmp.UI.AggregationUIs.Advanced
 {
@@ -32,6 +33,10 @@ namespace Rdmp.UI.AggregationUIs.Advanced
         public AggregateTopXUI()
         {
             InitializeComponent();
+
+            //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
+            ddAscOrDesc.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+            ddOrderByDimension.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
         }
 
         private bool bLoading = false;

--- a/Rdmp.UI/AggregationUIs/Advanced/AggregateTopXUI.cs
+++ b/Rdmp.UI/AggregationUIs/Advanced/AggregateTopXUI.cs
@@ -35,8 +35,8 @@ namespace Rdmp.UI.AggregationUIs.Advanced
             InitializeComponent();
 
             //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
-            ddAscOrDesc.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
-            ddOrderByDimension.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+            RDMPControlCommonFunctionality.DisableMouseWheel(ddAscOrDesc);
+            RDMPControlCommonFunctionality.DisableMouseWheel(ddOrderByDimension);
         }
 
         private bool bLoading = false;

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueComboBoxUI.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueComboBoxUI.cs
@@ -11,7 +11,7 @@ using System.Windows.Forms;
 using MapsDirectlyToDatabaseTable;
 using Rdmp.UI.ItemActivation;
 using Rdmp.UI.SimpleDialogs;
-
+using Rdmp.UI.TestsAndSetup.ServicePropogation;
 
 namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs.ArgumentValueControls
 {
@@ -40,7 +40,7 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs.ArgumentValueControls
             InitializeComponent();
 
             //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
-            cbxValue.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+            RDMPControlCommonFunctionality.DisableMouseWheel(cbxValue);
 
             if(objectsForComboBox == null || objectsForComboBox.Length == 0)
                 return;

--- a/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueComboBoxUI.cs
+++ b/Rdmp.UI/PipelineUIs/DemandsInitializationUIs/ArgumentValueControls/ArgumentValueComboBoxUI.cs
@@ -39,6 +39,9 @@ namespace Rdmp.UI.PipelineUIs.DemandsInitializationUIs.ArgumentValueControls
             _objectsForComboBox = objectsForComboBox;
             InitializeComponent();
 
+            //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
+            cbxValue.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+
             if(objectsForComboBox == null || objectsForComboBox.Length == 0)
                 return;
 

--- a/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
+++ b/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
@@ -164,7 +164,7 @@ namespace Rdmp.UI.SimpleDialogs.ForwardEngineering
             ddIsExtractionIdentifier.Items.Add("<<None>>");
             ddIsExtractionIdentifier.Items.AddRange(olvColumnExtractability.Objects.OfType<ColPair>().ToArray());
 
-            ddIsExtractionIdentifier.MouseWheel += (s,e)=> ((HandledMouseEventArgs)e).Handled = true;
+            RDMPControlCommonFunctionality.DisableMouseWheel(ddIsExtractionIdentifier);
 
             CommonFunctionality.AddHelp(btnPickProject, "IExtractableDataSet.Project_ID", "Project Specific Datasets");
             CommonFunctionality.AddHelpString(btnAddToExisting,"Add to existing catalogue","Use this option if you want to create a Catalogue which extracts from multiple tables (via a JOIN).  Once used you will still need to configure a JoinInfo between column(s) in all the tables the Catalogue draws data from.");

--- a/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
+++ b/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
@@ -164,6 +164,8 @@ namespace Rdmp.UI.SimpleDialogs.ForwardEngineering
             ddIsExtractionIdentifier.Items.Add("<<None>>");
             ddIsExtractionIdentifier.Items.AddRange(olvColumnExtractability.Objects.OfType<ColPair>().ToArray());
 
+            ddIsExtractionIdentifier.MouseWheel += (s,e)=> ((HandledMouseEventArgs)e).Handled = true;
+
             CommonFunctionality.AddHelp(btnPickProject, "IExtractableDataSet.Project_ID", "Project Specific Datasets");
             CommonFunctionality.AddHelpString(btnAddToExisting,"Add to existing catalogue","Use this option if you want to create a Catalogue which extracts from multiple tables (via a JOIN).  Once used you will still need to configure a JoinInfo between column(s) in all the tables the Catalogue draws data from.");
 

--- a/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
+++ b/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
@@ -9,6 +9,7 @@ using System.Windows.Forms;
 using Rdmp.UI.Collections;
 using Rdmp.UI.CommandExecution.AtomicCommands;
 using Rdmp.UI.ItemActivation;
+using Rdmp.UI.TestsAndSetup.ServicePropogation;
 using ReusableLibraryCode;
 using ReusableLibraryCode.Checks;
 using ReusableLibraryCode.Settings;
@@ -42,8 +43,8 @@ namespace Rdmp.UI.SimpleDialogs
 
             InitializeComponent();
             //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
-            ddWordWrap.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
-            ddTheme.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+            RDMPControlCommonFunctionality.DisableMouseWheel(ddWordWrap);
+            RDMPControlCommonFunctionality.DisableMouseWheel(ddTheme);
 
 
             olvErrorCodes.CellEditActivation = CellEditActivateMode.SingleClick;

--- a/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
+++ b/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
@@ -41,6 +41,10 @@ namespace Rdmp.UI.SimpleDialogs
             _activator = activator;
 
             InitializeComponent();
+            //Stop mouse wheel scroll from scrolling the combobox when it's closed to avoid the value being changed without user noticing.
+            ddWordWrap.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+            ddTheme.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+
 
             olvErrorCodes.CellEditActivation = CellEditActivateMode.SingleClick;
             olvErrorCodes.ShowGroups = false;

--- a/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPControlCommonFunctionality.cs
+++ b/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPControlCommonFunctionality.cs
@@ -479,5 +479,14 @@ Stack Trace:{exception.StackTrace}";
             //go red after you have set the text
             ScintillaGoRed(queryEditor,true);
         }
+
+        /// <summary>
+        /// Disables mouse wheel scrolling on the given <paramref name="cb"/>
+        /// </summary>
+        /// <param name="cb"></param>
+        public static void DisableMouseWheel(ComboBox cb)
+        {
+            cb.MouseWheel += (s, e) => ((HandledMouseEventArgs)e).Handled = !((ComboBox)s).DroppedDown;
+        }
     }
 }


### PR DESCRIPTION
Scroll wheels will not work on comboboxs for AggregateEditorUI, AggregateTopXUI, ArgumentValueComboBoxUI and UserSettingsUI unless the dropdown is expanded.

Closes #778