### PR TITLE
Added CohortSampler

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Made Select objects dialog filter in the same way as the Find dialog (i.e. support short codes and Type names)
 - Ability to select multiple objects at once when adding to a Session
 - Ability to find multiple objects at once (ctrl+shift+f)
+- Added new pipeline component CohortSampler
 
 ### Fixed
 

--- a/Rdmp.Core.Tests/DataLoad/Engine/Unit/CohortSamplerTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Unit/CohortSamplerTests.cs
@@ -1,0 +1,177 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using NUnit.Framework;
+using Rdmp.Core.CohortCommitting.Pipeline;
+using Rdmp.Core.DataExport.Data;
+using Rdmp.Core.DataFlowPipeline;
+using Rdmp.Core.DataLoad.Modules.DataFlowOperations;
+using ReusableLibraryCode.Progress;
+using System;
+using System.Data;
+using System.Linq;
+using System.Threading;
+using Tests.Common;
+
+namespace Rdmp.Core.Tests.DataLoad.Engine.Unit
+{
+    class CohortSamplerTests : UnitTests
+    {
+        [Test]
+        public void TestCohortSampler_NoColumnFound()
+        {
+            var sampler = GetCohortSampler();
+
+            var dt = new DataTable();
+            dt.Columns.Add("ff");
+            dt.Rows.Add("1");
+
+            var ex = Assert.Throws<Exception>(()=>sampler.ProcessPipelineData(dt, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken()));
+            Assert.AreEqual("CohortSampler was unable to find a column called 'priv' in the data passed in.  This is the expected private identifier column name of the cohort you are committing.", ex.Message);
+        }
+
+        [Test]
+        public void TestCohortSampler_NoColumnFoundExplicit()
+        {
+            var sampler = GetCohortSampler();
+            sampler.PrivateIdentifierColumnName = "ddd";
+
+            var dt = new DataTable();
+            dt.Columns.Add("ff");
+            dt.Rows.Add("1");
+
+            var ex = Assert.Throws<Exception>(() => sampler.ProcessPipelineData(dt, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken()));
+            Assert.AreEqual("CohortSampler was unable to find a column called 'ddd' in the data passed in.  This is the expected private identifier column name of the cohort you are committing.", ex.Message);
+        }
+        [Test]
+        public void TestCohortSampler_NotEnoughIdentifiersInBatch()
+        {
+            var sampler = GetCohortSampler();
+            sampler.SampleSize = 100;
+
+            var dt = new DataTable();
+            dt.Columns.Add("priv");
+            dt.Rows.Add("1");
+
+            var ex = Assert.Throws<Exception>(() => sampler.ProcessPipelineData(dt, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken()));
+            Assert.AreEqual("Cohort only contains 1 unique identifiers.  This is less than the requested sample size of 100 and FailIfNotEnoughIdentifiers is true", ex.Message);
+        }
+        [Test]
+        public void TestCohortSampler_NotEnoughIdentifiersInBatch_ButThatsOk()
+        {
+            var sampler = GetCohortSampler();
+            sampler.SampleSize = 100;
+            // accept less than 100
+            sampler.FailIfNotEnoughIdentifiers = false;
+
+            var dt = new DataTable();
+            dt.Columns.Add("priv");
+            dt.Rows.Add("1");
+
+            var result = sampler.ProcessPipelineData(dt, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken());
+            Assert.AreEqual(1, result.Rows.Count);
+        }
+
+        [Test]
+        public void TestCohortSampler_Repeatability()
+        {
+            var sampler1 = GetCohortSampler();
+            var sampler2 = GetCohortSampler();
+
+            sampler1.SampleSize = 5;
+            sampler2.SampleSize = 5;
+
+            var dt = new DataTable();
+            dt.Columns.Add("priv");
+            dt.Rows.Add("11");
+            dt.Rows.Add("2123");
+            dt.Rows.Add("32213");
+            dt.Rows.Add("41");
+            dt.Rows.Add("14515");
+            dt.Rows.Add("13516");
+            dt.Rows.Add("12517");
+            dt.Rows.Add("1245121");
+            dt.Rows.Add("432143211");
+            dt.Rows.Add("12341241");
+            dt.Rows.Add("1121234");
+            dt.Rows.Add("612346231");
+            dt.Rows.Add("62323616");
+            dt.Rows.Add("2362361");
+
+            var result1 = sampler1.ProcessPipelineData(dt, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken());
+            
+            // just to be sure
+            Thread.Sleep(100);
+
+            var result2 = sampler2.ProcessPipelineData(dt, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken());
+
+            Assert.AreEqual(5, result1.Rows.Count);
+            Assert.AreEqual(5, result2.Rows.Count);
+
+
+            Assert.IsTrue(result1.Rows.Cast<DataRow>().Select(r => r[0])
+                .SequenceEqual(result2.Rows.Cast<DataRow>().Select(r => r[0])),
+                "Expected both samplers to select the same random sample of input values because the project number is the seed");
+        }
+
+
+        [Test]
+        public void TestCohortSampler_Repeatability_OrderIrrelevant()
+        {
+            var sampler1 = GetCohortSampler();
+            var sampler2 = GetCohortSampler();
+
+            sampler1.SampleSize = 2;
+            sampler2.SampleSize = 2;
+
+            var dt1 = new DataTable();
+            dt1.Columns.Add("priv");
+            dt1.Rows.Add("11");
+            dt1.Rows.Add("2123");
+            dt1.Rows.Add("32213");
+            dt1.Rows.Add("asdf");
+            dt1.Rows.Add("hgreerg");
+
+            var dt2 = new DataTable();
+            dt2.Columns.Add("priv");
+            dt2.Rows.Add("asdf");
+            dt2.Rows.Add("11");
+            dt2.Rows.Add("hgreerg");
+            dt2.Rows.Add("32213");
+            dt2.Rows.Add("2123");
+
+            var result1 = sampler1.ProcessPipelineData(dt1, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken());
+
+            // just to be sure
+            Thread.Sleep(100);
+
+            var result2 = sampler2.ProcessPipelineData(dt2, new ThrowImmediatelyDataLoadEventListener(), new GracefulCancellationToken());
+
+            Assert.AreEqual(2, result1.Rows.Count);
+            Assert.AreEqual(2, result2.Rows.Count);
+
+
+            Assert.IsTrue(result1.Rows.Cast<DataRow>().Select(r => r[0])
+                .SequenceEqual(result2.Rows.Cast<DataRow>().Select(r => r[0])),
+                "Expected both samplers to select the same random sample of input values because the project number is the seed");
+        }
+
+        private CohortSampler GetCohortSampler()
+        {
+            var sampler = new CohortSampler();
+
+            var definition = new CohortDefinition(null, "my cool cohort", 1, 234, WhenIHaveA<ExternalCohortTable>());
+            var p = WhenIHaveA<Project>();
+            p.ProjectNumber = 234;
+
+            var request = new CohortCreationRequest(p, definition, Repository, "Cohort read from space!!!");
+
+            sampler.PreInitialize(request, new ThrowImmediatelyDataLoadEventListener());
+
+            return sampler;
+        }
+    }
+}

