### PR TITLE
Plugin assistance

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 - Fixed closing and changing instance not consulting tabs before closing
 - Fixed bug where setting `SuggestedCategory` on a plugin command resulted in it vanishing from context menu
+- Fixed bug with AllowEmptyExtractions not working under some situations
 
 ## [7.0.6] - 2022-01-25
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 - Added ArchiveTriggerTimeout user setting [#623](https://github.com/HicServices/RDMP/issues/623)
-- 
+- Support for referencing plugin objects from command line e.g. `./rdmp.exe cmd delete MyPluginClass:2`
+
 ### Fixed
 - Fixed closing and changing instance not consulting tabs before closing
 - Fixed bug where setting `SuggestedCategory` on a plugin command resulted in it vanishing from context menu

--- a/Rdmp.Core.Tests/CommandExecution/CommandInvokerTests.cs
+++ b/Rdmp.Core.Tests/CommandExecution/CommandInvokerTests.cs
@@ -40,16 +40,15 @@ namespace Rdmp.Core.Tests.CommandExecution
         [Timeout(5000)]
         public void Test_Delete_WithPicker()
         {
-            var mgr = new ConsoleInputManager(RepositoryLocator,new ThrowImmediatelyCheckNotifier());
+            var mgr = GetActivator();
             var invoker = new CommandInvoker(mgr);
 
             WhenIHaveA<Catalogue>();
 
-            var picker = new CommandLineObjectPicker(new[] {"Catalogue:*"}, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] {"Catalogue:*"}, mgr);
             invoker.ExecuteCommand(typeof(ExecuteCommandDelete),picker);
         }
 
-        
         [Test]
         [Timeout(5000)]
         public void Test_Generic_WithPicker()
@@ -70,7 +69,7 @@ namespace Rdmp.Core.Tests.CommandExecution
 
         private CommandLineObjectPicker GetPicker(params string[] args)
         {
-            return new CommandLineObjectPicker(args, RepositoryLocator);
+            return new CommandLineObjectPicker(args, GetActivator());
         }
 
         private class GenericTestCommand<T> : BasicCommandExecution

--- a/Rdmp.Core.Tests/CommandExecution/ExecuteCommandListTests.cs
+++ b/Rdmp.Core.Tests/CommandExecution/ExecuteCommandListTests.cs
@@ -24,7 +24,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             Assert.IsEmpty(RepositoryLocator.CatalogueRepository.GetAllObjects<Catalogue>(),"Failed to clear CatalogueRepository");
 
             GetInvoker().ExecuteCommand(typeof(ExecuteCommandList),
-                new CommandLineObjectPicker(new string[]{ "Catalogue"}, RepositoryLocator));
+                new CommandLineObjectPicker(new string[]{ "Catalogue"}, GetActivator()));
         }
         
         [Test]
@@ -33,7 +33,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             var c = WhenIHaveA<Catalogue>();
 
             GetInvoker().ExecuteCommand(typeof(ExecuteCommandList),
-                new CommandLineObjectPicker(new string[]{ "Catalogue"}, RepositoryLocator));
+                new CommandLineObjectPicker(new string[]{ "Catalogue"}, GetActivator()));
             
             c.DeleteInDatabase();
         }

--- a/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetArgumentTests.cs
+++ b/Rdmp.Core.Tests/CommandExecution/ExecuteCommandSetArgumentTests.cs
@@ -18,7 +18,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         [Test]
         public void TestSetArgument_WrongArgCount()
         {
-            var picker = new CommandLineObjectPicker(new []{"yyy" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{"yyy" }, GetActivator());
             var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
 
             Assert.IsTrue(cmd.IsImpossible);
@@ -29,7 +29,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         {
             var c = WhenIHaveA<Catalogue>();
 
-            var picker = new CommandLineObjectPicker(new []{$"Catalogue:{c.ID}","fff","yyy" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"Catalogue:{c.ID}","fff","yyy" }, GetActivator());
             var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
 
             Assert.IsTrue(cmd.IsImpossible);
@@ -42,7 +42,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             var pt = WhenIHaveA<ProcessTask>();
             
 
-            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","yyy" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","yyy" }, GetActivator());
             var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
 
             Assert.IsTrue(cmd.IsImpossible);
@@ -60,7 +60,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             // Argument expects int but is given string value "yyy"
             pta.SetType(typeof(int));
 
-            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","yyy" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","yyy" }, GetActivator());
             var cmd = new ExecuteCommandSetArgument(GetMockActivator().Object,picker);
 
             Assert.IsTrue(cmd.IsImpossible);
@@ -79,7 +79,7 @@ namespace Rdmp.Core.Tests.CommandExecution
 
             Assert.IsNull(pta.Value);
 
-            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","5" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff","5" }, GetActivator());
             
             Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
 
@@ -101,7 +101,7 @@ namespace Rdmp.Core.Tests.CommandExecution
 
             Assert.IsNull(pta.Value);
 
-            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff",$"Catalogue:kapow splat" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"ProcessTask:{pt.ID}","fff",$"Catalogue:kapow splat" }, GetActivator());
             
             Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
 
@@ -124,7 +124,7 @@ namespace Rdmp.Core.Tests.CommandExecution
 
             Assert.IsNull(pca.Value);
 
-            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Catalogue:lolzzzyy" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Catalogue:lolzzzyy" }, GetActivator());
             
             Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
 
@@ -150,7 +150,7 @@ namespace Rdmp.Core.Tests.CommandExecution
 
             Assert.IsNull(pca.Value);
 
-            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Catalogue:kapow*" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Catalogue:kapow*" }, GetActivator());
             
             Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
 
@@ -176,7 +176,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             
             Assert.Contains(cata1, (System.Collections.ICollection)pca.GetValueAsSystemType());
 
