### PR TITLE
Ability to select multiple objects at once when adding to a Session

### DIFF
--- a/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.Designer.cs
+++ b/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.Designer.cs
@@ -72,6 +72,7 @@ namespace ResearchDataManagementPlatform.Menus
             this.queryCatalogue = new System.Windows.Forms.ToolStripMenuItem();
             this.queryDataExport = new System.Windows.Forms.ToolStripMenuItem();
             this.restartApplicationToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.terminateProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.helpToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.userManualToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.generateClassTableSummaryToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
@@ -80,7 +81,7 @@ namespace ResearchDataManagementPlatform.Menus
             this.licenseToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.checkForUpdatesToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.rdmpTaskBar1 = new ResearchDataManagementPlatform.WindowManagement.TopBar.RDMPTaskBarUI();
-            this.terminateProcessToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
+            this.findMultipleToolStripMenuItem = new System.Windows.Forms.ToolStripMenuItem();
             this.menuStrip1.SuspendLayout();
             this.SuspendLayout();
             // 
@@ -108,6 +109,7 @@ namespace ResearchDataManagementPlatform.Menus
             this.runToolStripMenuItem,
             this.openToolStripMenuItem,
             this.findToolStripMenuItem,
+            this.findMultipleToolStripMenuItem,
             this.findAndReplaceToolStripMenuItem,
             this.closeToolStripMenuItem,
             this.quitToolStripMenuItem});
@@ -119,14 +121,14 @@ namespace ResearchDataManagementPlatform.Menus
             // 
             this.newToolStripMenuItem.Name = "newToolStripMenuItem";
             this.newToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.N)));
-            this.newToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.newToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.newToolStripMenuItem.Text = "New...";
             this.newToolStripMenuItem.Click += new System.EventHandler(this.NewToolStripMenuItem_Click);
             // 
             // newSessionToolStripMenuItem
             // 
             this.newSessionToolStripMenuItem.Name = "newSessionToolStripMenuItem";
-            this.newSessionToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.newSessionToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.newSessionToolStripMenuItem.Text = "New Session";
             this.newSessionToolStripMenuItem.Click += new System.EventHandler(this.newSessionToolStripMenuItem_Click);
             // 
@@ -134,7 +136,7 @@ namespace ResearchDataManagementPlatform.Menus
             // 
             this.runToolStripMenuItem.Name = "runToolStripMenuItem";
             this.runToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.R)));
-            this.runToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.runToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.runToolStripMenuItem.Text = "Run...";
             this.runToolStripMenuItem.Click += new System.EventHandler(this.runToolStripMenuItem_Click);
             // 
@@ -142,7 +144,7 @@ namespace ResearchDataManagementPlatform.Menus
             // 
             this.openToolStripMenuItem.Name = "openToolStripMenuItem";
             this.openToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.O)));
-            this.openToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.openToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.openToolStripMenuItem.Text = "Open...";
             this.openToolStripMenuItem.Click += new System.EventHandler(this.openToolStripMenuItem_Click);
             // 
@@ -150,7 +152,7 @@ namespace ResearchDataManagementPlatform.Menus
             // 
             this.findToolStripMenuItem.Name = "findToolStripMenuItem";
             this.findToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.F)));
-            this.findToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.findToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.findToolStripMenuItem.Text = "Find";
             this.findToolStripMenuItem.Click += new System.EventHandler(this.findToolStripMenuItem_Click);
             // 
@@ -158,7 +160,7 @@ namespace ResearchDataManagementPlatform.Menus
             // 
             this.findAndReplaceToolStripMenuItem.Name = "findAndReplaceToolStripMenuItem";
             this.findAndReplaceToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.H)));
-            this.findAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.findAndReplaceToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.findAndReplaceToolStripMenuItem.Text = "Find and Replace";
             this.findAndReplaceToolStripMenuItem.Click += new System.EventHandler(this.findAndReplaceToolStripMenuItem_Click);
             // 
@@ -166,14 +168,14 @@ namespace ResearchDataManagementPlatform.Menus
             // 
             this.closeToolStripMenuItem.Name = "closeToolStripMenuItem";
             this.closeToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.W)));
-            this.closeToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.closeToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.closeToolStripMenuItem.Text = "Close";
             this.closeToolStripMenuItem.Click += new System.EventHandler(this.closeToolStripMenuItem_Click);
             // 
             // quitToolStripMenuItem
             // 
             this.quitToolStripMenuItem.Name = "quitToolStripMenuItem";
-            this.quitToolStripMenuItem.Size = new System.Drawing.Size(207, 22);
+            this.quitToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
             this.quitToolStripMenuItem.Text = "Quit";
             this.quitToolStripMenuItem.Click += new System.EventHandler(this.quitToolStripMenuItem_Click);
             // 