--- a/Rdmp.Core/DataLoad/Modules/DataFlowOperations/CohortSampler.cs
+++ b/Rdmp.Core/DataLoad/Modules/DataFlowOperations/CohortSampler.cs
@@ -1,0 +1,120 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.CohortCommitting.Pipeline;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataExport.Data;
+using Rdmp.Core.DataFlowPipeline;
+using Rdmp.Core.DataFlowPipeline.Requirements;
+using ReusableLibraryCode.Checks;
+using ReusableLibraryCode.Progress;
+using System;
+using System.Collections.Generic;
+using System.Data;
+using System.Linq;
+
+namespace Rdmp.Core.DataLoad.Modules.DataFlowOperations
+{
+    /// <summary>
+    /// Component for reproducibly pulling a random sample of records from a cohort being committed.
+    /// </summary>
+    public class CohortSampler : IPluginDataFlowComponent<DataTable>, IPipelineRequirement<CohortCreationRequest>
+    {
+        private IExternalCohortTable _ect;
+        private IProject _project;
+        bool _firstBatch = true;
+
+        [DemandsInitialization("The number of unique patient identifiers you want returned from the input data")]
+        public int SampleSize { get; set; }
+
+        [DemandsInitialization("Optional.  The name of the identifier column that you are submitting.  Set this if it is different than the destination cohort private identifier field")]
+        public string PrivateIdentifierColumnName { get; set; }
+
+        [DemandsInitialization("Determines components behaviour if not enough unique identifiers are being comitted.  True to crash.  False to pass on however many records there are.")]
+        public bool FailIfNotEnoughIdentifiers { get; set; }
+
+        public void Abort(IDataLoadEventListener listener)
+        {
+        }
+
+        public void Check(ICheckNotifier notifier)
+        {
+        }
+
+        public void Dispose(IDataLoadEventListener listener, Exception pipelineFailureExceptionIfAny)
+        {
+        }
+
+        public void PreInitialize(CohortCreationRequest value, IDataLoadEventListener listener)
+        {
+            _ect = value.NewCohortDefinition.LocationOfCohort;
+            _project = value.Project;
+        }
+
+        public DataTable ProcessPipelineData(DataTable toProcess, IDataLoadEventListener listener, GracefulCancellationToken cancellationToken)
+        {
+            if (!_firstBatch)
+                throw new Exception("Expected to get the whole cohort at once but got multiple batches.  This component only works if the Source returns all data at once");
+
+            if (_project.ProjectNumber == null)
+                throw new Exception("Project must have a ProjectNumber so that it can be used as a seed in random cohort sampling");
+
+            var expectedFieldName = GetPrivateFieldName();
+            
+            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information,$"Looking for column called '{expectedFieldName}' in the data in order to produce a sample"));
+
+            if (!toProcess.Columns.Contains(expectedFieldName))
+                throw new Exception($"Could not find a column called {expectedFieldName} in the data");
+
+
+            // get all the unique values
+            HashSet<object> uniques = new HashSet<object>();
+
+            foreach(DataRow row in toProcess.Rows)
+            {
+                var val = row[expectedFieldName];
+
+                if(val != DBNull.Value)
+                {
+                    uniques.Add(val);
+                }
+            }
+
+            _firstBatch = false;
+
+
+            Random r = new Random(_project.ProjectNumber.Value);
+
+#pragma warning disable SCS0005 // Weak random number generator.
+            var chosen = uniques.OrderBy(v => r.Next()).Take(SampleSize).ToList();
+#pragma warning restore SCS0005 // Weak random number generator.
+
+            if(chosen.Count < SampleSize && FailIfNotEnoughIdentifiers)
+            {
+                throw new Exception($"Cohort only contains {chosen.Count} unique identifiers.  This is less than the requested sample size of {SampleSize} and {nameof(FailIfNotEnoughIdentifiers)} is true");
+            }
+
+            DataTable dtToReturn = new DataTable();
+            dtToReturn.Columns.Add(expectedFieldName);
+
+            foreach(var val in chosen)
+            {
+                dtToReturn.Rows.Add(val);
+            }
+
+            return dtToReturn;
+        }
+
+        private string GetPrivateFieldName()
+        {
+            if (!string.IsNullOrWhiteSpace(PrivateIdentifierColumnName))
+                return PrivateIdentifierColumnName;
+
+            var syntax = _ect.GetQuerySyntaxHelper();
+            return syntax.GetRuntimeName(_ect.PrivateIdentifierField);
+        }
+    }
+}