-            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Null" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"PipelineComponent:{pc.ID}","ggg",$"Null" }, GetActivator());
             
             Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetArgument),picker));
 

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandAssociateCatalogueWithLoadMetadata.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandAssociateCatalogueWithLoadMetadata.cs
@@ -30,7 +30,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             var lmd = new LoadMetadata(RepositoryLocator.CatalogueRepository,"mylmd");
 
             GetInvoker().ExecuteCommand(typeof(ExecuteCommandAssociateCatalogueWithLoadMetadata),
-                new CommandLineObjectPicker(new[]{$"LoadMetadata:{lmd.ID}", "Catalogue:fff"}, RepositoryLocator));
+                new CommandLineObjectPicker(new[]{$"LoadMetadata:{lmd.ID}", "Catalogue:fff"}, GetActivator()));
 
             cata1.RevertToDatabaseState();
             cata2.RevertToDatabaseState();

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandImportTableInfo.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandImportTableInfo.cs
@@ -18,7 +18,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         {
             
             var ex = Assert.Throws<Exception>(() => GetInvoker().ExecuteCommand(typeof(ExecuteCommandImportTableInfo),
-                new CommandLineObjectPicker(new string[0], RepositoryLocator)));
+                new CommandLineObjectPicker(new string[0], GetActivator())));
 
             StringAssert.StartsWith("Expected parameter at index 0 to be a FAnsi.Discovery.DiscoveredTable (for parameter 'table') but it was Missing",ex.Message);
         }
@@ -27,7 +27,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         public void Test_ImportTableInfo_MalformedArgument()
         {
             var ex = Assert.Throws<Exception>(() => GetInvoker().ExecuteCommand(typeof(ExecuteCommandImportTableInfo),
-                new CommandLineObjectPicker(new string[]{ "MyTable"}, RepositoryLocator)));
+                new CommandLineObjectPicker(new string[]{ "MyTable"}, GetActivator())));
 
             StringAssert.StartsWith("Expected parameter at index 0 to be a FAnsi.Discovery.DiscoveredTable (for parameter 'table') but it was MyTable",ex.Message);
         }
@@ -38,7 +38,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             var tbl = "Table:MyTable:DatabaseType:MicrosoftSQLServer:Server=myServerAddress;Database=myDataBase;Trusted_Connection=True";
             
             var ex = Assert.Throws<Exception>(() => GetInvoker().ExecuteCommand(typeof(ExecuteCommandImportTableInfo),
-                new CommandLineObjectPicker(new string[]{ tbl,"true"}, RepositoryLocator)));
+                new CommandLineObjectPicker(new string[]{ tbl,"true"}, GetActivator())));
             
             StringAssert.StartsWith("Could not reach server myServerAddress",ex.Message);
         }

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandNewObject.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandNewObject.cs
@@ -23,7 +23,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         {
             
             var ex = Assert.Throws<Exception>(() => GetInvoker().ExecuteCommand(typeof(ExecuteCommandNewObject),
-                new CommandLineObjectPicker(new string[0], RepositoryLocator)));
+                new CommandLineObjectPicker(new string[0], GetActivator())));
 
             StringAssert.StartsWith("First parameter must be a Type",ex.Message);
         }
@@ -32,7 +32,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         public void Test_NewObjectCommand_NonExistentTypeArgument()
         {
             var ex = Assert.Throws<Exception>(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandNewObject),
-                new CommandLineObjectPicker(new[]{"Fissdlkfldfj"}, RepositoryLocator)));
+                new CommandLineObjectPicker(new[]{"Fissdlkfldfj"}, GetActivator())));
 
             StringAssert.StartsWith("First parameter must be a Type",ex.Message);
         }
@@ -40,7 +40,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         [Test]
         public void Test_NewObjectCommand_WrongTypeArgument()
         {
-            var picker = new CommandLineObjectPicker(new[] {"UnitTests"},RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] {"UnitTests"}, GetActivator());
             Assert.AreEqual(typeof(UnitTests),picker[0].Type);
 
             var ex = Assert.Throws<Exception>(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandNewObject),picker));
@@ -51,7 +51,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         [Test]
         public void Test_NewObjectCommand_MissingNameArgument()
         {
-            var picker = new CommandLineObjectPicker(new[] {"Catalogue"},RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] {"Catalogue"}, GetActivator());
             Assert.AreEqual(typeof(Catalogue),picker[0].Type);
 
             var ex = Assert.Throws<ArgumentException>(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandNewObject),picker));
@@ -62,7 +62,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         [Test]
         public void Test_NewObjectCommand_Success()
         {
-            var picker = new CommandLineObjectPicker(new[] {"Catalogue","lolzeeeyeahyeah"},RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] {"Catalogue","lolzeeeyeahyeah"}, GetActivator());
             Assert.AreEqual(typeof(Catalogue),picker[0].Type);
 
             Assert.DoesNotThrow(() =>  GetInvoker().ExecuteCommand(typeof(ExecuteCommandNewObject),picker));

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandSet.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandSet.cs
@@ -24,7 +24,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         {
             var cata = new Catalogue(Repository.CatalogueRepository, "Bob");
 
-            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSet),new CommandLineObjectPicker(new []{"Catalogue:" + cata.ID,"Description","Some long description"},RepositoryLocator));
+            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSet),new CommandLineObjectPicker(new []{"Catalogue:" + cata.ID,"Description","Some long description"}, GetActivator()));
 
             cata.RevertToDatabaseState();
             Assert.AreEqual("Some long description",cata.Description);
@@ -38,7 +38,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             cata.Description = "something cool";
             cata.SaveToDatabase();
 
-            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSet),new CommandLineObjectPicker(new []{"Catalogue:" + cata.ID,"Description","NULL"},RepositoryLocator));
+            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSet),new CommandLineObjectPicker(new []{"Catalogue:" + cata.ID,"Description","NULL"}, GetActivator()));
 
             cata.RevertToDatabaseState();
             Assert.IsNull(cata.Description);
@@ -63,7 +63,7 @@ namespace Rdmp.Core.Tests.CommandExecution
             Assert.IsNull(pta.Value);
             Assert.IsNull(pta.GetValueAsSystemType());
 
-            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSet),new CommandLineObjectPicker(new []{"ProcessTaskArgument:TablesToIsolate" ,"Value",ids},RepositoryLocator));
+            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSet),new CommandLineObjectPicker(new []{"ProcessTaskArgument:TablesToIsolate" ,"Value",ids}, GetActivator()));
 
             Assert.AreEqual(ids,pta.Value);
 

