### PR TITLE
Added prompts to create JoinInfo when adding new TableInfo to existing Catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Added 'RAWTableToLoad' dropdown property to RemoteTableAttacher to prevent mispellings when typing table names - [#1134](https://github.com/HicServices/RDMP/issues/1134)
 - Added optional argument to 'ExecuteCommandConfirmLogs' that requires rows were loaded by the DLE to pass
 - Added ability to search the UserSettings UI 
+- Added a prompt to configure JoinInfos when adding a new table to an existing Catalogue
 
 ### Fixed
 

--- a/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
+++ b/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
@@ -483,7 +483,7 @@ namespace Rdmp.UI.SimpleDialogs.ForwardEngineering
             {
                 joinFrom = (ITableInfo)Activator.SelectOne(new DialogArgs {
                     WindowTitle = "Pick Table for Join",
-                    TaskDescription = $"Your Catalogue '{addToInstead}' has {existingTables.Length} tables alreayd associated with it.  Which of these can be joined to your new table '{TableInfoCreated}'"
+                    TaskDescription = $"Your Catalogue '{addToInstead}' has {existingTables.Length} tables already associated with it.  Which of these can be joined to your new table '{TableInfoCreated}'"
                 },existingTables);
 
                 // user cancelled joining


### PR DESCRIPTION
Fixes #1152

This PR adds a new step into the windows client UI for RDMP.  After choosing the 'Add to existing Catalogue' the user is now prompted to pick how to join to the other table(s) in the Catalogue.

The first TableInfo associated with a Catalogue is also marked as 'Is Primary Extraction Table' (at the point when a second table is added).

### When adding a second table to a Catalogue
![image](https://user-images.githubusercontent.com/31306100/168054237-c8002b96-bd35-4490-9540-e7d495ab9160.png)


### When there are already 2+ tables associated with the Catalogue
![image](https://user-images.githubusercontent.com/31306100/168053644-0ef564c6-68fe-4819-b9af-8ad3c85b9437.png)
