### PR TITLE
Added optional field requireLoadedRows into ExecuteCommandConfirmLogs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- Added optional argument to 'ExecuteCommandConfirmLogs' that requires rows were loaded by the DLE to pass
+
 ### Fixed
 
 - Empty cohort builder containers are now treated as disabled by query builder when StrictValidationForCohortBuilderContainers is off [#1131](https://github.com/HicServices/RDMP/issues/1131)

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandConfirmLogs.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandConfirmLogs.cs
@@ -94,12 +94,12 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                                       .Where(a=>!checkInclusionCriteria || Include(a))
                                       .FirstOrDefault();
 
-            string messageClarrification = checkInclusionCriteria ? " (where rows were loaded)" : "";
+            string messageClarification = checkInclusionCriteria ? " (where rows were loaded)" : "";
 
             // if no logs
             if (latest == null)
             {
-                throw new LogsNotConfirmedException($"There are no log entries for {LogRootObject}{messageClarrification}");
+                throw new LogsNotConfirmedException($"There are no log entries for {LogRootObject}{messageClarification}");
             }
 
             // we have logs but are they in the time period we are interested in
@@ -111,20 +111,20 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 // if the latest log entry is older than the time period the user indicated
                 if (startTime < thresholdDate)
                 {
-                    throw new LogsNotConfirmedException($"Latest logged activity for {LogRootObject}{messageClarrification} is {startTime}.  This is older than the requested date threshold:{thresholdDate}");
+                    throw new LogsNotConfirmedException($"Latest logged activity for {LogRootObject}{messageClarification} is {startTime}.  This is older than the requested date threshold:{thresholdDate}");
                 }
             }
 
             // we have an acceptably recent log entry
             if (latest.HasErrors)
             {
-                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject}{messageClarrification} ({latest.StartTime}) indicate that it failed");
+                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject}{messageClarification} ({latest.StartTime}) indicate that it failed");
             }
 
             // most recent log entry did not complete
             if (!latest.EndTime.HasValue)
             {
-                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject}{messageClarrification} ({latest.StartTime}) indicate that it did not complete");
+                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject}{messageClarification} ({latest.StartTime}) indicate that it did not complete");
             }
             // latest log entry is passing yay!
         }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandConfirmLogs.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandConfirmLogs.cs
@@ -7,9 +7,11 @@
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Curation.Data.DataLoad;
 using Rdmp.Core.Logging;
+using Rdmp.Core.Logging.PastEvents;
 using System;
 using System.Globalization;
 using System.Linq;
+using System.Text.RegularExpressions;
 using TypeGuesser.Deciders;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands
@@ -32,22 +34,34 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         public ILoggedActivityRootObject LogRootObject { get; }
 
         /// <summary>
+        /// If <see cref="LogRootObject"/> is a <see cref="LoadMetadata"/> then
+        /// setting this to true requires that rows were updated/inserted into
+        /// the live tables for the command to pass
+        /// </summary>
+        public bool RequireLoadedRows { get; }
+
+        /// <summary>
         /// Checks the RDMP logs for the latest log entry of a given object.  Throws (returns exit code non zero) if
         /// the top log entry is failing or if there are no log entries within the expected time span.
         /// </summary>
         /// <param name="activator"></param>
         /// <param name="obj"></param>
         /// <param name="withinTime"></param>