--- a/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandSetUserSetting.cs
+++ b/Rdmp.Core.Tests/CommandExecution/TestExecuteCommandSetUserSetting.cs
@@ -21,11 +21,11 @@ namespace Rdmp.Core.Tests.CommandExecution
         {
             UserSettings.AllowIdentifiableExtractions = false;
 
-            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetUserSetting),new CommandLineObjectPicker(new []{"AllowIdentifiableExtractions","true"},RepositoryLocator));
+            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetUserSetting),new CommandLineObjectPicker(new []{"AllowIdentifiableExtractions","true"}, GetActivator()));
 
             Assert.IsTrue(UserSettings.AllowIdentifiableExtractions);
 
-            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetUserSetting),new CommandLineObjectPicker(new []{"AllowIdentifiableExtractions","false"},RepositoryLocator));
+            GetInvoker().ExecuteCommand(typeof(ExecuteCommandSetUserSetting),new CommandLineObjectPicker(new []{"AllowIdentifiableExtractions","false"}, GetActivator()));
             
             Assert.IsFalse(UserSettings.AllowIdentifiableExtractions);
 

--- a/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
@@ -162,14 +162,15 @@ namespace Rdmp.Core.Tests.CommandLine
         {
             var oc = new ObjectConstructor();
 
-            var mem = RepositoryLocator.DataExportRepository;
+            var mem = new MemoryDataExportRepository();
+            mem.MEF = MEF;
 
             //create some objects that the examples can successfully reference
             new Catalogue(mem.CatalogueRepository, "mycata1"); //ID = 1
             new Catalogue(mem.CatalogueRepository, "mycata2"); //ID = 2
             new Catalogue(mem.CatalogueRepository, "mycata3"); //ID = 3
 
-            PickObjectBase picker = (PickObjectBase) oc.Construct(pickerType, GetActivator());
+            PickObjectBase picker = (PickObjectBase) oc.Construct(pickerType, GetActivator(new RepositoryProvider(mem)));
 
             Assert.IsNotEmpty(picker.Help,"No Help for picker {0}",picker);
             Assert.IsNotEmpty(picker.Format,"No Format for picker {0}",picker);

--- a/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
@@ -43,7 +43,7 @@ namespace Rdmp.Core.Tests.CommandLine
         public void Test_RandomGarbage_GeneratesRawValueOnly()
         {
             string str = $"Shiver me timbers";
-             var picker = new CommandLineObjectPicker(new []{str}, RepositoryLocator);
+             var picker = new CommandLineObjectPicker(new []{str}, GetActivator());
 
             Assert.AreEqual(str,picker[0].RawValue); 
             Assert.IsNull(picker[0].DatabaseEntities);
@@ -57,13 +57,13 @@ namespace Rdmp.Core.Tests.CommandLine
         {
            var cata =  WhenIHaveA<Catalogue>();
 
-           var picker = new CommandLineObjectPicker(new []{$"Catalogue:{cata.ID}"}, RepositoryLocator);
+           var picker = new CommandLineObjectPicker(new []{$"Catalogue:{cata.ID}"}, GetActivator());
 
            Assert.AreEqual(cata,picker[0].DatabaseEntities.Single());
 
            
            //specifying the same ID twice shouldn't return duplicate objects
-           picker = new CommandLineObjectPicker(new []{$"Catalogue:{cata.ID},{cata.ID}"}, RepositoryLocator);
+           picker = new CommandLineObjectPicker(new []{$"Catalogue:{cata.ID},{cata.ID}"}, GetActivator());
 
            Assert.AreEqual(cata,picker[0].DatabaseEntities.Single());
         }
@@ -76,7 +76,7 @@ namespace Rdmp.Core.Tests.CommandLine
         [TestCase("\r\n")]
         public void Test_PickerForWhitespace(string val)
         {
-            var picker = new CommandLineObjectPicker(new []{val },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{val }, GetActivator());
 
             Assert.AreEqual(1,picker.Length);
             
@@ -96,7 +96,7 @@ namespace Rdmp.Core.Tests.CommandLine
             var cata1 =  WhenIHaveA<Catalogue>();
             var cata2 =  WhenIHaveA<Catalogue>();
 
-            var picker = new CommandLineObjectPicker(new []{$"Catalogue:{cata1.ID},{cata2.ID}"}, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{$"Catalogue:{cata1.ID},{cata2.ID}"}, GetActivator());
 
             Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
             Assert.Contains(cata1,picker[0].DatabaseEntities);
@@ -118,7 +118,7 @@ namespace Rdmp.Core.Tests.CommandLine
            cata2.SaveToDatabase();
            cata3.SaveToDatabase();
 
-           var picker = new CommandLineObjectPicker(new []{$"Catalogue:lol*"}, RepositoryLocator);
+           var picker = new CommandLineObjectPicker(new []{$"Catalogue:lol*"}, GetActivator());
 
            Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
            Assert.Contains(cata1, picker[0].DatabaseEntities);
@@ -134,7 +134,7 @@ namespace Rdmp.Core.Tests.CommandLine
             Assert.IsEmpty(RepositoryLocator.CatalogueRepository.GetAllObjects<Catalogue>());
 
             //when interpreting the string "Catalogue" for a command
-            var picker = new CommandLineObjectPicker(new []{"Catalogue" },RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{"Catalogue" }, GetActivator());
 
             //we can pick it as either a Catalogue or a collection of all the Catalogues
             Assert.AreEqual(typeof(Catalogue),picker.Arguments.Single().Type);
@@ -191,7 +191,7 @@ namespace Rdmp.Core.Tests.CommandLine
         [Test]
         public void PickTypeName()
         {
-            var picker = new CommandLineObjectPicker(new []{"Name"},RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{"Name"}, GetActivator());
             
             Assert.IsNull(picker[0].Type);
             Assert.AreEqual("Name",picker[0].RawValue);
@@ -201,7 +201,7 @@ namespace Rdmp.Core.Tests.CommandLine
         [TestCase("NULL")]
         public void PickNull(string nullString)
         {
-            var picker = new CommandLineObjectPicker(new []{nullString},RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new []{nullString}, GetActivator());
             Assert.IsTrue(picker[0].ExplicitNull);
         }
         [Test]
@@ -213,7 +213,7 @@ namespace Rdmp.Core.Tests.CommandLine
             cata1.Name = "Biochem";
             cata2.Name = "Haematology";
 
-            var picker = new CommandLineObjectPicker(new[] { $"c:*io*" }, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] { $"c:*io*" }, GetActivator());
 
             Assert.AreEqual(cata1, picker[0].DatabaseEntities[0]);
             Assert.AreEqual(1, picker[0].DatabaseEntities.Count);
@@ -225,7 +225,7 @@ namespace Rdmp.Core.Tests.CommandLine
             var cata1 = WhenIHaveA<Catalogue>();
             var cata2 = WhenIHaveA<Catalogue>();
 
-            var picker = new CommandLineObjectPicker(new[] { $"c:{cata1.ID},{cata2.ID}" }, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] { $"c:{cata1.ID},{cata2.ID}" }, GetActivator());
 
             Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
             Assert.Contains(cata1, picker[0].DatabaseEntities);
@@ -240,7 +240,7 @@ namespace Rdmp.Core.Tests.CommandLine
 
             // c is short for Catalogue 
             // so this would be the use case 'rdmp cmd list Catalogue' where user can instead write 'rdmp cmd list c'
-            var picker = new CommandLineObjectPicker(new[] { $"c" }, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] { $"c" }, GetActivator());
 
             Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
             Assert.Contains(cata1, picker[0].DatabaseEntities);
@@ -258,7 +258,7 @@ namespace Rdmp.Core.Tests.CommandLine
             var ci3 = WhenIHaveA<CatalogueItem>();
 
             var cataId = ci.Catalogue.ID;
-            var picker = new CommandLineObjectPicker(new[] { $"CatalogueItem?Catalogue_ID:{cataId}" }, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] { $"CatalogueItem?Catalogue_ID:{cataId}" }, GetActivator());
 
             Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
             Assert.Contains(ci, picker[0].DatabaseEntities);
