### PR TITLE
Added CatalogueItemCombineable

### DIFF
--- a/Rdmp.Core/CommandExecution/Combining/CatalogueItemCombineable.cs
+++ b/Rdmp.Core/CommandExecution/Combining/CatalogueItemCombineable.cs
@@ -1,0 +1,36 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data;
+using System;
+using System.Linq;
+
+namespace Rdmp.Core.CommandExecution.Combining
+{
+    /// <summary>
+    /// <see cref="ICombineToMakeCommand"/> for one or more objects of type <see cref="CatalogueItem"/>
+    /// </summary>
+    public class CatalogueItemCombineable : ICombineToMakeCommand
+    {
+        public CatalogueItem[] CatalogueItems { get; private set; }
+
+        public CatalogueItemCombineable(CatalogueItem catalogueItem)
+        {
+            CatalogueItems = new[] { catalogueItem };
+        }
+
+        public CatalogueItemCombineable(CatalogueItem[] catalogueItems)
+        {
+            CatalogueItems = catalogueItems;
+        }
+
+        public string GetSqlString()
+        {
+            var strings = CatalogueItems.Select(ci => ci.ExtractionInformation?.SelectSQL).Where(v => !string.IsNullOrEmpty(v)).ToArray();
+            return string.Join(Environment.NewLine, strings);
+        }
+    }
+}

--- a/Rdmp.UI/Copying/RDMPCombineableFactory.cs
+++ b/Rdmp.UI/Copying/RDMPCombineableFactory.cs
@@ -80,6 +80,15 @@ namespace Rdmp.UI.Copying
             if (pipeline != null)
                 return new PipelineCombineable(pipeline);
 
+            if (modelObject is CatalogueItem ci)
+                return new CatalogueItemCombineable(ci);
+
+            var arrayOfCatalogueItems = IsArrayOf<CatalogueItem>(modelObject);
+            if (arrayOfCatalogueItems != null)
+            {
+                return new CatalogueItemCombineable(arrayOfCatalogueItems);
+            }
+
             //table column pointers (not extractable)
             var columnInfo = modelObject as ColumnInfo; //ColumnInfo is not an IColumn btw because it does not have column order or other extraction rule stuff (alias, hash etc)
             var linkedColumnInfo = modelObject as LinkedColumnInfoNode;


### PR DESCRIPTION
Enables drag and drop operations starting with one or more CatalogueItem objects.  This also enables SQL drag and drop into SQL editors.

Fixes  #835