### PR TITLE
ViewLogs sort order now persists

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -21,11 +21,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug with AllowEmptyExtractions not working under some situations
 - Fixed [Lookup] creation UI creating CatalogueItem with the suffix _Desc even when you ask it not to in prompt
 - Fixed layout bug in rule validation configuration UI where rationale tip was cut off [#909](https://github.com/HicServices/RDMP/issues/909)
+- Fixed ViewLogs tab not remembering sort order between usages [#902](https://github.com/HicServices/RDMP/issues/902)
 
 ### Changed
 
 - Find sorts ties firstly by favourite status (favourite items appear above others)
 - Find sorts ties lastly alphabetically (previously by order of ID)
+- Default sort order of ViewLogs on first time use is now date order descending [#902](https://github.com/HicServices/RDMP/issues/902)
 
 ## [7.0.6] - 2022-01-25
 

--- a/Rdmp.UI/CatalogueSummary/LoadEvents/LoadEventsTreeView.cs
+++ b/Rdmp.UI/CatalogueSummary/LoadEvents/LoadEventsTreeView.cs
@@ -182,13 +182,13 @@ namespace Rdmp.UI.CatalogueSummary.LoadEvents
             {
 
                 if(dli.Errors.Any())
-                    children.Add(new LoadEventsTreeView_Category("Errors", dli.Errors.ToArray(), LoggingTables.FatalError, dli.ID));
+                    children.Add(new LoadEventsTreeView_Category("Errors", dli.Errors.OrderByDescending(d=>d.Date).ToArray(), LoggingTables.FatalError, dli.ID));
 
                 if(dli.Progress.Any())
-                    children.Add(new LoadEventsTreeView_Category("Progress Messages", dli.Progress.ToArray(),LoggingTables.ProgressLog, dli.ID));
+                    children.Add(new LoadEventsTreeView_Category("Progress Messages", dli.Progress.OrderByDescending(d => d.Date).ToArray(),LoggingTables.ProgressLog, dli.ID));
 
                 if(dli.TableLoadInfos.Any())
-                    children.Add(new LoadEventsTreeView_Category("Tables Loaded", dli.TableLoadInfos.ToArray(),LoggingTables.TableLoadRun, dli.ID));
+                    children.Add(new LoadEventsTreeView_Category("Tables Loaded", dli.TableLoadInfos.OrderByDescending(d => d.Start).ToArray(),LoggingTables.TableLoadRun, dli.ID));
             }
 
             var category = model as LoadEventsTreeView_Category;
@@ -452,7 +452,9 @@ namespace Rdmp.UI.CatalogueSummary.LoadEvents
             SetItemActivator(activator);
 
             Collection = (LoadEventsTreeViewObjectCollection)collection;
-            
+
+            RDMPCollectionCommonFunctionality.SetupColumnSortTracking(treeView1, new Guid("ccbea22e-a784-4968-a127-7c3a55b6d281"));
+
             CommonFunctionality.ClearToolStrip();
 
             CommonFunctionality.Add(new ToolStripLabel("Filter:"));

--- a/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
+++ b/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
@@ -125,25 +125,23 @@ namespace Rdmp.UI.Collections
 
         public static void SetupColumnSortTracking(ObjectListView tree, Guid collectionGuid)
         {
-            if (tree.PrimarySortColumn == null)
-                tree.PrimarySortColumn = tree.AllColumns.FirstOrDefault(c => c.IsVisible && c.Sortable);
+            tree.PrimarySortColumn ??= tree.AllColumns.FirstOrDefault(c => c.IsVisible && c.Sortable);
 
             //persist user sort orders
-            if (collectionGuid != Guid.Empty)
+            if (collectionGuid == Guid.Empty) return;
+            
+            //if we know the sort order for this collection last time
+            var lastSort = UserSettings.GetLastColumnSortForCollection(collectionGuid);
+
+            //reestablish that sort order
+            if (lastSort != null && tree.AllColumns.Any(c => c.Text == lastSort.Item1))
             {
-                //if we know the sort order fo this collection last time
-                var lastSort = UserSettings.GetLastColumnSortForCollection(collectionGuid);
-
-                //reestablish that sort order
-                if (lastSort != null && tree.AllColumns.Any(c => c.Text == lastSort.Item1))
-                {
-                    tree.PrimarySortColumn = tree.GetColumn(lastSort.Item1);
-                    tree.PrimarySortOrder = lastSort.Item2 ? SortOrder.Ascending : SortOrder.Descending;
-                }
-
-                //and track changes to the sort order
-                tree.AfterSorting += (s,e)=>TreeOnAfterSorting(s,e, collectionGuid);
+                tree.PrimarySortColumn = tree.GetColumn(lastSort.Item1);
+                tree.PrimarySortOrder = lastSort.Item2 ? SortOrder.Ascending : SortOrder.Descending;
             }
+
+            //and track changes to the sort order
+            tree.AfterSorting += (s, e) => TreeOnAfterSorting(s, e, collectionGuid);
         }
 
         /// <summary>

--- a/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
+++ b/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
@@ -122,6 +122,30 @@ namespace Rdmp.UI.Collections
 
             view.RebuildColumns();
         }
+
+        public static void SetupColumnSortTracking(ObjectListView tree, Guid collectionGuid)
+        {
+            if (tree.PrimarySortColumn == null)
+                tree.PrimarySortColumn = tree.AllColumns.FirstOrDefault(c => c.IsVisible && c.Sortable);
+
+            //persist user sort orders
+            if (collectionGuid != Guid.Empty)
+            {
+                //if we know the sort order fo this collection last time
+                var lastSort = UserSettings.GetLastColumnSortForCollection(collectionGuid);
+
+                //reestablish that sort order
+                if (lastSort != null && tree.AllColumns.Any(c => c.Text == lastSort.Item1))
+                {
+                    tree.PrimarySortColumn = tree.GetColumn(lastSort.Item1);
+                    tree.PrimarySortOrder = lastSort.Item2 ? SortOrder.Ascending : SortOrder.Descending;
+                }
+
+                //and track changes to the sort order
+                tree.AfterSorting += (s,e)=>TreeOnAfterSorting(s,e, collectionGuid);
+            }
+        }
+
         /// <summary>
         /// Sets up common functionality for an RDMPCollectionUI with the default settings
         /// </summary>
@@ -249,25 +273,7 @@ namespace Rdmp.UI.Collections
 
             if(Settings.AllowSorting)
             {
-                if (Tree.PrimarySortColumn == null)
-                    Tree.PrimarySortColumn = Tree.AllColumns.FirstOrDefault(c => c.IsVisible && c.Sortable);
-
-                //persist user sort orders
-                if (TreeGuids.ContainsKey(_collection))
-                {
-                    //if we know the sort order fo this collection last time
-                    var lastSort = UserSettings.GetLastColumnSortForCollection(TreeGuids[_collection]);
-
-                    //reestablish that sort order
-                    if (lastSort != null && Tree.AllColumns.Any(c => c.Text == lastSort.Item1))
-                    {
-                        Tree.PrimarySortColumn = Tree.GetColumn(lastSort.Item1);
-                        Tree.PrimarySortOrder = lastSort.Item2 ? SortOrder.Ascending : SortOrder.Descending;
-                    }
-
-                    //and track changes to the sort order
-                    Tree.AfterSorting += TreeOnAfterSorting;
-                }
+                SetupColumnSortTracking(Tree, TreeGuids.ContainsKey(collection) ? TreeGuids[collection] : Guid.Empty);
             }
             else
                 foreach (OLVColumn c in Tree.AllColumns)
@@ -334,10 +340,9 @@ namespace Rdmp.UI.Collections
                 e.Handled = true;
         }
 
-        private void TreeOnAfterSorting(object sender, AfterSortingEventArgs e)
+        private static void TreeOnAfterSorting(object sender, AfterSortingEventArgs e, Guid collectionGuid)
         {
-            if (TreeGuids.ContainsKey(_collection))
-                UserSettings.SetLastColumnSortForCollection(TreeGuids[_collection], e.ColumnToSort == null ? null:e.ColumnToSort.Text, e.SortOrder == SortOrder.Ascending);
+            UserSettings.SetLastColumnSortForCollection(collectionGuid, e.ColumnToSort == null ? null:e.ColumnToSort.Text, e.SortOrder == SortOrder.Ascending);
         }
 
         private void CreateColorIndicator(TreeListView tree, RDMPCollection collection)


### PR DESCRIPTION
Also now has consistent default sort order for first time use
Fixes #902