@@ -277,7 +277,7 @@ namespace Rdmp.Core.Tests.CommandLine
             c2.Folder = new CatalogueFolder("\\datasets\\no\\");
             c3.Folder = new CatalogueFolder("\\datasets\\hi\\");
 
-            var picker = new CommandLineObjectPicker(new[] { $"Catalogue?Folder:*hi*" }, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] { $"Catalogue?Folder:*hi*" }, GetActivator());
 
             Assert.AreEqual(2, picker[0].DatabaseEntities.Count);
             Assert.Contains(c1, picker[0].DatabaseEntities);
@@ -294,7 +294,7 @@ namespace Rdmp.Core.Tests.CommandLine
             c1.PivotCategory_ExtractionInformation_ID = 10;
             c2.PivotCategory_ExtractionInformation_ID = null;
 
-            var picker = new CommandLineObjectPicker(new[] { $"Catalogue?PivotCategory_ExtractionInformation_ID:null" }, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new[] { $"Catalogue?PivotCategory_ExtractionInformation_ID:null" }, GetActivator());
 
             Assert.AreEqual(1, picker[0].DatabaseEntities.Count);
             Assert.Contains(c2, picker[0].DatabaseEntities);
@@ -302,7 +302,7 @@ namespace Rdmp.Core.Tests.CommandLine
         [Test]
         public void Test_PickWithPropertyQuery_UnknownProperty()
         {
-            var ex = Assert.Throws<Exception>(()=>new CommandLineObjectPicker(new[] { $"Catalogue?Blarg:null" }, RepositoryLocator));
+            var ex = Assert.Throws<Exception>(()=>new CommandLineObjectPicker(new[] { $"Catalogue?Blarg:null" }, GetActivator()));
             Assert.AreEqual("Unknown property 'Blarg'.  Did not exist on Type 'Catalogue'", ex.Message);
         }
     }

--- a/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/CommandLineObjectPickerTests.cs
@@ -12,6 +12,7 @@ using Rdmp.Core.CommandLine.Interactive.Picking;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Repositories;
 using Rdmp.Core.Repositories.Construction;
+using Rdmp.Core.Startup;
 using Tests.Common;
 
 namespace Rdmp.Core.Tests.CommandLine
@@ -161,16 +162,14 @@ namespace Rdmp.Core.Tests.CommandLine
         {
             var oc = new ObjectConstructor();
 
-            var mem = new MemoryDataExportRepository();
-            mem.CatalogueRepository.MEF = MEF;
+            var mem = RepositoryLocator.DataExportRepository;
 
             //create some objects that the examples can successfully reference
             new Catalogue(mem.CatalogueRepository, "mycata1"); //ID = 1
             new Catalogue(mem.CatalogueRepository, "mycata2"); //ID = 2
             new Catalogue(mem.CatalogueRepository, "mycata3"); //ID = 3
 
-
-            PickObjectBase picker = (PickObjectBase) oc.Construct(pickerType, new RepositoryProvider(mem));
+            PickObjectBase picker = (PickObjectBase) oc.Construct(pickerType, GetActivator());
 
             Assert.IsNotEmpty(picker.Help,"No Help for picker {0}",picker);
             Assert.IsNotEmpty(picker.Format,"No Format for picker {0}",picker);

--- a/Rdmp.Core.Tests/CommandLine/NewObjectPoolTests.cs
+++ b/Rdmp.Core.Tests/CommandLine/NewObjectPoolTests.cs
@@ -27,13 +27,13 @@ namespace Rdmp.Core.Tests.CommandLine
             var cata1 = new Catalogue(Repository,"Hey");
 
             // When there is only one object we can pick it by name
-            var picker = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+            var picker = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, GetActivator());
             Assert.IsTrue(picker.HasArgumentOfType(0, typeof(Catalogue)));
             Assert.AreEqual(cata1, picker.Arguments.First().GetValueForParameterOfType(typeof(Catalogue)));
 
             // But when there are 2 objects we don't know which to pick so cannot pick a Catalogue
             new Catalogue(Repository, "Hey");
-            var picker2 = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+            var picker2 = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, GetActivator());
             Assert.IsFalse(picker2.HasArgumentOfType(0, typeof(Catalogue)));
         }
 
@@ -47,13 +47,13 @@ namespace Rdmp.Core.Tests.CommandLine
                 var cata1 = new Catalogue(Repository, "Hey");
 
                 // When there is only one object we can pick it by name
