### PR TITLE
Ignore empty cohort containers when strict validation is off

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Fixed
+
+- Empty cohort builder containers are now treated as disabled by query builder when StrictValidationForCohortBuilderContainers is off [#1131](https://github.com/HicServices/RDMP/issues/1131)
+
 ## [7.0.11] - 2022-05-03
 
 ### Added

--- a/Rdmp.Core/CohortCreation/Execution/CohortCompilerRunner.cs
+++ b/Rdmp.Core/CohortCreation/Execution/CohortCompilerRunner.cs
@@ -12,6 +12,7 @@ using System.Threading.Tasks;
 using Rdmp.Core.CohortCreation.Execution.Joinables;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Curation.Data.Cohort;
+using Rdmp.Core.QueryBuilding;
 
 namespace Rdmp.Core.CohortCreation.Execution
 {
@@ -111,7 +112,8 @@ namespace Rdmp.Core.CohortCreation.Execution
                 if(RunSubcontainers)
                 {
                     Parallel.ForEach(
-                        _cic.RootCohortAggregateContainer.GetAllSubContainersRecursively().Where(c => !c.IsDisabled),
+                        _cic.RootCohortAggregateContainer.GetAllSubContainersRecursively().Where(
+                            c=>CohortQueryBuilderResult.IsEnabled(c,Compiler.CoreChildProvider)),
                         (a)=>Compiler.AddTask(a, globals));
                 }
                         

--- a/Rdmp.Core/QueryBuilding/CohortQueryBuilderResult.cs
+++ b/Rdmp.Core/QueryBuilding/CohortQueryBuilderResult.cs
@@ -263,15 +263,20 @@ namespace Rdmp.Core.QueryBuilding
                 sql += Environment.NewLine + TabIn(")",tabs) + Environment.NewLine ;
 
             return sql;
-        }      
+        }
+
+        private bool IsEnabled(IOrderable arg)
+        {
+            return IsEnabled(arg, ChildProvider);
+        }
 
         /// <summary>
         /// Objects are enabled if they do not support disabling (<see cref="IDisableable"/>) or are <see cref="IDisableable.IsDisabled"/> = false
         /// </summary>
         /// <returns></returns>
-        private bool IsEnabled(IOrderable arg)
+        public static bool IsEnabled(IOrderable arg, ICoreChildProvider childProvider)
         {
-            var parentDisabled = ChildProvider.GetDescendancyListIfAnyFor(arg)?.Parents.Any(p => p is IDisableable d && d.IsDisabled);
+            var parentDisabled = childProvider.GetDescendancyListIfAnyFor(arg)?.Parents.Any(p => p is IDisableable d && d.IsDisabled);
 
             //if a parent is disabled
             if (parentDisabled.HasValue && parentDisabled.Value)

--- a/Rdmp.Core/QueryBuilding/CohortQueryBuilderResult.cs
+++ b/Rdmp.Core/QueryBuilding/CohortQueryBuilderResult.cs
@@ -21,6 +21,7 @@ using Rdmp.Core.Providers;
 using Rdmp.Core.QueryBuilding.Parameters;
 using Rdmp.Core.QueryCaching.Aggregation;
 using ReusableLibraryCode.DataAccess;
+using ReusableLibraryCode.Settings;
 
 namespace Rdmp.Core.QueryBuilding
 {
@@ -262,9 +263,7 @@ namespace Rdmp.Core.QueryBuilding
                 sql += Environment.NewLine + TabIn(")",tabs) + Environment.NewLine ;
 
             return sql;
-        }
-
-        
+        }      
 
         /// <summary>
         /// Objects are enabled if they do not support disabling (<see cref="IDisableable"/>) or are <see cref="IDisableable.IsDisabled"/> = false
@@ -277,6 +276,14 @@ namespace Rdmp.Core.QueryBuilding
             //if a parent is disabled
             if (parentDisabled.HasValue && parentDisabled.Value)
                 return false;
+
+            // skip empty containers unless strict validation is enabled
+            if(arg is CohortAggregateContainer container &&
+                !UserSettings.StrictValidationForCohortBuilderContainers)
+            {
+                if (!container.GetOrderedContents().Any())
+                    return false;
+            }
 
             //or you yourself are disabled
             var dis = arg as IDisableable;


### PR DESCRIPTION
Fixes #1131

This is a change to the query building engine so a dangerous area of code to mess with.  But I think this change should achieve the goal.  It makes the CohortCompiler treat set containers as disabled when they are empty.

You can still break it by nesting empty containers but I think that is fine.  

The big run button will also now not run empty containers (when strict validation is disabled).  But the user can manually execute them if they want at which point they will see the Crashed state and an error about the container being empty