### PR TITLE
No agg dimension

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,7 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added new command 'RefreshBrokenCohorts' for clearing the 'forbid list' of unreachable cohort sources - [#1094](https://github.com/HicServices/RDMP/issues/1094)
-- Added new command 'SetAggregateDimension' for changing the linkage column in cohort builder for an [AggregateConfiguration]
+- Added new command 'SetAggregateDimension' for changing the linkage column in cohort builder for an [AggregateConfiguration] - [#1102](https://github.com/HicServices/RDMP/issues/1102)
 - Added abilty to skip CIC validation checks when opening the commit cohort dialogue - [#1118](https://github.com/HicServices/RDMP/issues/1118)
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added new command 'RefreshBrokenCohorts' for clearing the 'forbid list' of unreachable cohort sources - [#1094](https://github.com/HicServices/RDMP/issues/1094)
+- Added new command 'SetAggregateDimension' for changing the linkage column in cohort builder for an [AggregateConfiguration]
 
 ### Changed
 
@@ -1250,7 +1251,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 [CacheProgress]: ./Documentation/CodeTutorials/Glossary.md#CacheProgress
 
 [JoinInfo]: ./Documentation/CodeTutorials/Glossary.md#JoinInfo
-
+[AggregateConfiguration]: ./Documentation/CodeTutorials/Glossary.md#AggregateConfiguration
 [PipelineComponent]: ./Documentation/CodeTutorials/Glossary.md#PipelineComponent
 [Pipeline]: ./Documentation/CodeTutorials/Glossary.md#Pipeline
 [Pipelines]: ./Documentation/CodeTutorials/Glossary.md#Pipeline

--- a/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
@@ -210,6 +210,11 @@ namespace Rdmp.Core.CommandExecution
 
                 yield return new ExecuteCommandViewSample(_activator, ac) { OverrideCommandName = "View Sample SQL/Data" };
 
+                if(ac.IsCohortIdentificationAggregate)
+                {
+                    yield return new ExecuteCommandSetAggregateDimension(_activator, ac);
+                }
+
                 // graph options
                 yield return new ExecuteCommandAddDimension(_activator, ac) { SuggestedCategory = Dimensions };
                 yield return new ExecuteCommandSetPivot(_activator, ac) { SuggestedCategory = Dimensions };

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetAggregateDimension.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetAggregateDimension.cs
@@ -1,0 +1,107 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Curation.Data.Aggregation;
+using Rdmp.Core.Curation.Data.Cohort;
+using System.Linq;
+
+namespace Rdmp.Core.CommandExecution.AtomicCommands
+{
+    /// <summary>
+    /// Removes all <see cref="AggregateDimension"/> on an <see cref="AggregateConfiguration"/> and creates
+    /// a single new dimension for linkage in a <see cref="CohortIdentificationConfiguration"/> based on
+    /// a chosen <see cref="ExtractionInformation"/> which must be marked <see cref="ConcreteColumn.IsExtractionIdentifier"/>
+    /// </summary>
+    public class ExecuteCommandSetAggregateDimension : BasicCommandExecution, IAtomicCommand
+    {
+        private AggregateConfiguration _aggregate;
+        private ExtractionInformation[] _available;
+        private ExtractionInformation _extractionInformation;
+
+        public ExecuteCommandSetAggregateDimension(IBasicActivateItems activator, 
+            [DemandsInitialization("The AggregateConfiguration which you want to change the extraction identifier on")]
+            AggregateConfiguration ac,
+            [DemandsInitialization("The extractable column in the Catalogue which should be created as a new AggregateDimension on the aggregate.  Or null to prompt at runtime",DefaultValue = true)]
+            ExtractionInformation ei = null):base(activator)
+        {
+            if (!ac.IsCohortIdentificationAggregate)
+            {
+                SetImpossible("AggregateConfiguration is not a cohort aggregate");
+                return;
+            }
+            
+            _extractionInformation = ei;
+
+            if(_extractionInformation != null && !_extractionInformation.IsExtractionIdentifier)
+            {
+                SetImpossible($"'{_extractionInformation}' is not marked IsExtractionIdentifier");
+                return;
+            }
+
+            try
+            {
+                var cata = ac.GetCatalogue();
+                _available = cata.GetAllExtractionInformation().Where(ci=>ci.IsExtractionIdentifier).ToArray();
+
+                if (_extractionInformation != null)
+                {
+                    if(cata.ID != _extractionInformation.CatalogueItem.Catalogue_ID)
+                    {
+                        SetImpossible($"'{_extractionInformation}' does not belong to the same Catalogue as '{ac}'");
+                        return;
+                    }
+                }
+
+                if (_available.Length == 0)
+                {
+                    SetImpossible($"There are no columns in Catalogue '{cata}' that are marked IsExtractionIdentifier");
+                    return;
+                }
+
+                if(_available.Length == 1 && ac.AggregateDimensions.Length == 1 && _available[0].ID == ac.AggregateDimensions[0].ExtractionInformation_ID)
+                {
+                    SetImpossible($"AggregateConfiguration already uses the only IsExtractionIdentifier column in '{cata}'");
+                    return;
+                }
+
+            }
+            catch (System.Exception ex)
+            {
+                SetImpossible($"Could not determine compatible columns:{ex.Message}");
+            }
+            
+            _aggregate = ac;
+        }
+
+        public override void Execute()
+        {
+            base.Execute();
+
+            var chosen = _extractionInformation;
+            
+            if(chosen == null && BasicActivator.IsInteractive)
+            {
+                chosen = (ExtractionInformation)BasicActivator.SelectOne(new DialogArgs {
+                    WindowTitle = "Select AggregateDimension",
+                    TaskDescription = "Choose which column to query and link with other datasets in the CohortIdentificationConfiguration.  All datasets in the configuration must have the same identifier type to be linkable."
+                }, _available);
+            }
+
+            if (chosen == null)
+                return;
+
+            foreach(var d in _aggregate.AggregateDimensions)
+            {
+                d.DeleteInDatabase();
+            }
+
+            var added = _aggregate.AddDimension(chosen);
+            Publish(_aggregate);
+            Emphasise(added);
+        }
+    }
+}

--- a/Rdmp.Core/Providers/CatalogueProblemProvider.cs
+++ b/Rdmp.Core/Providers/CatalogueProblemProvider.cs
@@ -123,7 +123,7 @@ namespace Rdmp.Core.Providers
 
             if(!aggregateConfiguration.AggregateDimensions.Any())
             {
-                return "Aggregate has no dimensions.  Add an AggregateDimension to specify which column is fetched by the query.";
+                return "Aggregate has no dimensions.  Set an AggregateDimension to specify which column is fetched by the query.";
             }
 
             return null;

--- a/Rdmp.Core/Providers/CatalogueProblemProvider.cs
+++ b/Rdmp.Core/Providers/CatalogueProblemProvider.cs
@@ -121,6 +121,11 @@ namespace Rdmp.Core.Providers
                 if (!_usedJoinables.Contains(aggregateConfiguration.JoinableCohortAggregateConfiguration.ID))
                     return "Patient Index Table is not joined to any cohort sets";
 
+            if(!aggregateConfiguration.AggregateDimensions.Any())
+            {
+                return "Aggregate has no dimensions.  Add an AggregateDimension to specify which column is fetched by the query.";
+            }
+
             return null;
         }
 


### PR DESCRIPTION
Fixes #1102

![image](https://user-images.githubusercontent.com/31306100/166222475-a1c66268-7a34-4545-8f97-743595b06fad.png)

![image](https://user-images.githubusercontent.com/31306100/166222605-e299f331-a27a-464e-98df-a3338782efd4.png)


```
PS Z:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> ./rdmp cmd DescribeCommand SetAggregateDimension

Name: ExecuteCommandSetAggregateDimension

Description:
Removes all AggregateDimension on an AggregateConfiguration and creates a single new dimension for linkage in a CohortIdentificationConfiguration based on a chosen ExtractionInformation which must be marked ConcreteColumn.IsExtractionIdentifier

USAGE:
./rdmp.exe cmd SetAggregateDimension <ac> <ei>

PARAMETERS:
ac        AggregateConfiguration The AggregateConfiguration which you want to change the extraction identifier on
ei        ExtractionInformation  The extractable column in the Catalogue which should be created as a new
                                 AggregateDimension on the aggregate.  Or null to prompt at runtime
```