@@ -429,6 +431,13 @@ namespace ResearchDataManagementPlatform.Menus
             this.restartApplicationToolStripMenuItem.Text = "Restart Application";
             this.restartApplicationToolStripMenuItem.Click += new System.EventHandler(this.restartApplicationToolStripMenuItem_Click);
             // 
+            // terminateProcessToolStripMenuItem
+            // 
+            this.terminateProcessToolStripMenuItem.Name = "terminateProcessToolStripMenuItem";
+            this.terminateProcessToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
+            this.terminateProcessToolStripMenuItem.Text = "Terminate Process";
+            this.terminateProcessToolStripMenuItem.Click += new System.EventHandler(this.terminateProcessToolStripMenuItem_Click);
+            // 
             // helpToolStripMenuItem
             // 
             this.helpToolStripMenuItem.DropDownItems.AddRange(new System.Windows.Forms.ToolStripItem[] {
@@ -494,12 +503,14 @@ namespace ResearchDataManagementPlatform.Menus
             this.rdmpTaskBar1.Size = new System.Drawing.Size(1353, 29);
             this.rdmpTaskBar1.TabIndex = 57;
             // 
-            // terminateProcessToolStripMenuItem
+            // findMultipleToolStripMenuItem
             // 
-            this.terminateProcessToolStripMenuItem.Name = "terminateProcessToolStripMenuItem";
-            this.terminateProcessToolStripMenuItem.Size = new System.Drawing.Size(229, 22);
-            this.terminateProcessToolStripMenuItem.Text = "Terminate Process";
-            this.terminateProcessToolStripMenuItem.Click += new System.EventHandler(this.terminateProcessToolStripMenuItem_Click);
+            this.findMultipleToolStripMenuItem.Name = "findMultipleToolStripMenuItem";
+            this.findMultipleToolStripMenuItem.ShortcutKeys = ((System.Windows.Forms.Keys)(((System.Windows.Forms.Keys.Control | System.Windows.Forms.Keys.Shift) 
+            | System.Windows.Forms.Keys.F)));
+            this.findMultipleToolStripMenuItem.Size = new System.Drawing.Size(216, 22);
+            this.findMultipleToolStripMenuItem.Text = "Find Multiple";
+            this.findMultipleToolStripMenuItem.Click += new System.EventHandler(this.findMultipleToolStripMenuItem_Click);
             // 
             // RDMPTopMenuStripUI
             // 
@@ -569,5 +580,6 @@ namespace ResearchDataManagementPlatform.Menus
         private System.Windows.Forms.ToolStripMenuItem switchToInstanceToolStripMenuItem;
         private System.Windows.Forms.ToolStripMenuItem switchToDefaultSettings;
         private System.Windows.Forms.ToolStripMenuItem terminateProcessToolStripMenuItem;
+        private System.Windows.Forms.ToolStripMenuItem findMultipleToolStripMenuItem;
     }
 }

--- a/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
+++ b/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
@@ -422,7 +422,7 @@ namespace ResearchDataManagementPlatform.Menus
 
         private void openToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var navigate = new NavigateToObjectUI(Activator);
+            var navigate = new NavigateToObjectUI(Activator, addFindMultiple: true);
             navigate.Text = "Open";
             navigate.CompletionAction = (o) => Activator.WindowArranger.SetupEditAnything(this, o);
             navigate.Show();
@@ -432,7 +432,7 @@ namespace ResearchDataManagementPlatform.Menus
         {
             var visibleCollection = _windowManager.GetFocusedCollection();
 
-            new NavigateToObjectUI(Activator, null, visibleCollection).Show();
+            new NavigateToObjectUI(Activator, null, visibleCollection, addFindMultiple: true).Show();
         }
 
         private void closeToolStripMenuItem_Click(object sender, EventArgs e)
@@ -558,21 +558,7 @@ namespace ResearchDataManagementPlatform.Menus
 
         private void findMultipleToolStripMenuItem_Click(object sender, EventArgs e)
         {
-
-            var sessions = Activator.GetSessions().ToArray();
-
-            string name = "Find Results";
-
-            int i = 1;
-
-            while(sessions.Any(s=>s.Collection.SessionName.Equals(name)))
-            {
-                i++;
-                name = "Find Results " + i;
-            }
-
-
-            var cmd = new ExecuteCommandStartSession(Activator, null, name);
+            var cmd = new ExecuteCommandStartSession(Activator, null, ExecuteCommandStartSession.FindResultsTitle);
             cmd.Execute();
         }
     }

--- a/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
+++ b/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
@@ -506,7 +506,7 @@ namespace ResearchDataManagementPlatform.Menus
 
         private void newSessionToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            var cmd = new ExecuteCommandStartSession(Activator,null);
