### PR TITLE
ExecuteCommandChooseCohort no longer lets you pick deprecated cohorts

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dll load warnings must now be enabled otherwise the information is reported as Success (see user settings error codes R008 and R009)
+- The Choose Cohort command no longer lets you pick deprecated cohorts
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 
 - Dll load warnings must now be enabled otherwise the information is reported as Success (see user settings error codes R008 and R009)
-- The Choose Cohort command no longer lets you pick deprecated cohorts
+- The Choose Cohort command no longer lets you pick deprecated cohorts - [#/1109](https://github.com/HicServices/RDMP/issues/1109)
 
 ### Fixed
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandChooseCohort.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandChooseCohort.cs
@@ -48,7 +48,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
             //find cohorts that match the project number
             if (_childProvider.ProjectNumberToCohortsDictionary.ContainsKey(project.ProjectNumber.Value))
-                _compatibleCohorts = (_childProvider.ProjectNumberToCohortsDictionary[project.ProjectNumber.Value]).ToList();
+                _compatibleCohorts = _childProvider.ProjectNumberToCohortsDictionary[project.ProjectNumber.Value].Where(c=>!c.IsDeprecated).ToList();
 
             //if there's only one compatible cohort and that one is already selected
             if (_compatibleCohorts.Count == 1 && _compatibleCohorts.Single().ID == _extractionConfiguration.Cohort_ID)
@@ -70,7 +70,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             if (SelectOne(new DialogArgs() {
                 WindowTitle = "Select Saved Cohort",
                 TaskDescription = "Select the existing Cohort you would like to be used for your Extraction Configuration."
-            }, _compatibleCohorts.Where(c => c.ID != _extractionConfiguration.Cohort_ID).ToList(), out ExtractableCohort selected))
+            }, _compatibleCohorts.Where(c => c.ID != _extractionConfiguration.Cohort_ID && !c.IsDeprecated).ToList(), out ExtractableCohort selected))
             {
                 //clear current one
                 _extractionConfiguration.Cohort_ID = selected.ID;


### PR DESCRIPTION
Fixes #1109

![image](https://user-images.githubusercontent.com/31306100/165926292-b86ee5cd-5174-403c-9216-726c71cd6851.png)
_This command and all users of this command (e.g. new ExtractionConfiguration commmand) no longer let you pick deprecated cohorts_