+        /// <param name="requireLoadedRows"></param>
         public ExecuteCommandConfirmLogs(IBasicActivateItems activator,
             
             [DemandsInitialization("The object you want to confirm passing log entries for")]
             ILoggedActivityRootObject obj,
 
             [DemandsInitialization("Optional time period in which to expect successful logs e.g. 24:00:00 (24 hours)")]
-            string withinTime = null):base(activator)
+            string withinTime = null,
+            
+            [DemandsInitialization("Optional.  Pass true to require rows to be loaded if obj is a LoadMetadata")]
+            bool requireLoadedRows=false):base(activator)
         {
             LogRootObject = obj;
-            if(withinTime != null)
+            RequireLoadedRows = requireLoadedRows;
+            if (withinTime != null)
             {
                 var decider = new TimeSpanTypeDecider(CultureInfo.CurrentCulture);
                 WithinTime = (TimeSpan)decider.Parse(withinTime);
@@ -60,15 +74,32 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
             var logManager = new LogManager(LogRootObject.GetDistinctLoggingDatabase());
 
-            // get the latest log entry
+            // run first without additional restrictions so that
+            // the user gets the most high level fail conditions
+            // e.g. no runs or latest run was a failure etc
+            ThrowIfNoEntries(logManager, false);
 
-            var unfilteredResults = logManager.GetArchivalDataLoadInfos(LogRootObject.GetDistinctLoggingTask(),null, null);
-            var latest = LogRootObject.FilterRuns(unfilteredResults).FirstOrDefault();
+            if(LogRootObject is ILoadMetadata && RequireLoadedRows)
+            {
+                // run again but only consider loads where rows were loaded
+                ThrowIfNoEntries(logManager, true);
+            }
+        }
+
+        private void ThrowIfNoEntries(LogManager logManager, bool checkInclusionCriteria)
+        {
+            // get the latest log entry
+            var unfilteredResults = logManager.GetArchivalDataLoadInfos(LogRootObject.GetDistinctLoggingTask(), null, null);
+            var latest = LogRootObject.FilterRuns(unfilteredResults)
+                                      .Where(a=>!checkInclusionCriteria || Include(a))
+                                      .FirstOrDefault();
+
+            string messageClarrification = checkInclusionCriteria ? " (where rows were loaded)" : "";
 
             // if no logs
             if (latest == null)
             {
-                throw new LogsNotConfirmedException($"There are no log entries for {LogRootObject}");
+                throw new LogsNotConfirmedException($"There are no log entries for {LogRootObject}{messageClarrification}");
             }
 
             // we have logs but are they in the time period we are interested in
@@ -80,22 +111,52 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 // if the latest log entry is older than the time period the user indicated
                 if (startTime < thresholdDate)
                 {
-                    throw new LogsNotConfirmedException($"Latest logged activity for {LogRootObject} is {startTime}.  This is older than the requested date threshold:{thresholdDate}");
+                    throw new LogsNotConfirmedException($"Latest logged activity for {LogRootObject}{messageClarrification} is {startTime}.  This is older than the requested date threshold:{thresholdDate}");
                 }
             }
 
             // we have an acceptably recent log entry
-            if(latest.HasErrors)
+            if (latest.HasErrors)
             {
-                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject} ({latest.StartTime}) indicate that it failed");
+                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject}{messageClarrification} ({latest.StartTime}) indicate that it failed");
             }
 
             // most recent log entry did not complete
             if (!latest.EndTime.HasValue)
             {
-                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject} ({latest.StartTime}) indicate that it did not complete");
+                throw new LogsNotConfirmedException($"Latest logs for {LogRootObject}{messageClarrification} ({latest.StartTime}) indicate that it did not complete");
             }
             // latest log entry is passing yay!
+        }
+
+        /// <summary>
+        /// Returns false if <paramref name="arg"/> is an audit for <see cref="LogRootObject"/>
+        /// as a DLE load (<see cref="LoadMetadata"/>) and <see cref="RequireLoadedRows"/> is set
+        /// and no rows were reported as loaded into the final tables of the load
+        /// </summary>
+        /// <param name="arg"></param>
+        /// <returns></returns>
+        private bool Include(ArchivalDataLoadInfo arg)
+        {
+            if (!RequireLoadedRows || !(LogRootObject is ILoadMetadata lmd))
+                return true;
+
+            var excludeStaging = new Regex("_STAGING");
+            var excludeRaw = new Regex("_RAW");
+
+            var liveTableNames = lmd.GetAllCatalogues()
+                            .SelectMany(c => c.GetTableInfoList(true))
+                            .Select(t=> new Regex($"\\b{Regex.Escape(t.GetRuntimeName())}\\b"))
+                            .Distinct();
+
+            // tables where there was at least 1 insert or update and it wasn't in a RAW or STAGING table
+            var loadedTables = arg.TableLoadInfos
+                .Where(l => l.Inserts > 0 || l.Updates > 0)
+                .Where(l => !excludeRaw.IsMatch(l.TargetTable) && !excludeStaging.IsMatch(l.TargetTable));
+
+            // of those they must match the live table name
+            return loadedTables.Any(l =>
+                liveTableNames.Any(n => n.IsMatch(l.TargetTable)));
         }
     }
 }


### PR DESCRIPTION
Adds support for passing 'true' to require that the referenced object (`LoadMetadata:1` in example below) has had rows inserted within the given timeframe as well as the latest load not being a crash.

Fixes  #1139


##Running##
```
PS Z:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> .\rdmp.exe cmd ConfirmLogs LoadMetadata:1 null true
2022-05-05 14:00:18.5350 INFO Dotnet Version:6.0.2 .
2022-05-05 14:00:18.5608 INFO RDMP Version:7.0.11.0 .
2022-05-05 14:00:23.8451 ERROR There are no log entries for Capture Algorithm 1232 Results (where rows were loaded) .
```

##Help##

```
PS Z:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> .\rdmp.exe cmd DescribeCommand ConfirmLogs
Name: ExecuteCommandConfirmLogs

Description:
Checks the RDMP logs for the latest log entry of a given object. Throws (returns exit code non zero) if the top log entry is failing or if there are no log entries within the expected time span.

USAGE:
./rdmp.exe cmd ConfirmLogs <obj> <withinTime> <requireLoadedRows>

PARAMETERS:
obj               ILoggedActivityRootObject The object you want to confirm passing log entries for
withinTime        String                    Optional time period in which to expect successful logs e.g. 24:00:00 (24
                                            hours)
requireLoadedRows Boolean                   Optional.  Pass true to require rows to be loaded if obj is a LoadMetadata
```