+            var cmd = new ExecuteCommandStartSession(Activator,null,null);
             cmd.Execute();
         }
 
@@ -554,6 +554,26 @@ namespace ResearchDataManagementPlatform.Menus
             {
                 Process.GetCurrentProcess().Kill();
             }   
+        }
+
+        private void findMultipleToolStripMenuItem_Click(object sender, EventArgs e)
+        {
+
+            var sessions = Activator.GetSessions().ToArray();
+
+            string name = "Find Results";
+
+            int i = 1;
+
+            while(sessions.Any(s=>s.Collection.SessionName.Equals(name)))
+            {
+                i++;
+                name = "Find Results " + i;
+            }
+
+
+            var cmd = new ExecuteCommandStartSession(Activator, null, name);
+            cmd.Execute();
         }
     }
 }

--- a/Application/ResearchDataManagementPlatform/WindowManagement/ActivateItems.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/ActivateItems.cs
@@ -697,9 +697,24 @@ namespace ResearchDataManagementPlatform.WindowManagement
         }
         public void StartSession(string sessionName, IEnumerable<IMapsDirectlyToDatabaseTable> initialObjects)
         {
+            if(initialObjects == null)
+            {
+                initialObjects =  SelectMany(new DialogArgs
+                {
+                    WindowTitle = "Session Objects",
+                    TaskDescription = "Pick which objects you want added to the session window.  You can always add more later"
+                },typeof(IMapsDirectlyToDatabaseTable),CoreChildProvider.GetAllSearchables().Keys.ToArray())?.ToList();
+
+                if(initialObjects == null || initialObjects.Count() == 0)
+                {
+                    // user cancelled picking objects
+                    return;
+                }
+            }
+
             var panel = WindowFactory.Create(this,new SessionCollectionUI(),new SessionCollection(sessionName)
             {
-                DatabaseObjects = initialObjects?.ToList() ?? new List<IMapsDirectlyToDatabaseTable>()
+                DatabaseObjects = initialObjects.ToList()
             },CatalogueIcons.WindowLayout);
             panel.Show(_mainDockPanel,DockState.DockLeft);
         }

--- a/Application/ResearchDataManagementPlatform/WindowManagement/ActivateItems.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/ActivateItems.cs
@@ -695,14 +695,15 @@ namespace ResearchDataManagementPlatform.WindowManagement
                 new CommandInvokerDelegate(typeof(IActivateItems),true,(p)=>this)
             };
         }