--- a/Rdmp.Core/DataLoad/Modules/DataFlowOperations/CohortSampler.cs
+++ b/Rdmp.Core/DataLoad/Modules/DataFlowOperations/CohortSampler.cs
@@ -30,11 +30,11 @@ namespace Rdmp.Core.DataLoad.Modules.DataFlowOperations
         [DemandsInitialization("The number of unique patient identifiers you want returned from the input data")]
         public int SampleSize { get; set; }
 
-        [DemandsInitialization("Optional.  The name of the identifier column that you are submitting.  Set this if it is different than the destination cohort private identifier field")]
-        public string PrivateIdentifierColumnName { get; set; }
-
         [DemandsInitialization("Determines components behaviour if not enough unique identifiers are being comitted.  True to crash.  False to pass on however many records there are.")]
         public bool FailIfNotEnoughIdentifiers { get; set; }
+
+        [DemandsInitialization("Optional.  The name of the identifier column that you are submitting.  Set this if it is different than the destination cohort private identifier field")]
+        public string PrivateIdentifierColumnName { get; set; }
 
         public void Abort(IDataLoadEventListener listener)
         {


### PR DESCRIPTION
Fixes  #993

- [x] unit tests
- [x] Add to description that ProjectNumber is used as the seed
- [x] Make component not care about input row order
   - [x] apply an order by to the DataTable such that even if the order of rows in the input is random as long as the same set is passed in then the same matched seed records get returned