### PR TITLE
Fixed GoTo where path includes CatalogueFolder

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,6 +32,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Fixed order of Sql Parameters not always being first in tree
 - Prevented Find/Select columns showing sort indicator when it is not supported
+- Fixed GoTo where path includes CatalogueFolder in CLI gui
 
 ## [7.0.12] - 2022-05-16
 

--- a/Tools/rdmp/CommandLine/Gui/ConsoleMainWindow.cs
+++ b/Tools/rdmp/CommandLine/Gui/ConsoleMainWindow.cs
@@ -680,8 +680,9 @@ namespace Rdmp.Core.CommandLine.Gui
         {
             var type = o.GetType();
 
-            if(type == typeof(CatalogueFolder))
+            if(type == typeof(string) || type == typeof(CatalogueFolder))
                 return Catalogues;
+
             if(type == typeof(Project))
                 return Projects;
             if(type == typeof(LoadMetadata))	


### PR DESCRIPTION
Was caused in #1019 by the change of Catalogue.Folder from the type CatalogueFolder to a simple string