-        public void StartSession(string sessionName, IEnumerable<IMapsDirectlyToDatabaseTable> initialObjects)
+        public void StartSession(string sessionName, IEnumerable<IMapsDirectlyToDatabaseTable> initialObjects, string initialSearch)
         {
             if(initialObjects == null)
             {
                 initialObjects =  SelectMany(new DialogArgs
                 {
                     WindowTitle = "Session Objects",
-                    TaskDescription = "Pick which objects you want added to the session window.  You can always add more later"
+                    TaskDescription = "Pick which objects you want added to the session window.  You can always add more later",
+                    InitialSearchText = initialSearch
                 },typeof(IMapsDirectlyToDatabaseTable),CoreChildProvider.GetAllSearchables().Keys.ToArray())?.ToList();
 
                 if(initialObjects == null || initialObjects.Count() == 0)

--- a/Application/ResearchDataManagementPlatform/WindowManagement/HomePane/HomeBoxUI.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/HomePane/HomeBoxUI.cs
@@ -56,7 +56,7 @@ namespace ResearchDataManagementPlatform.WindowManagement.HomePane
                 btnOpen.DisplayStyle = ToolStripItemDisplayStyle.Text;
                 btnOpen.Click += (s, e) =>
                 {
-                    var ui = new NavigateToObjectUI(activator);
+                    var ui = new NavigateToObjectUI(activator,addFindMultiple:true);
                     ui.AlwaysFilterOn = openType;
                     ui.CompletionAction = Open;
                     ui.Show();

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Improved performance of Select objects dialog when there are many objects available to pick from
 - Made Select objects dialog filter in the same way as the Find dialog (i.e. support short codes and Type names)
 - Ability to select multiple objects at once when adding to a Session
+- Ability to find multiple objects at once (ctrl+shift+f)
 
 ## [7.0.8] - 2022-03-08
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- Improved performance of Select objects dialog when there are many objects available to pick from
+- Made Select objects dialog filter in the same way as the Find dialog (i.e. support short codes and Type names)
+- Ability to select multiple objects at once when adding to a Session
+
 ## [7.0.8] - 2022-03-08
 
 ### Fixed

--- a/Rdmp.UI.Tests/TestActivateItems.cs
+++ b/Rdmp.UI.Tests/TestActivateItems.cs
@@ -293,7 +293,7 @@ namespace Rdmp.UI.Tests
             throw new NotImplementedException();
         }
 
-        public void StartSession(string sessionName, IEnumerable<IMapsDirectlyToDatabaseTable> initialSelectionIfAny)
+        public void StartSession(string sessionName, IEnumerable<IMapsDirectlyToDatabaseTable> initialSelectionIfAny, string initialSearch)
         {
             throw new NotImplementedException();
         }

--- a/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
+++ b/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
@@ -586,7 +586,7 @@ namespace Rdmp.UI.Collections
 
                     if (many.Cast<object>().All(d => d is IMapsDirectlyToDatabaseTable))
                     {
-                        menu.Items.Add(factory.CreateMenuItem(new ExecuteCommandStartSession(_activator, many.Cast<IMapsDirectlyToDatabaseTable>().ToArray())));
+                        menu.Items.Add(factory.CreateMenuItem(new ExecuteCommandStartSession(_activator, many.Cast<IMapsDirectlyToDatabaseTable>().ToArray(),null)));
                         menu.Items.Add(factory.CreateMenuItem(new ExecuteCommandAddToSession(_activator, many.Cast<IMapsDirectlyToDatabaseTable>().ToArray(),null)));
                     }
 

--- a/Rdmp.UI/Collections/SessionCollectionUI.cs
+++ b/Rdmp.UI/Collections/SessionCollectionUI.cs
@@ -6,15 +6,13 @@
 
 using MapsDirectlyToDatabaseTable;
 using Rdmp.Core;
-using Rdmp.Core.Curation.Data.Cohort;
+using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Curation.Data.Dashboarding;
 using Rdmp.Core.Curation.Data.Pipelines;
 using Rdmp.Core.Curation.Data.Spontaneous;
-using Rdmp.Core.Icons.IconProvision;
 using Rdmp.Core.Providers.Nodes.PipelineNodes;
 using Rdmp.UI.ItemActivation;
 using Rdmp.UI.Refreshing;
-using Rdmp.UI.SimpleDialogs.NavigateTo;
 using Rdmp.UI.SingleControlForms;
 using Rdmp.UI.TestsAndSetup.ServicePropogation;
 using System;
@@ -138,9 +136,20 @@ namespace Rdmp.UI.Collections
         }
         private void AddObjectToSession(object sender, EventArgs e)
         {
-            var ui = new NavigateToObjectUI(Activator);
-            ui.CompletionAction = (s)=>Add(s);
-            ui.Show();
+            var toAdd = Activator.SelectMany(new DialogArgs
+                {
+                    WindowTitle = "Add to Session",
+                    TaskDescription = "Pick which objects you want added to the session window."
+                }, typeof(IMapsDirectlyToDatabaseTable),
+                Activator.CoreChildProvider.GetAllSearchables().Keys.Except(Collection.DatabaseObjects).ToArray())?.ToList();
+
+            if (toAdd == null || toAdd.Count() == 0)
+            {
+                // user cancelled picking objects
+                return;
+            }
+
+            Add(toAdd.ToArray());
         }
 
         private void RefreshSessionObjects()

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandStartSession.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandStartSession.cs
@@ -7,6 +7,7 @@
 using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.CommandExecution.AtomicCommands;
 using Rdmp.UI.ItemActivation;
+using System.Linq;
 
 namespace Rdmp.UI.CommandExecution.AtomicCommands
 {
@@ -15,8 +16,14 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
     /// </summary>
     public class ExecuteCommandStartSession : BasicUICommandExecution, IAtomicCommand
     {
+        public const string FindResultsTitle = "Find Results";
         private readonly string _sessionName;
         private IMapsDirectlyToDatabaseTable[] _initialSelection;
+
+        /// <summary>
+        /// True if the command was cancelled before finishing <see cref="Execute"/>
+        /// </summary>
+        public bool Cancelled { get; set; } = true;
 
         public ExecuteCommandStartSession(IActivateItems activator, IMapsDirectlyToDatabaseTable[] initialSelection, string sessionName) : base(activator)
         {
@@ -38,7 +45,26 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
                 name = sessionName;
             }
 
+            name = MakeNovel(name);
+
             Activator.StartSession(name, _initialSelection);
+            Cancelled = false;
+        }
+
+        private string MakeNovel(string name)
+        {
+            var novelName = name;
+            var sessions = ((IActivateItems)BasicActivator).GetSessions().ToArray();
+
+            int i = 1;
+
+            while (sessions.Any(s => s.Collection.SessionName.Equals(novelName)))
+            {
+                i++;
+                novelName = name + i;
+            }
+
+            return novelName;
         }
     }
 }

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandStartSession.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandStartSession.cs
@@ -15,19 +15,30 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
     /// </summary>
     public class ExecuteCommandStartSession : BasicUICommandExecution, IAtomicCommand
     {
+        private readonly string _sessionName;
         private IMapsDirectlyToDatabaseTable[] _initialSelection;
 
-        public ExecuteCommandStartSession(IActivateItems activator, IMapsDirectlyToDatabaseTable[] initialSelection) : base(activator)
+        public ExecuteCommandStartSession(IActivateItems activator, IMapsDirectlyToDatabaseTable[] initialSelection, string sessionName) : base(activator)
         {
             _initialSelection = initialSelection;
+            _sessionName = sessionName;
         }
 
         public override void Execute()
         {
             base.Execute();
 
-            if (Activator.TypeText("Session Name", "Name", 100, "Session 0", out string sessionName, false))
-                Activator.StartSession(sessionName, _initialSelection);
+            var name = _sessionName;
+
+            if (string.IsNullOrWhiteSpace(name))
+            {
+                if (!Activator.TypeText("Session Name", "Name", 100, "Session 0", out string sessionName, false))
+                    return;
+
+                name = sessionName;
+            }
+
+            Activator.StartSession(name, _initialSelection);
         }
     }
 }

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandStartSession.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandStartSession.cs
@@ -24,6 +24,7 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
         /// True if the command was cancelled before finishing <see cref="Execute"/>
         /// </summary>
         public bool Cancelled { get; set; } = true;
