### PR TITLE
Add IDataLoadJob.CrashAtEnd method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- Added `CrashAtEnd` system for DLE that allows Attachers to flag a load as a failure without halting execution [#1157](https://github.com/HicServices/RDMP/issues/1157)
+
 ## [7.0.12] - 2022-05-16
 
 ### Added

--- a/Rdmp.Core.Tests/DataLoad/Engine/Integration/ToMemoryDataLoadJob.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Integration/ToMemoryDataLoadJob.cs
@@ -22,6 +22,10 @@ namespace Rdmp.Core.Tests.DataLoad.Engine.Integration
 {
     public class ToMemoryDataLoadJob : ToMemoryDataLoadEventListener, IDataLoadJob
     {
+        private List<NotifyEventArgs> _crashAtEnd = new ();
+        /// <inheritdoc/>
+        public IReadOnlyCollection<NotifyEventArgs> CrashAtEndMessages => _crashAtEnd.AsReadOnly();
+
         public ToMemoryDataLoadJob(bool throwOnErrorEvents = true): base(throwOnErrorEvents)
         {
         }
@@ -63,6 +67,11 @@ namespace Rdmp.Core.Tests.DataLoad.Engine.Integration
         public ColumnInfo[] GetAllColumns()
         {
             return RegularTablesToLoad.SelectMany(t=>t.ColumnInfos).Union(LookupTablesToLoad.SelectMany(t=>t.ColumnInfos)).Distinct().ToArray();
+        }
+        /// <inheritdoc/>
+        public void CrashAtEnd(NotifyEventArgs because)
+        {
+            _crashAtEnd.Add(because);
         }
     }
 }

--- a/Rdmp.Core/DataLoad/Engine/Job/DataLoadJob.cs
+++ b/Rdmp.Core/DataLoad/Engine/Job/DataLoadJob.cs
@@ -43,6 +43,10 @@ namespace Rdmp.Core.DataLoad.Engine.Job
         public HICDatabaseConfiguration Configuration { get; set; }
         public object Payload { get; set; }
 
+        private List<NotifyEventArgs> _crashAtEnd = new();
+
+        public IReadOnlyCollection<NotifyEventArgs> CrashAtEndMessages => _crashAtEnd.AsReadOnly();
+
 
         private string _loggingTask;
 
@@ -201,6 +205,11 @@ namespace Rdmp.Core.DataLoad.Engine.Job
         public ColumnInfo[] GetAllColumns()
         {
             return RegularTablesToLoad.SelectMany(t=>t.ColumnInfos).Union(LookupTablesToLoad.SelectMany(t=>t.ColumnInfos)).Distinct().ToArray();
+        }
+
+        public void CrashAtEnd(NotifyEventArgs because)
+        {
+            _crashAtEnd.Add(because);
         }
     }
 }

--- a/Rdmp.Core/DataLoad/Engine/Job/IDataLoadJob.cs
+++ b/Rdmp.Core/DataLoad/Engine/Job/IDataLoadJob.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Collections.Generic;
 using Rdmp.Core.Curation;
 using Rdmp.Core.Curation.Data;
@@ -35,9 +36,15 @@ namespace Rdmp.Core.DataLoad.Engine.Job
         /// </summary>
         object Payload { get; set; }
 
+        /// <summary>
+        /// Collection of all calls to <see cref="CrashAtEnd"/>.  If there are any
+        /// of these at the end of the load they will be notified and a crash exit code will be 
+        /// returned (but otherwise the load will complete normally).
+        /// </summary>
+        IReadOnlyCollection<NotifyEventArgs> CrashAtEndMessages { get; }
         List<ITableInfo> RegularTablesToLoad { get; }
         List<ITableInfo> LookupTablesToLoad { get; }
-        
+
         IRDMPPlatformRepositoryServiceLocator RepositoryLocator { get; }
 
         void StartLogging();
@@ -60,5 +67,14 @@ namespace Rdmp.Core.DataLoad.Engine.Job
         /// </summary>
         /// <returns></returns>
         ColumnInfo[] GetAllColumns();
+
+        /// <summary>
+        /// Call you see that something has gone horribly wrong but want to keep going
+        /// with the load anyway.  Once the load has been completed these will crash
+        /// the process and result in a non 0 exit code.  Archiving and postload operations
+        /// will still occur.
+        /// </summary>
+        /// <param name="because"></param>
+        void CrashAtEnd(NotifyEventArgs because);
     }
 }

--- a/Rdmp.Core/DataLoad/Engine/Job/ThrowImmediatelyDataLoadJob.cs
+++ b/Rdmp.Core/DataLoad/Engine/Job/ThrowImmediatelyDataLoadJob.cs
@@ -70,6 +70,12 @@ namespace Rdmp.Core.DataLoad.Engine.Job
 
         public object Payload { get; set; }
 
+        private List<NotifyEventArgs> _crashAtEnd = new();
+
+        /// <inheritdoc/>
+        public IReadOnlyCollection<NotifyEventArgs> CrashAtEndMessages => _crashAtEnd.AsReadOnly();
+
+
         public void AddForDisposalAfterCompletion(IDisposeAfterDataLoad disposable)
         {
         }
@@ -98,6 +104,12 @@ namespace Rdmp.Core.DataLoad.Engine.Job
         public ColumnInfo[] GetAllColumns()
         {
             return RegularTablesToLoad.SelectMany(t=>t.ColumnInfos).Union(LookupTablesToLoad.SelectMany(t=>t.ColumnInfos)).Distinct().ToArray();
+        }
+
+        /// <inheritdoc/>
+        public void CrashAtEnd(NotifyEventArgs because)
+        {
+            _crashAtEnd.Add(because);
         }
     }
 }

--- a/Rdmp.Core/DataLoad/Engine/LoadExecution/SingleJobExecution.cs
+++ b/Rdmp.Core/DataLoad/Engine/LoadExecution/SingleJobExecution.cs
@@ -80,6 +80,20 @@ namespace Rdmp.Core.DataLoad.Engine.LoadExecution
 
                 job.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, "Completed job " + job.JobID));
                 
+                if(job.CrashAtEndMessages.Count > 0)
+                {
+                    job.OnNotify(this, new NotifyEventArgs(ProgressEventType.Warning, $"There were {job.CrashAtEndMessages.Count} {nameof(IDataLoadJob.CrashAtEndMessages)} registered for job " + job.JobID));
+
+                    // pop the messages into the handler
+                    foreach (var m in job.CrashAtEndMessages)
+                    {
+                        job.OnNotify(job, m);  // depending on the listener these may break flow of control (e.g. 
+                    }
+
+                    // return failed (even if the messages are all warnings)
+                    return ExitCodeType.Error;                    
+                }
+
                 return ExitCodeType.Success;
             }
             catch (OperationCanceledException)


### PR DESCRIPTION
Fixes #1157

For example running a DLE configuration with 2 files in ForLoading only 1 of which is compatible with the loaded table (Biochemistry).  The load results in failure but archiving etc still occurs.

![image](https://user-images.githubusercontent.com/31306100/168788963-4a493348-8f1f-4d22-bca4-0a5c7774043a.png)
