### PR TITLE
Added resizing logic for dialogue box based on the height of the description label

### DIFF
--- a/Rdmp.UI/SimpleDialogs/TaskDescriptionLabel.cs
+++ b/Rdmp.UI/SimpleDialogs/TaskDescriptionLabel.cs
@@ -74,6 +74,7 @@ namespace Rdmp.UI.SimpleDialogs
         /// Returns the width this control would ideally like to take up
         /// </summary>
         public int PreferredWidth => Math.Max(tbEntryLabel.Width, tbTaskDescription.Width);
+        public int PreferredHeight => this.Height;
 
         private void textBox1_Resize(object sender, EventArgs e)
         {

--- a/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.Designer.cs
+++ b/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.Designer.cs
@@ -111,6 +111,7 @@
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
+            this.AutoSize = true;
             this.ClientSize = new System.Drawing.Size(739, 131);
             this.Controls.Add(this.pTextEditor);
             this.Controls.Add(this.panel1);
@@ -120,6 +121,7 @@
             this.Name = "TypeTextOrCancelDialog";
             this.StartPosition = System.Windows.Forms.FormStartPosition.CenterScreen;
             this.Text = "Input";
+            this.Resize += new System.EventHandler(this.TypeTextOrCancelDialog_Resize);
             this.panel1.ResumeLayout(false);
             this.pTextEditor.ResumeLayout(false);
             this.pTextEditor.PerformLayout();

--- a/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.cs
@@ -80,7 +80,6 @@ namespace Rdmp.UI.SimpleDialogs
 
                 this.textBox1.Anchor = (AnchorStyles.Top | AnchorStyles.Bottom | AnchorStyles.Left | AnchorStyles.Right);
                 this.textBox1.ScrollBars = ScrollBars.Vertical;
-                this.Height = 290;
                 this.Width = 740;
 
                 //Update the tooltip for the OK button
@@ -167,6 +166,19 @@ namespace Rdmp.UI.SimpleDialogs
             if (e.KeyCode == Keys.Escape)
              btnCancel_Click(null, null);
 
+        }
+
+        private void TypeTextOrCancelDialog_Resize(object sender, EventArgs e)
+        {
+            // Set the height by taking the designer height and adding on the height that the task description label wants to be
+            if (_multiline)
+            {
+                this.Height = taskDescriptionLabel1.PreferredHeight + 220;
+            }
+            else
+            {
+                this.Height = taskDescriptionLabel1.PreferredHeight + 100;
+            }
         }
     }
 }


### PR DESCRIPTION
Fixes #911

Fixed for single line:
![image](https://user-images.githubusercontent.com/5470814/155752672-e007ee69-a213-46c2-9f62-7f3ed0987039.png)

![image](https://user-images.githubusercontent.com/5470814/155752709-2f089478-d374-4e67-b1f6-0892a04d3617.png)

![image](https://user-images.githubusercontent.com/5470814/155752740-98b37c5c-9782-40bf-9f8f-de7739fb2a22.png)

![image](https://user-images.githubusercontent.com/5470814/155756001-cfe2a914-91d0-483c-b354-329262ad3fec.png)

Also made multiline resize better (it used to only take up a maximum of 240px tall meaning the had a similar problem for much larger descriptions)

![image](https://user-images.githubusercontent.com/5470814/155756386-2fba12d7-ba26-48e0-a90c-0eb71cc729c1.png)

![image](https://user-images.githubusercontent.com/5470814/155756426-5ea499fe-863b-45df-8e49-53a75431bf4b.png)