+        public string InitialSearch { get; set; }
 
         public ExecuteCommandStartSession(IActivateItems activator, IMapsDirectlyToDatabaseTable[] initialSelection, string sessionName) : base(activator)
         {
@@ -47,7 +48,7 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
 
             name = MakeNovel(name);
 
-            Activator.StartSession(name, _initialSelection);
+            Activator.StartSession(name, _initialSelection, InitialSearch);
             Cancelled = false;
         }
 

--- a/Rdmp.UI/ItemActivation/IActivateItems.cs
+++ b/Rdmp.UI/ItemActivation/IActivateItems.cs
@@ -146,7 +146,8 @@ namespace Rdmp.UI.ItemActivation
         /// </summary>
         /// <param name="sessionName"></param>
         /// <param name="initialSelectionIfAny">Initial root objects to be in scope (or null if not known)</param>
-        void StartSession(string sessionName, IEnumerable<IMapsDirectlyToDatabaseTable> initialSelectionIfAny);
+        /// <param name="initialSearch">The value to set the search textbox to on load if objects are being selected during this operation, or null.</param>
+        void StartSession(string sessionName, IEnumerable<IMapsDirectlyToDatabaseTable> initialSelectionIfAny, string initialSearch);
 
         /// <summary>
         /// Returns all currently open session uis

--- a/Rdmp.UI/SimpleDialogs/FindSearchTailFilterWithAlwaysShowList.cs
+++ b/Rdmp.UI/SimpleDialogs/FindSearchTailFilterWithAlwaysShowList.cs
@@ -1,0 +1,59 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using BrightIdeasSoftware;
+using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.CommandExecution;
+using Rdmp.Core.Providers;
+using System.Collections;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+
+namespace Rdmp.UI.SimpleDialogs
+{
+    internal class FindSearchTailFilterWithAlwaysShowList : IListFilter
+    {
+        private List<IMapsDirectlyToDatabaseTable> _scoringObjects;
+
+        public IEnumerable<object> AlwaysShow { get; }
+        public CancellationToken CancellationToken { get; }
+
+        public FindSearchTailFilterWithAlwaysShowList(IBasicActivateItems activator, IEnumerable<object> alwaysShow, IEnumerable<IMapsDirectlyToDatabaseTable> allObjects, string text,int maxToTake, CancellationToken cancellationToken) 
+        {
+            AlwaysShow = alwaysShow;
+            CancellationToken = cancellationToken;
+
+            if(string.IsNullOrEmpty(text))
+            {
+                _scoringObjects = allObjects.Take(maxToTake).ToList();
+            }
+            else
+            {
+                var searchThese = allObjects.ToDictionary(o => o, activator.CoreChildProvider.GetDescendancyListIfAnyFor);
+
+                var scorer = new SearchablesMatchScorer();
+                var matches = scorer.ScoreMatches(searchThese, text, cancellationToken, null);
+
+                // we were cancelled
+                if (matches == null)
+                {
+                    _scoringObjects = new List<IMapsDirectlyToDatabaseTable>();
+                    return;
+                }
+
+                _scoringObjects = scorer.ShortList(matches, maxToTake, activator);
+            }
+
+        }
+
+
+        public IEnumerable Filter(IEnumerable modelObjects)
+        {
+            return _scoringObjects.Union(AlwaysShow);
+        }
+    }
+}

