### PR TITLE
Lookups now check for a single Catalogue and extract only Core column

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - 'View Aggregate' now explicitly applies an ORDER BY count descending.
 - New CatalogueItems are now always marked Core (affects drag and drop and new Catalogue creation) - [#1165](https://github.com/HicServices/RDMP/issues/1165),[#1164](https://github.com/HicServices/RDMP/issues/1164)
+- If a Catalogue is defined for a Lookup TableInfo then only Core extractable columns will be released (previously all columns were released) [#692](https://github.com/HicServices/RDMP/issues/692)
 
 ### Added
 

--- a/Rdmp.Core.Tests/Curation/Integration/BundledLookupTableTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/BundledLookupTableTests.cs
@@ -8,6 +8,7 @@ using NUnit.Framework;
 using Rdmp.Core.Curation;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.DataExport.DataExtraction.UserPicks;
+using Rdmp.Core.QueryBuilding;
 using Tests.Common;
 
 namespace Rdmp.Core.Tests.Curation.Integration
@@ -52,6 +53,17 @@ SELECT
 ChildCol
 FROM 
 ChildTable", bundle.GetDataTableFetchSql());
+
+
+            // ei 0 is marked IsExtractionIdentifier - so is also not a valid
+            // lookup extractable column (Lookups shouldn't have patient linkage
+            // identifiers in them so)
+            eis[0].IsExtractionIdentifier = true;
+            eis[0].SaveToDatabase();
+
+            // so now there are no columns at all that are extractable
+            var ex = Assert.Throws<QueryBuildingException>(() => bundle.GetDataTableFetchSql());
+            Assert.AreEqual("Lookup table 'ChildTable' has a Catalogue defined 'ChildTable' but it has no Core extractable columns", ex.Message);
         }
     }
 }

--- a/Rdmp.Core.Tests/Curation/Integration/BundledLookupTableTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/BundledLookupTableTests.cs
@@ -1,0 +1,57 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using NUnit.Framework;
+using Rdmp.Core.Curation;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataExport.DataExtraction.UserPicks;
+using Tests.Common;
+
+namespace Rdmp.Core.Tests.Curation.Integration
+{
+    public class BundledLookupTableTests : UnitTests
+    {
+        [Test]
+        public void TestLookupGetDataTableFetchSql()
+        {
+            var l = WhenIHaveA<Lookup>();
+            var t =l.PrimaryKey.TableInfo;
+            
+            var bundle = new BundledLookupTable(t);
+            Assert.AreEqual("select * from [MyDb]..[ChildTable]", bundle.GetDataTableFetchSql());
+        }
+        [Test]
+        public void TestLookupGetDataTableFetchSql_WithCatalogue()
+        {
+            var l = WhenIHaveA<Lookup>();
+            var t = l.PrimaryKey.TableInfo;
+
+            var engineer = new ForwardEngineerCatalogue(t, t.ColumnInfos);
+            engineer.ExecuteForwardEngineering(out var cata,out _, out var eis);
+
+            var bundle = new BundledLookupTable(t);
+            Assert.AreEqual(@"
+SELECT 
+
+ChildCol,
+Desc
+FROM 
+ChildTable", bundle.GetDataTableFetchSql());
+
+
+            // ei 1 is suplemental now
+            eis[1].ExtractionCategory = ExtractionCategory.Supplemental;
+            eis[1].SaveToDatabase();
+
+            Assert.AreEqual(@"
+SELECT 
+
+ChildCol
+FROM 
+ChildTable", bundle.GetDataTableFetchSql());
+        }
+    }
+}

--- a/Rdmp.Core/DataExport/DataExtraction/ExtractTableVerbatim.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/ExtractTableVerbatim.cs
@@ -10,6 +10,7 @@ using System.IO;
 using System.Linq;
 using FAnsi.Discovery;
 using Rdmp.Core.DataExport.DataExtraction.FileOutputFormats;
+using Rdmp.Core.DataExport.DataExtraction.UserPicks;
 using Rdmp.Core.DataViewing;
 using ReusableLibraryCode.DataAccess;
 

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExecuteFullExtractionToDatabaseMSSql.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExecuteFullExtractionToDatabaseMSSql.cs
@@ -471,7 +471,7 @@ namespace Rdmp.Core.DataExport.DataExtraction.Pipeline.Destinations
         protected override void TryExtractLookupTableImpl(BundledLookupTable lookup, DirectoryInfo lookupDir,
             IExtractionConfiguration requestConfiguration,IDataLoadEventListener listener, out int linesWritten, out string destinationDescription)
         {
-            var dt = lookup.GetDataTable();
+            using var dt = lookup.GetDataTable();
                 
             dt.TableName = GetTableName(_destinationDatabase.Server.GetQuerySyntaxHelper().GetSensibleEntityNameFromString(lookup.TableInfo.Name));
 
@@ -489,8 +489,6 @@ namespace Rdmp.Core.DataExport.DataExtraction.Pipeline.Destinations
             }
 
             destinationDb.CreateTable(dt.TableName, dt);
-            
-            dt.Dispose();
         }
 
         private DiscoveredDatabase GetDestinationDatabase(IDataLoadEventListener listener)

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExecuteFullExtractionToDatabaseMSSql.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExecuteFullExtractionToDatabaseMSSql.cs
@@ -471,8 +471,7 @@ namespace Rdmp.Core.DataExport.DataExtraction.Pipeline.Destinations
         protected override void TryExtractLookupTableImpl(BundledLookupTable lookup, DirectoryInfo lookupDir,
             IExtractionConfiguration requestConfiguration,IDataLoadEventListener listener, out int linesWritten, out string destinationDescription)
         {
-            var tbl = lookup.TableInfo.Discover(DataAccessContext.DataExport);
-            var dt = tbl.GetDataTable();
+            var dt = lookup.GetDataTable();
                 
             dt.TableName = GetTableName(_destinationDatabase.Server.GetQuerySyntaxHelper().GetSensibleEntityNameFromString(lookup.TableInfo.Name));
 
@@ -490,6 +489,8 @@ namespace Rdmp.Core.DataExport.DataExtraction.Pipeline.Destinations
             }
 
             destinationDb.CreateTable(dt.TableName, dt);
+            
+            dt.Dispose();
         }
 
         private DiscoveredDatabase GetDestinationDatabase(IDataLoadEventListener listener)

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExtractionDestination.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Destinations/ExtractionDestination.cs
@@ -473,9 +473,14 @@ e.g. /$i/$a")]
         }
 
         protected virtual void TryExtractLookupTableImpl( BundledLookupTable lookup, DirectoryInfo lookupDir, IExtractionConfiguration requestConfiguration,IDataLoadEventListener listener, out int linesWritten, out string destinationDescription)
