### PR TITLE
Fixed ProgressUI filter to support always showing a given message

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed a bug where ProjectUI would not show cohorts when some cohort sources are unreachable
+- Fixed ProgressUI filter hiding global errors on extraction where the whole operation failed and a dataset filter was selected ([888](https://github.com/HicServices/RDMP/issues/888))
 
 ## [7.0.5] - 2022-01-10
 

--- a/Rdmp.UI/Progress/ProgressUI.Designer.cs
+++ b/Rdmp.UI/Progress/ProgressUI.Designer.cs
@@ -104,7 +104,7 @@ namespace Rdmp.UI.Progress
             // 
             // lblCrashed
             // 
-            this.lblCrashed.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Left) 
+            this.lblCrashed.Anchor = ((System.Windows.Forms.AnchorStyles)(((System.Windows.Forms.AnchorStyles.Bottom | System.Windows.Forms.AnchorStyles.Left) 
             | System.Windows.Forms.AnchorStyles.Right)));
             this.lblCrashed.BackColor = System.Drawing.Color.IndianRed;
             this.lblCrashed.Font = new System.Drawing.Font("Microsoft Sans Serif", 8.25F, System.Drawing.FontStyle.Bold, System.Drawing.GraphicsUnit.Point);

--- a/Rdmp.UI/Progress/ProgressUI.cs
+++ b/Rdmp.UI/Progress/ProgressUI.cs
@@ -36,6 +36,11 @@ namespace Rdmp.UI.Progress
         DataTable progress = new DataTable();
 
         /// <summary>
+        /// Sender for all global errors that should never be filtered out of the <see cref="ProgressUI"/>
+        /// </summary>
+        public const string GlobalRunError = "Run Error";
+
+        /// <summary>
         /// See HandleFloodOfMessagesFromJob, basically if the message in a progress event changes over time we don't want to spam the datagrid so instead we just note that there is a
         /// flood of distinct messages coming from a specific source component
         /// </summary>
@@ -397,11 +402,13 @@ namespace Rdmp.UI.Progress
 
         private void SetFilterFromTextBox()
         {
-            olvProgressEvents.ModelFilter = new TextMatchFilter(olvProgressEvents, tbTextFilter.Text, StringComparison.CurrentCultureIgnoreCase);
+            var alwaysShow = olvProgressEvents.Objects.OfType<ProgressUIEntry>().Where(p => p.Sender == GlobalRunError).ToArray();
+            olvProgressEvents.ModelFilter = new TextMatchFilterWithWhiteList(alwaysShow, olvProgressEvents, tbTextFilter.Text, StringComparison.CurrentCultureIgnoreCase);
         }
         public void SetFatal()
         {
             lblCrashed.Visible = true;
+            lblCrashed.BringToFront();
         }
 
         

--- a/Rdmp.UI/SimpleControls/CheckAndExecuteUI.cs
+++ b/Rdmp.UI/SimpleControls/CheckAndExecuteUI.cs
@@ -13,6 +13,7 @@ using Rdmp.Core.CommandLine.Options;
 using Rdmp.Core.CommandLine.Runners;
 using Rdmp.Core.DataFlowPipeline;
 using Rdmp.UI.ItemActivation;
+using Rdmp.UI.Progress;
 using Rdmp.UI.SingleControlForms;
 using Rdmp.UI.TestsAndSetup.ServicePropogation;
 using Rdmp.UI.TransparentHelpSystem;
@@ -219,7 +220,7 @@ namespace Rdmp.UI.SimpleControls
             }
             catch (Exception ex)
             {
-                loadProgressUI1.OnNotify(this,new NotifyEventArgs(ProgressEventType.Error, "Fatal Error",ex));
+                loadProgressUI1.OnNotify(ProgressUI.GlobalRunError,new NotifyEventArgs(ProgressEventType.Error, "Fatal Error",ex));
             }
 
             return -1;


### PR DESCRIPTION
Fixes #888 

![image](https://user-images.githubusercontent.com/31306100/150759734-c0be5526-3adb-4105-b4f4-af103415d63d.png)


Set sender to `ProgressUI.GlobalRunError` in order for the message to always show