--- a/Rdmp.UI/SimpleDialogs/FindSearchTailFilterWithAlwaysShowList.cs
+++ b/Rdmp.UI/SimpleDialogs/FindSearchTailFilterWithAlwaysShowList.cs
@@ -8,6 +8,7 @@ using BrightIdeasSoftware;
 using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Providers;
+using System;
 using System.Collections;
 using System.Collections.Generic;
 using System.Linq;
@@ -36,7 +37,8 @@ namespace Rdmp.UI.SimpleDialogs
                 var searchThese = allObjects.ToDictionary(o => o, activator.CoreChildProvider.GetDescendancyListIfAnyFor);
 
                 var scorer = new SearchablesMatchScorer();
-                var matches = scorer.ScoreMatches(searchThese, text, cancellationToken, null);
+                scorer.TypeNames = new HashSet<string>(allObjects.Select(m => m.GetType().Name).Distinct(), StringComparer.CurrentCultureIgnoreCase);
+                var matches = scorer.ScoreMatches(searchThese, text, cancellationToken,null);
 
                 // we were cancelled
                 if (matches == null)

--- a/Rdmp.UI/SimpleDialogs/NavigateTo/NavigateToObjectUI.cs
+++ b/Rdmp.UI/SimpleDialogs/NavigateTo/NavigateToObjectUI.cs
@@ -226,7 +226,8 @@ namespace Rdmp.UI.SimpleDialogs.NavigateTo
             {
                 var cmd = new ExecuteCommandStartSession(Activator, null, ExecuteCommandStartSession.FindResultsTitle)
                 {
-                    OverrideCommandName = "Find Multiple"
+                    OverrideCommandName = "Find Multiple",
+                    InitialSearch = textBox1.Text
                 };
                 cmd.Execute();
 

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.Designer.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.Designer.cs
@@ -66,12 +66,11 @@ namespace Rdmp.UI.SimpleDialogs
             this.olvObjects.Cursor = System.Windows.Forms.Cursors.Default;
             this.olvObjects.Dock = System.Windows.Forms.DockStyle.Fill;
             this.olvObjects.FullRowSelect = true;
-            this.olvObjects.HideSelection = false;
             this.olvObjects.Location = new System.Drawing.Point(0, 42);
             this.olvObjects.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.olvObjects.Name = "olvObjects";
             this.olvObjects.ShowGroups = false;
-            this.olvObjects.Size = new System.Drawing.Size(326, 449);
+            this.olvObjects.Size = new System.Drawing.Size(480, 439);
             this.olvObjects.TabIndex = 1;
             this.olvObjects.UseCompatibleStateImageBehavior = false;
             this.olvObjects.UseFiltering = true;
@@ -88,6 +87,7 @@ namespace Rdmp.UI.SimpleDialogs
             // olvSelected
             // 
             this.olvSelected.Text = "Selected";
+            this.olvSelected.TextAlign = System.Windows.Forms.HorizontalAlignment.Center;
             // 
             // olvName
             // 
@@ -102,7 +102,7 @@ namespace Rdmp.UI.SimpleDialogs
             this.btnSelect.Location = new System.Drawing.Point(0, 582);
             this.btnSelect.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnSelect.Name = "btnSelect";
-            this.btnSelect.Size = new System.Drawing.Size(326, 27);
+            this.btnSelect.Size = new System.Drawing.Size(480, 27);
             this.btnSelect.TabIndex = 2;
             this.btnSelect.Text = "Select";
             this.btnSelect.UseVisualStyleBackColor = true;
@@ -114,7 +114,7 @@ namespace Rdmp.UI.SimpleDialogs
             this.btnSelectNULL.Location = new System.Drawing.Point(0, 609);
             this.btnSelectNULL.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnSelectNULL.Name = "btnSelectNULL";
-            this.btnSelectNULL.Size = new System.Drawing.Size(326, 27);
+            this.btnSelectNULL.Size = new System.Drawing.Size(480, 27);
             this.btnSelectNULL.TabIndex = 3;
             this.btnSelectNULL.Text = "Select \'NULL\'";
             this.btnSelectNULL.UseVisualStyleBackColor = true;
@@ -126,7 +126,7 @@ namespace Rdmp.UI.SimpleDialogs
             this.btnCancel.Location = new System.Drawing.Point(0, 636);
             this.btnCancel.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.btnCancel.Name = "btnCancel";
-            this.btnCancel.Size = new System.Drawing.Size(326, 27);
+            this.btnCancel.Size = new System.Drawing.Size(480, 27);
             this.btnCancel.TabIndex = 4;
             this.btnCancel.Text = "Cancel";
             this.btnCancel.UseVisualStyleBackColor = true;
@@ -138,7 +138,7 @@ namespace Rdmp.UI.SimpleDialogs
             this.tbFilter.Location = new System.Drawing.Point(36, 0);
             this.tbFilter.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.tbFilter.Name = "tbFilter";
-            this.tbFilter.Size = new System.Drawing.Size(290, 23);
+            this.tbFilter.Size = new System.Drawing.Size(444, 23);
             this.tbFilter.TabIndex = 0;
             this.tbFilter.TextChanged += new System.EventHandler(this.tbFilter_TextChanged);
             this.tbFilter.KeyDown += new System.Windows.Forms.KeyEventHandler(this.tbFilter_KeyDown);
@@ -158,7 +158,7 @@ namespace Rdmp.UI.SimpleDialogs
             // timer1
             // 
             this.timer1.Enabled = true;
-            this.timer1.Interval = 200;
+            this.timer1.Interval = 500;
             this.timer1.Tick += new System.EventHandler(this.timer1_Tick);
             // 
             // splitContainer1
@@ -180,8 +180,8 @@ namespace Rdmp.UI.SimpleDialogs
             // splitContainer1.Panel2
             // 
             this.splitContainer1.Panel2.Controls.Add(this.catalogueCollectionFilterUI1);
-            this.splitContainer1.Size = new System.Drawing.Size(326, 582);
-            this.splitContainer1.SplitterDistance = 516;
+            this.splitContainer1.Size = new System.Drawing.Size(480, 582);
+            this.splitContainer1.SplitterDistance = 506;
             this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 5;
             // 
@@ -191,9 +191,9 @@ namespace Rdmp.UI.SimpleDialogs
             this.panel1.Controls.Add(this.tbFilter);
             this.panel1.Controls.Add(this.label1);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel1.Location = new System.Drawing.Point(0, 491);
+            this.panel1.Location = new System.Drawing.Point(0, 481);
             this.panel1.Name = "panel1";
-            this.panel1.Size = new System.Drawing.Size(326, 25);
+            this.panel1.Size = new System.Drawing.Size(480, 25);
             this.panel1.TabIndex = 4;
             // 
             // taskDescriptionLabel1
@@ -203,7 +203,7 @@ namespace Rdmp.UI.SimpleDialogs
             this.taskDescriptionLabel1.Dock = System.Windows.Forms.DockStyle.Top;
             this.taskDescriptionLabel1.Location = new System.Drawing.Point(0, 0);
             this.taskDescriptionLabel1.Name = "taskDescriptionLabel1";
-            this.taskDescriptionLabel1.Size = new System.Drawing.Size(326, 42);
+            this.taskDescriptionLabel1.Size = new System.Drawing.Size(480, 42);
             this.taskDescriptionLabel1.TabIndex = 0;
             // 
             // catalogueCollectionFilterUI1
@@ -218,7 +218,7 @@ namespace Rdmp.UI.SimpleDialogs
             // 
             this.AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             this.AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            this.ClientSize = new System.Drawing.Size(326, 663);
+            this.ClientSize = new System.Drawing.Size(480, 663);
             this.Controls.Add(this.splitContainer1);
             this.Controls.Add(this.btnSelect);
             this.Controls.Add(this.btnSelectNULL);

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.Designer.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.Designer.cs
@@ -70,7 +70,7 @@ namespace Rdmp.UI.SimpleDialogs
             this.olvObjects.Margin = new System.Windows.Forms.Padding(4, 3, 4, 3);
             this.olvObjects.Name = "olvObjects";
             this.olvObjects.ShowGroups = false;
-            this.olvObjects.Size = new System.Drawing.Size(480, 439);
+            this.olvObjects.Size = new System.Drawing.Size(480, 437);
             this.olvObjects.TabIndex = 1;
             this.olvObjects.UseCompatibleStateImageBehavior = false;
             this.olvObjects.UseFiltering = true;
@@ -181,7 +181,7 @@ namespace Rdmp.UI.SimpleDialogs
             // 
             this.splitContainer1.Panel2.Controls.Add(this.catalogueCollectionFilterUI1);
             this.splitContainer1.Size = new System.Drawing.Size(480, 582);
-            this.splitContainer1.SplitterDistance = 506;
+            this.splitContainer1.SplitterDistance = 504;
             this.splitContainer1.SplitterWidth = 5;
             this.splitContainer1.TabIndex = 5;
             // 
@@ -191,7 +191,7 @@ namespace Rdmp.UI.SimpleDialogs
             this.panel1.Controls.Add(this.tbFilter);
             this.panel1.Controls.Add(this.label1);
             this.panel1.Dock = System.Windows.Forms.DockStyle.Bottom;
-            this.panel1.Location = new System.Drawing.Point(0, 481);
+            this.panel1.Location = new System.Drawing.Point(0, 479);
             this.panel1.Name = "panel1";
             this.panel1.Size = new System.Drawing.Size(480, 25);
             this.panel1.TabIndex = 4;

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.cs
@@ -132,6 +132,21 @@ namespace Rdmp.UI.SimpleDialogs
 
             RDMPCollectionCommonFunctionality.SetupColumnTracking(olvObjects, olvName, new Guid("298cda00-5ec8-423c-9230-71d78bec6bc4"));
             RDMPCollectionCommonFunctionality.SetupColumnTracking(olvObjects, olvID, new Guid("bb0fe2f0-1e73-4b00-a5b7-4b6ce3510bab"));
+
+            btnCancel.KeyPress += BtnKeypress;
+            btnSelect.KeyPress += BtnKeypress;
+            btnSelectNULL.KeyPress += BtnKeypress;
+        }
+
+        private void BtnKeypress(object sender, KeyPressEventArgs e)
+        {
+            // if user is typing change the focus to the text box
+            if(char.IsLetterOrDigit(e.KeyChar))
+            {
+                tbFilter.Text += e.KeyChar;
+                tbFilter.Select(tbFilter.TextLength, 0);
+                tbFilter.Focus();
+            }
         }
 
         private bool IsBasicallyAllCatalogues(T[] o)

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.cs
@@ -400,7 +400,7 @@ namespace Rdmp.UI.SimpleDialogs
 
 
             // if we are dealing with database objects