-        {            
-            //extracts all of them
-            var extractTableVerbatim = new ExtractTableVerbatim(lookupDir, _request.Configuration.Separator, DateFormat,lookup.TableInfo.Discover(DataAccessContext.DataExport));
+        {
+            //extract the lookup table SQL
+            var sql = lookup.GetDataTableFetchSql();
+
+            var extractTableVerbatim = new ExtractTableVerbatim(
+                lookup.TableInfo.Discover(DataAccessContext.DataExport).Database.Server,
+                sql,lookup.TableInfo.GetRuntimeName(), lookupDir, _request.Configuration.Separator, DateFormat);
+
             linesWritten = extractTableVerbatim.DoExtraction();
             destinationDescription = extractTableVerbatim.OutputFilename;
         }

--- a/Rdmp.Core/DataExport/DataExtraction/UserPicks/BundledLookupTable.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/UserPicks/BundledLookupTable.cs
@@ -5,7 +5,10 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Data;
 using Rdmp.Core.Curation.Data;
+using Rdmp.Core.QueryBuilding;
+using ReusableLibraryCode.DataAccess;
 
 namespace Rdmp.Core.DataExport.DataExtraction.UserPicks
 {
@@ -28,6 +31,51 @@ namespace Rdmp.Core.DataExport.DataExtraction.UserPicks
         public override string ToString()
         {
             return TableInfo.ToString();
+        }
+
+        /// <summary>
+        /// Reads lookup data from the <see cref="TableInfo"/> using <see cref="DataAccessContext.DataExport"/>
+        /// </summary>
+        /// <returns></returns>
+        public DataTable GetDataTable()
+        {
+            var tbl = TableInfo.Discover(DataAccessContext.DataExport);
+            var server = tbl.Database.Server;
+
+            var dt = new DataTable();
+
+            using (var con = server.GetConnection())
+            {
+                con.Open();
+                using (var da = server.GetDataAdapter(
+                    server.GetCommand(GetDataTableFetchSql(),con)))
+                {
+                    da.Fill(dt);
+                }
+            }
+            return dt;
+        }
+
+        public string GetDataTableFetchSql()
+        {
+            var catas = TableInfo.GetAllRelatedCatalogues();
+            QueryBuilder qb;
+
+            if (catas.Length == 1)
+            {
+                // if there is a Catalogue associated with this TableInfo use its extraction instead
+                var cata = catas[0];
+                var eis = cata.GetAllExtractionInformation(ExtractionCategory.Core);
+                
+                if(eis.Length > 0)
+                {
+                    qb = new QueryBuilder(null, null, new[] { TableInfo });
+                    qb.AddColumnRange(eis);
+                    return qb.SQL;
+                }
+            }
+
+            return $"select * from {TableInfo.GetFullyQualifiedName()}";
         }
     }
 }

