### PR TITLE
closes #1022

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -31,6 +31,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Fixed
 
 - Fixed order of Sql Parameters not always being first in tree
+- Prevented Find/Select columns showing sort indicator when it is not supported
 
 ## [7.0.12] - 2022-05-16
 

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.cs
@@ -286,6 +286,12 @@ namespace Rdmp.UI.SimpleDialogs
                 olv.CellToolTip.InitialDelay = UserSettings.TooltipAppearDelay;
                 olv.CellToolTipShowing += (s, e) => RDMPCollectionCommonFunctionality.Tree_CellToolTipShowing(activator, e);
             }
+
+            //prevent sorting
+            foreach(var col in olv.AllColumns)
+            {
+                col.Sortable = false;
+            }
         }
 
         private void AddUsefulPropertiesIfHomogeneousTypes(T[] mapsDirectlyToDatabaseTables)


### PR DESCRIPTION
Its not feasible to allow sorting of the find which is already implicitly sorted on 'Sore'.  Performance would be bad and it would be complicated to maintain and error prone (from a usability point of view).

This PR closes #1022 by marking the columns as not sortable.  There is already a fix in for search indicator on another PR.