-            if (typeof(IMapsDirectlyToDatabaseTable).IsAssignableFrom(typeof(T)))
+            if (typeof(IMapsDirectlyToDatabaseTable).IsAssignableFrom(typeof(T)) && !_useCatalogueFilter)
             {
                 FindSearchTailFilterWithAlwaysShowList filter = null;
 

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.cs
@@ -136,6 +136,14 @@ namespace Rdmp.UI.SimpleDialogs
             btnCancel.KeyPress += BtnKeypress;
             btnSelect.KeyPress += BtnKeypress;
             btnSelectNULL.KeyPress += BtnKeypress;
+
+            // Prevents the object list view going 'BONG' every time the user hits space
+            // to check/uncheck objects
+            olvObjects.KeyPress += (s, e) =>
+            {
+                if (e.KeyChar == ' ' || e.KeyChar == '\r' || e.KeyChar == '\n')
+                    e.Handled = true;
+            };
         }
 
         private void BtnKeypress(object sender, KeyPressEventArgs e)

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.cs
@@ -174,6 +174,10 @@ namespace Rdmp.UI.SimpleDialogs
 
         private void Selected_AspectPutter(object rowobject, object newvalue)
         {
+
+            timer1.Stop();
+            timer1.Start();
+
             var b = (bool) newvalue;
             if (b)
                 MultiSelected.Add((T) rowobject);
@@ -211,6 +215,7 @@ namespace Rdmp.UI.SimpleDialogs
                     {
                         //add a column
                         var newCol = new OLVColumn(propertyInfo.Name, propertyInfo.Name);
+                        RDMPCollectionCommonFunctionality.SetupColumnTracking(olvObjects, newCol, new Guid("646da5ab-468a-49d0-afbb-a60c23e45bbb" + propertyInfo.Name));
                         olvObjects.AllColumns.Add(newCol);
                     }
                 }