-                var picker = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+                var picker = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, GetActivator());
                 Assert.IsTrue(picker.HasArgumentOfType(0, typeof(Catalogue)));
                 Assert.AreEqual(cata1, picker.Arguments.First().GetValueForParameterOfType(typeof(Catalogue)));
 
                 // There are now 2 objects with the same name but because we are in a session we can pick the latest
                 var cata2 = new Catalogue(Repository, "Hey");
-                var picker2 = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, RepositoryLocator);
+                var picker2 = new CommandLineObjectPicker(new string[] { "Catalogue:Hey" }, GetActivator());
 
                 Assert.IsTrue(picker2.HasArgumentOfType(0, typeof(Catalogue)));
                 Assert.AreEqual(cata2, picker2.Arguments.First().GetValueForParameterOfType(typeof(Catalogue)));

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribeCommand.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribeCommand.cs
@@ -40,7 +40,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
             var invoker = new CommandInvoker(BasicActivator);
 
-            var commandCtor = invoker.GetConstructor(_commandType, new CommandLineObjectPicker(new string[0],BasicActivator.RepositoryLocator));
+            var commandCtor = invoker.GetConstructor(_commandType, new CommandLineObjectPicker(new string[0],BasicActivator));
 
             var sb = new StringBuilder();
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSet.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSet.cs
@@ -73,7 +73,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             }
             else
             {
-                var picker = new CommandLineObjectPicker(new string[]{value ?? "NULL"},activator.RepositoryLocator);
+                var picker = new CommandLineObjectPicker(new string[]{value ?? "NULL"},activator);
 
                 if(!picker.HasArgumentOfType(0,_property.PropertyType))
                 {

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetUserSetting.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetUserSetting.cs
@@ -64,7 +64,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             }
             else
             {
-                var picker = new CommandLineObjectPicker(new string[]{value ?? "NULL"},activator.RepositoryLocator);
+                var picker = new CommandLineObjectPicker(new string[]{value ?? "NULL"},activator);
 
                 if(!picker.HasArgumentOfType(0,_property.PropertyType))
                 {

--- a/Rdmp.Core/CommandExecution/BasicActivateItems.cs
+++ b/Rdmp.Core/CommandExecution/BasicActivateItems.cs
@@ -124,10 +124,11 @@ namespace Rdmp.Core.CommandExecution
             //Shouldn't ever change externally to your session so doesn't need constantly refreshed
             FavouritesProvider = new FavouritesProvider(this);
 
+            // This has to happen before we create the child providers
+            ConstructPluginChildProviders();
+
             // Note that this is virtual so can return null e.g. if other stuff has to happen with the activator before a valid child provider can be built (e.g. loading plugin user interfaces)
             CoreChildProvider = GetChildProvider();
-
-            ConstructPluginChildProviders();
 
             //handle custom icons from plugin user interfaces in which
             CoreIconProvider = new DataExportIconProvider(repositoryLocator, PluginUserInterfaces.ToArray());

--- a/Rdmp.Core/CommandExecution/BasicActivateItems.cs
+++ b/Rdmp.Core/CommandExecution/BasicActivateItems.cs
@@ -773,5 +773,17 @@ namespace Rdmp.Core.CommandExecution
         /// <inheritdoc/>
         public abstract void ShowGraph(AggregateConfiguration aggregate);
 
+        public IRepository GetRepositoryFor(Type type)
+        {
+            foreach(var repo in RepositoryLocator.GetAllRepositories())
+            {
+                if(repo.SupportsObjectType(type))
+                {
+                    return repo;
+                }
+            }
+
+            throw new ArgumentException("Did not know what repository to use to fetch objects of Type '" + type + "'");
+        }
     }
 }

--- a/Rdmp.Core/CommandExecution/BasicActivateItems.cs
+++ b/Rdmp.Core/CommandExecution/BasicActivateItems.cs
@@ -773,6 +773,7 @@ namespace Rdmp.Core.CommandExecution
         /// <inheritdoc/>
         public abstract void ShowGraph(AggregateConfiguration aggregate);
 
+        /// <inheritdoc/>
         public IRepository GetRepositoryFor(Type type)
         {
             foreach(var repo in RepositoryLocator.GetAllRepositories())

--- a/Rdmp.Core/CommandExecution/CommandInvoker.cs
+++ b/Rdmp.Core/CommandExecution/CommandInvoker.cs
@@ -307,7 +307,7 @@ namespace Rdmp.Core.CommandExecution
 
             try
             {
-                var constructor = GetConstructor(t, new CommandLineObjectPicker(new string[0]{ },_repositoryLocator));
+                var constructor = GetConstructor(t, new CommandLineObjectPicker(new string[0]{ },_basicActivator));
 
                 if (constructor == null)
                     return false;

--- a/Rdmp.Core/CommandExecution/IBasicActivateItems.cs
+++ b/Rdmp.Core/CommandExecution/IBasicActivateItems.cs
@@ -94,6 +94,13 @@ namespace Rdmp.Core.CommandExecution
         /// </summary>
         /// <param name="collection"></param>
         void ShowData(IViewSQLAndResultsCollection collection);
+        
+        /// <summary>
+        /// Returns the repository that stores objects of the given <paramref name="type"/> (Must be <see cref="IMapsDirectlyToDatabaseTable"/>)
+        /// </summary>
+        /// <param name="type"></param>
+        /// <returns></returns>
+        IRepository GetRepositoryFor(Type type);
 
         /// <summary>
         /// Component for recording object tree inheritance (for RDMPCollectionUI primarily but also for anyone who wants to know children of objects or all objects quickly without having to go back to the database)

--- a/Rdmp.Core/CommandExecution/IBasicActivateItems.cs
+++ b/Rdmp.Core/CommandExecution/IBasicActivateItems.cs
@@ -96,10 +96,12 @@ namespace Rdmp.Core.CommandExecution
         void ShowData(IViewSQLAndResultsCollection collection);
         
         /// <summary>
-        /// Returns the repository that stores objects of the given <paramref name="type"/> (Must be <see cref="IMapsDirectlyToDatabaseTable"/>)
+        /// Returns the repository that stores objects of the given <paramref name="type"/> (Must be <see cref="IMapsDirectlyToDatabaseTable"/>).
+        /// Throws if no compatible repo is found.
         /// </summary>
         /// <param name="type"></param>
         /// <returns></returns>
+        /// <exception cref="ArgumentException">If no repositories are found that own the given <paramref name="type"/></exception>
         IRepository GetRepositoryFor(Type type);
 
         /// <summary>

--- a/Rdmp.Core/CommandLine/DatabaseCreation/PlatformDatabaseCreationRepositoryFinder.cs
+++ b/Rdmp.Core/CommandLine/DatabaseCreation/PlatformDatabaseCreationRepositoryFinder.cs
@@ -8,6 +8,7 @@ using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.Repositories;
 using Rdmp.Core.Startup;
 using System;
+using System.Collections.Generic;
 
 namespace Rdmp.Core.CommandLine.DatabaseCreation
 {
@@ -49,6 +50,11 @@ namespace Rdmp.Core.CommandLine.DatabaseCreation
         public IMapsDirectlyToDatabaseTable GetObjectByID(Type t, int value)
         {
             return _linkedRepositoryProvider.GetObjectByID(t,value);
+        }
+
+        public IEnumerable<IRepository> GetAllRepositories()
+        {
+            return _linkedRepositoryProvider.GetAllRepositories();
         }
 
         public PlatformDatabaseCreationRepositoryFinder(PlatformDatabaseCreationOptions options)

--- a/Rdmp.Core/CommandLine/Interactive/ConsoleInputManager.cs
+++ b/Rdmp.Core/CommandLine/Interactive/ConsoleInputManager.cs
@@ -135,7 +135,7 @@ namespace Rdmp.Core.CommandLine.Interactive
             WritePromptFor(args);
 
             var value = ReadLineWithAuto(new PickObjectBase[]
-                {new PickObjectByID(RepositoryLocator), new PickObjectByName(RepositoryLocator)},
+                {new PickObjectByID(this), new PickObjectByName(this)},
                 availableObjects.Select(t=>t.GetType().Name).Distinct());
             
             var unavailable = value.DatabaseEntities.Except(availableObjects).ToArray();
@@ -192,7 +192,7 @@ namespace Rdmp.Core.CommandLine.Interactive
             Console.Write(args.EntryLabel);
 
             var value = ReadLineWithAuto(new PickObjectBase[]
-                {new PickObjectByID(RepositoryLocator), new PickObjectByName(RepositoryLocator)},
+                {new PickObjectByID(this), new PickObjectByName(this)},
                 availableObjects.Select(t=>t.GetType().Name).Distinct());
 
             var chosen = value.DatabaseEntities?.SingleOrDefault();

--- a/Rdmp.Core/CommandLine/Interactive/Picking/CommandLineObjectPicker.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/CommandLineObjectPicker.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Collections.ObjectModel;
 using System.Linq;
+using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Repositories;
 
 namespace Rdmp.Core.CommandLine.Interactive.Picking
@@ -25,21 +26,21 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
         public int Length => Arguments.Count;
 
         private readonly HashSet<PickObjectBase> _pickers = new HashSet<PickObjectBase>();
-        
+
         /// <summary>
         /// Constructs a picker with all possible formats and immediately parse the provided <paramref name="args"/>
         /// </summary>
         /// <param name="args"></param>
-        /// <param name="repositoryLocator"></param>
+        /// <param name="activator"></param>
         public CommandLineObjectPicker(IEnumerable<string> args,
-            IRDMPPlatformRepositoryServiceLocator repositoryLocator)
+            IBasicActivateItems activator)
         {
-            _pickers.Add(new PickObjectByID(repositoryLocator));
-            _pickers.Add(new PickObjectByName(repositoryLocator));
-            _pickers.Add(new PickObjectByQuery(repositoryLocator));
+            _pickers.Add(new PickObjectByID(activator));
+            _pickers.Add(new PickObjectByName(activator));
+            _pickers.Add(new PickObjectByQuery(activator));
             _pickers.Add(new PickDatabase());
             _pickers.Add(new PickTable());
-            _pickers.Add(new PickType(repositoryLocator));
+            _pickers.Add(new PickType(activator));
             Arguments = new ReadOnlyCollection<CommandLineObjectPickerArgumentValue>(args.Select(ParseValue).ToList());
         }
 

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByID.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByID.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Repositories;
 
@@ -43,8 +44,8 @@ ID2+: (optional) only allowed if you are being prompted for multiple objects, al
             return baseMatch && IsDatabaseObjectType(Regex.Match(arg).Groups[1].Value, out _);
         }
 
-        public PickObjectByID(IRDMPPlatformRepositoryServiceLocator repositoryLocator)
-            :base(repositoryLocator,
+        public PickObjectByID(IBasicActivateItems activator)
+            :base(activator,
                 new Regex("^([A-Za-z]+):([0-9,]+)$",RegexOptions.IgnoreCase))
         {
                 

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByName.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByName.cs
@@ -9,6 +9,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Text.RegularExpressions;
 using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Providers;
 using Rdmp.Core.Repositories;
@@ -32,8 +33,8 @@ NamePattern2+: (optional) only allowed if you are being prompted for multiple ob
             "Catalogue:mycata1,mycata2"
         };
 
-        public PickObjectByName(IRDMPPlatformRepositoryServiceLocator repositoryLocator) :
-            base(repositoryLocator,
+        public PickObjectByName(IBasicActivateItems activator) :
+            base(activator,
             new Regex(@"^([A-Za-z]+):([^:]+)$",RegexOptions.IgnoreCase))
         {
         }

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickObjectByQuery.cs
@@ -10,6 +10,7 @@ using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
 using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Providers;
 using Rdmp.Core.Repositories;
@@ -33,8 +34,8 @@ NamePattern: must be a value that could appear for the given Property.  Comparis
             "Catalogue?Folder:*edris*"
         };
 
-        public PickObjectByQuery(IRDMPPlatformRepositoryServiceLocator repositoryLocator) :
-            base(repositoryLocator,
+        public PickObjectByQuery(IBasicActivateItems activator) :
+            base(activator,
             new Regex(@"^(\w+)\?(\w+):([^:]+)$", RegexOptions.IgnoreCase))
         {
         }

--- a/Rdmp.Core/CommandLine/Interactive/Picking/PickType.cs
+++ b/Rdmp.Core/CommandLine/Interactive/Picking/PickType.cs
@@ -15,7 +15,7 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
 {
     class PickType : PickObjectBase
     {
-        public PickType(IRDMPPlatformRepositoryServiceLocator repositoryLocator) : base(repositoryLocator, new Regex(".*"))
+        public PickType(IBasicActivateItems activator) : base(activator, new Regex(".*"))
         {
         }
 
@@ -40,10 +40,10 @@ namespace Rdmp.Core.CommandLine.Interactive.Picking
 
             try
             {
-                return 
-                    RepositoryLocator.CatalogueRepository.MEF.GetType(BasicCommandExecution.ExecuteCommandPrefix + arg)
+                return
+                    Activator.RepositoryLocator.CatalogueRepository.MEF.GetType(BasicCommandExecution.ExecuteCommandPrefix + arg)
                     ??
-                    RepositoryLocator.CatalogueRepository.MEF.GetType(arg);
+                    Activator.RepositoryLocator.CatalogueRepository.MEF.GetType(arg);
             }
             catch (Exception)
             {

--- a/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
@@ -54,7 +54,7 @@ namespace Rdmp.Core.CommandLine.Runners
 
             _picker = 
                 _options.CommandArgs != null && _options.CommandArgs.Any() ?
-                 new CommandLineObjectPicker(_options.CommandArgs, repositoryLocator) :
+                 new CommandLineObjectPicker(_options.CommandArgs, _input) :
                 null;
             
             if(!string.IsNullOrWhiteSpace(_options.File) && _options.Script == null)
@@ -136,7 +136,7 @@ namespace Rdmp.Core.CommandLine.Runners
         {    
             if (command.Contains(' '))
             {
-                picker = new CommandLineObjectPicker(SplitCommandLine(command).Skip(1).ToArray(),repositoryLocator);
+                picker = new CommandLineObjectPicker(SplitCommandLine(command).Skip(1).ToArray(),_input);
                 return command.Substring(0, command.IndexOf(' '));
             }
 

--- a/Rdmp.Core/Curation/Data/Pipelines/PipelineUseCase.cs
+++ b/Rdmp.Core/Curation/Data/Pipelines/PipelineUseCase.cs
@@ -125,6 +125,11 @@ namespace Rdmp.Core.Curation.Data.Pipelines
                 foreach (var component in pipeline.PipelineComponents)
                 {
                     var type = component.GetClassAsSystemType();
+                    if(type == null)
+                    {
+                        return false;
+                    }
+
                     var advert = new AdvertisedPipelineComponentTypeUnderContext(type, this);
                     if (!advert.IsCompatible())
                     {

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -228,7 +228,7 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
                 throw new Exception("Data read cancelled because our cancellationToken was set, aborting data reading");
             
             //if the first chunk is null
-            if (firstChunk && chunk == null)
+            if (firstChunk && chunk == null && !AllowEmptyExtractions)
                 throw new Exception("There is no data to load, query returned no rows, query was:" + Environment.NewLine + 
                                     (_hostedSource.Sql??Request.QueryBuilder.SQL));
             

--- a/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
+++ b/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
@@ -75,7 +75,7 @@ namespace Rdmp.Core.DataLoad.Engine.Pipeline.Sources
             {
                 DataTable chunk = GetChunkSchema(_reader);
                 
-                while (_reader.Read())
+                while (_reader.HasRows && _reader.Read())
                 {
                     cancellationToken.ThrowIfCancellationRequested();
 

--- a/Rdmp.Core/Providers/CatalogueChildProvider.cs
+++ b/Rdmp.Core/Providers/CatalogueChildProvider.cs
@@ -177,7 +177,7 @@ namespace Rdmp.Core.Providers
         private IChildProvider[] _pluginChildProviders;
         private readonly ICatalogueRepository _catalogueRepository;
         private readonly ICheckNotifier _errorsCheckNotifier;
-        private readonly List<IChildProvider> _blacklistedPlugins = new List<IChildProvider>();
+        private readonly List<IChildProvider> _blockedPlugins = new List<IChildProvider>();
 
         public AllGovernanceNode AllGovernanceNode { get; private set; }
         public GovernancePeriod[] AllGovernancePeriods { get; private set; }
@@ -226,7 +226,7 @@ namespace Rdmp.Core.Providers
             // all the objects which are 
             AllMasqueraders = new ConcurrentDictionary<object, HashSet<IMasqueradeAs>>();
             
-            _pluginChildProviders = pluginChildProviders;
+            _pluginChildProviders = pluginChildProviders ?? new IChildProvider[0];
             
             ReportProgress("Before object fetches");
 
@@ -1456,7 +1456,7 @@ namespace Rdmp.Core.Providers
             
                 Stopwatch sw = new Stopwatch();
 
-                var providers = _pluginChildProviders.Except(_blacklistedPlugins).ToArray();
+                var providers = _pluginChildProviders.Except(_blockedPlugins).ToArray();
 
                 //for every object found so far
                 if(providers.Any())
@@ -1475,7 +1475,7 @@ namespace Rdmp.Core.Providers
                                 //if the plugin takes too long to respond we need to stop
                                 if (sw.ElapsedMilliseconds > 1000)
                                 {
-                                    _blacklistedPlugins.Add(plugin);
+                                    _blockedPlugins.Add(plugin);
                                     throw new Exception("Plugin '" + plugin + "' was blacklisted for taking too long to respond to GetChildren(o) where o was a '" + o.GetType().Name + "' ('" + o + "')");
                                 }
 

--- a/Rdmp.Core/Providers/DataExportChildProvider.cs
+++ b/Rdmp.Core/Providers/DataExportChildProvider.cs
@@ -230,6 +230,8 @@ namespace Rdmp.Core.Providers
             }
 
             ReportProgress("Pipeline adding");
+
+            GetPluginChildren();
         }
 
         private void AddChildren(IExtractableDataSetPackage package, DescendancyList descendancy)

--- a/Rdmp.Core/Repositories/IRDMPPlatformRepositoryServiceLocator.cs
+++ b/Rdmp.Core/Repositories/IRDMPPlatformRepositoryServiceLocator.cs
@@ -8,6 +8,7 @@ using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.DataQualityEngine.Data;
 using Rdmp.Core.Providers;
 using System;
+using System.Collections.Generic;
 
 namespace Rdmp.Core.Repositories
 {
@@ -47,5 +48,12 @@ namespace Rdmp.Core.Repositories
         /// <param name="value"></param>
         /// <returns></returns>
         IMapsDirectlyToDatabaseTable GetObjectByID(Type t,int value);
+
+        /// <summary>
+        /// Returns all repositories (including plugin repositories if supported) known about by this
+        /// repository locator.
+        /// </summary>
+        /// <returns></returns>
+        IEnumerable<IRepository> GetAllRepositories();
     }
 }

--- a/Rdmp.Core/Repositories/RepositoryProvider.cs
+++ b/Rdmp.Core/Repositories/RepositoryProvider.cs
@@ -121,5 +121,12 @@ namespace Rdmp.Core.Repositories
             else
                 throw new ArgumentException("Did not know what repository to use to fetch objects of Type '" + t + "'");
         }
+        public virtual IEnumerable<IRepository> GetAllRepositories()
+        {
+            yield return CatalogueRepository;
+
+            if(DataExportRepository != null)
+                yield return DataExportRepository;
+        }
     }
 }

--- a/Rdmp.Core/Startup/LinkedRepositoryProvider.cs
+++ b/Rdmp.Core/Startup/LinkedRepositoryProvider.cs
@@ -27,6 +27,7 @@ namespace Rdmp.Core.Startup
     {
         private List<IPluginRepositoryFinder> _pluginRepositoryFinders = null;
 
+
         public LinkedRepositoryProvider(string catalogueConnectionString, string dataExportConnectionString)
         {
             try
@@ -109,6 +110,23 @@ namespace Rdmp.Core.Startup
             //it's a plugin?
             foreach (Type type in CatalogueRepository.MEF.GetTypes<IPluginRepositoryFinder>())
                 _pluginRepositoryFinders.Add((IPluginRepositoryFinder)constructor.Construct(type, this));
+        }
+
+        public override IEnumerable<IRepository> GetAllRepositories()
+        {
+            LoadPluginRepositoryFindersIfNotLoaded();
+
+            yield return CatalogueRepository;
+
+            if(DataExportRepository != null)
+                yield return DataExportRepository;
+
+            foreach(var p in _pluginRepositoryFinders)
+            {
+                var r = p.GetRepositoryIfAny();
+                if (r != null)
+                    yield return r;
+            }
         }
     }
 }

--- a/Rdmp.Core/Startup/UserSettingsRepositoryFinder.cs
+++ b/Rdmp.Core/Startup/UserSettingsRepositoryFinder.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.Repositories;
 using ReusableLibraryCode.Comments;
@@ -120,6 +121,11 @@ namespace Rdmp.Core.Startup
         public IMapsDirectlyToDatabaseTable GetObjectByID(Type t, int value)
         {
             return _linkedRepositoryProvider.GetObjectByID(t,value);
+        }
+
+        public IEnumerable<IRepository> GetAllRepositories()
+        {
+            return _linkedRepositoryProvider.GetAllRepositories();
         }
     }
 }

--- a/Rdmp.UI.Tests/DesignPatternTests/ClassFileEvaluation/DocumentationCrossExaminationTest.cs
+++ b/Rdmp.UI.Tests/DesignPatternTests/ClassFileEvaluation/DocumentationCrossExaminationTest.cs
@@ -260,6 +260,7 @@ namespace Rdmp.UI.Tests.DesignPatternTests.ClassFileEvaluation
             "MyPluginUI",
             "SelectIMapsDirectlyToDatabaseTableDialog",
             "NuGet",
+            "MyPluginClass",
         };
         #endregion
         public DocumentationCrossExaminationTest(DirectoryInfo slndir)

--- a/Tests.Common/UnitTests.cs
+++ b/Tests.Common/UnitTests.cs
@@ -71,12 +71,13 @@ namespace Tests.Common
 
         /// <summary>
         /// Returns an <see cref="IBasicActivateItems"/> based on the <see cref="RepositoryLocator"/>
-        /// that throws if input is sought (e.g. <see cref="IBasicActivateItems.YesNo(DialogArgs)"/>)
+        /// (or <paramref name="locator"/> if specified) that throws if input is sought (e.g.
+        /// <see cref="IBasicActivateItems.YesNo(DialogArgs)"/>)
         /// </summary>
         /// <returns></returns>
-        protected IBasicActivateItems GetActivator()
+        protected IBasicActivateItems GetActivator(IRDMPPlatformRepositoryServiceLocator locator = null)
         {
-            return new ConsoleInputManager(RepositoryLocator, new ThrowImmediatelyCheckNotifier()) { DisallowInput = true};
+            return new ConsoleInputManager(locator ?? RepositoryLocator, new ThrowImmediatelyCheckNotifier()) { DisallowInput = true};
         }
 
         /// <summary>

--- a/Tests.Common/UnitTests.cs
+++ b/Tests.Common/UnitTests.cs
@@ -18,6 +18,8 @@ using FAnsi.Implementations.Oracle;
 using FAnsi.Implementations.PostgreSql;
 using MapsDirectlyToDatabaseTable;
 using NUnit.Framework;
+using Rdmp.Core.CommandExecution;
+using Rdmp.Core.CommandLine.Interactive;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Curation.Data.Aggregation;
 using Rdmp.Core.Curation.Data.Cache;
@@ -67,6 +69,15 @@ namespace Tests.Common
             RepositoryLocator = new RepositoryProvider(Repository);
         }
 
+        /// <summary>
+        /// Returns an <see cref="IBasicActivateItems"/> based on the <see cref="RepositoryLocator"/>
+        /// that throws if input is sought (e.g. <see cref="IBasicActivateItems.YesNo(DialogArgs)"/>)
+        /// </summary>
+        /// <returns></returns>
+        protected IBasicActivateItems GetActivator()
+        {
+            return new ConsoleInputManager(RepositoryLocator, new ThrowImmediatelyCheckNotifier()) { DisallowInput = true};
+        }
 
         /// <summary>
         /// Override to do stuff before your first instance is constructed


### PR DESCRIPTION
Allows for commands like `./rdmp.exe cmd delete MyPluginClass:2`

Also fixes the fact that we seem to have lost plugin children provider support