--- a/Rdmp.Core/DataExport/DataExtraction/UserPicks/BundledLookupTable.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/UserPicks/BundledLookupTable.cs
@@ -59,7 +59,7 @@ namespace Rdmp.Core.DataExport.DataExtraction.UserPicks
 
         public string GetDataTableFetchSql()
         {
-            var catas = TableInfo.GetAllRelatedCatalogues();
+            var catas = TableInfo.GetAllRelatedCatalogues().Where(IsLookupOnlyCatalogue).ToArray();
             QueryBuilder qb;
 
             if (catas.Length == 1)
@@ -83,6 +83,19 @@ namespace Rdmp.Core.DataExport.DataExtraction.UserPicks
             }
 
             return $"select * from {TableInfo.GetFullyQualifiedName()}";
+        }
+
+        /// <summary>
+        /// We only want Catalogues where all <see cref="CatalogueItem"/>
+        /// are us (i.e. we don't want to pick up Catalogues where we are 
+        /// Description column slotted in amongst the other columns).
+        /// </summary>
+        /// <param name="arg"></param>
+        /// <returns></returns>
+        private bool IsLookupOnlyCatalogue(Catalogue arg)
+        {
+            var tables = arg.GetTableInfoList(true);
+            return tables.Length == 1 && tables[0].ID == TableInfo.ID;
         }
     }
 }

--- a/Rdmp.UI/ExtractionUIs/JoinsAndLookups/KeyDropLocationUI.cs
+++ b/Rdmp.UI/ExtractionUIs/JoinsAndLookups/KeyDropLocationUI.cs
@@ -61,6 +61,9 @@ namespace Rdmp.UI.ExtractionUIs.JoinsAndLookups
 
             var col = GetColumnInfoOrNullFromDrag(e);
 
+            if (col == null)
+                return;
+
             if(IsValidGetter != null && !IsValidGetter(col))
                 return;
             

--- a/Tests.Common/UnitTests.cs
+++ b/Tests.Common/UnitTests.cs
@@ -598,11 +598,13 @@ namespace Tests.Common
         {
             ti1 = WhenIHaveA<TableInfo>(repository);
             ti1.Name = "ParentTable";
+            ti1.Database = "MyDb";
             ti1.SaveToDatabase();
             col1 = new ColumnInfo(repository, "ParentCol", "varchar(10)", ti1);
          
             ti2 = WhenIHaveA<TableInfo>(repository);
-            ti2.Name = "Child Table";
+            ti2.Name = "ChildTable";
+            ti2.Database = "MyDb";
             col2 = new ColumnInfo(repository, "ChildCol", "varchar(10)", ti2);
             col3 = new ColumnInfo(repository, "Desc", "varchar(10)", ti2);
         }


### PR DESCRIPTION
Fixes #692

To control what columns are extracted from a Lookup TableInfo.  Create a Catalogue from the TableInfo.  Then change the extractability of the `ExtractionInformation` in the Catalogue. 

- If a Lookup has no Catalogue then all columns are extracted
- If a Lookup has multiple Catalogue then all columns are extracted
- If a Lookup has a single Catalogue but none of the columns are extractable then an Exception is thrown

![image](https://user-images.githubusercontent.com/31306100/169012528-563cbae1-f987-4fdb-8fc4-0d320961c50c.png)