@@ -225,6 +230,7 @@ namespace Rdmp.UI.SimpleDialogs
                     //yes, then tell the user what they are with this exciting new column
                     var newCol = new OLVColumn("Type", null);
                     newCol.AspectGetter += TypeAspectGetter;
+                    RDMPCollectionCommonFunctionality.SetupColumnTracking(olvObjects, newCol, new Guid("189ea535-2ada-4bdd-b137-0d7db2c833c6"));
                     olvObjects.AllColumns.Add(newCol);
                 }
             }
@@ -478,7 +484,11 @@ namespace Rdmp.UI.SimpleDialogs
             if (buildGroupsRequired)
             {
                 buildGroupsRequired = false;
+                olvObjects.BeginUpdate();
+                olvObjects.SuspendLayout();
                 olvObjects.BuildGroups();
+                olvObjects.EndUpdate();
+                olvObjects.ResumeLayout();
             }
         }
     }


### PR DESCRIPTION
Makes `Select<T>` dialog work much more like the find dialog (`NavigateToObjectUI`) when `T` is `IMapsDirectlyToDatabaseTable`.  Performance is significantly improved and user can search using the same syntaxes and notations as in the find.

Add to session and New session now use `Select<T>` and pass all objects in RDMP to it.

Fixes #948
Fixes #947

![image](https://user-images.githubusercontent.com/31306100/157851780-36ad118f-fdae-43ff-9e32-83a7225d2266.png)
