### PR TITLE
Update build.yml

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,7 +21,9 @@ jobs:
     steps:
       - name: Stub Node dependencies
         shell: bash
-        run: touch package-lock.json
+        run: |
+          echo /mnt/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe
+          touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0
         with:
@@ -119,7 +121,7 @@ jobs:
         shell: bash
         run: |
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x64\\signtool.exe" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
+          /mnt/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)
           (cd PublishLinux ; zip -9r ../dist/rdmp-cli-linux-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,8 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           signtool=`echo $signtool | sed -e 's#^/c#c:#' | tr / \\\\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo cmd /c $signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll' | cmd
-          cmd /c $signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
+          echo '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
+          echo '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll' | cmd
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,14 +118,11 @@ jobs:
       - name: Sign
         shell: bash
         run: |
-          echo listing
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
-          echo slicing
           signtool=${signtool[${#signtool[@]}-1]}
-          echo decoding
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo running
-          "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
+          echo "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
+          cmd /c "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -124,7 +124,7 @@ jobs:
           dotnet publish Tools/rdmp/rdmp.csproj -r linux-x64 --self-contained -c Release -o PublishLinux --verbosity minimal --nologo
       - name: BundleSource
         shell: bash
-        run:
+        run: |
           echo "dir /s/b *.cs *.xml" | cmd | perl -pe '$_=reverse' | sort -t'\' -k1,1 -u | perl -pe '$_=reverse' > srcbits.txt
           echo 7z a Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip @srcbits.zip | cmd
       - name: Get the version

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -141,7 +141,7 @@ jobs:
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
           echo '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll' | cmd
           mkdir -p dist
-          (cd PublishWindows ; cmd /c 7z a -mx=9 ../dist/rdmp-cli-win-x64.zip .)
+          (cd PublishWindows ; echo 7z a -mx=9 ../dist/rdmp-cli-win-x64.zip . | cmd)
           (cd PublishLinux ; cmd /c 7z a -mx=9 ../dist/rdmp-cli-linux-x64.zip .)
           mv PublishLinux rdmp-cli-linux
           cmd /c 7z a dist/rdmp-cli-linux-x64.tar rdmp-cli-linux

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -19,6 +19,9 @@ jobs:
     runs-on: windows-latest
 
     steps:
+      - name: Stub Node dependencies
+        shell: bash
+        run: touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -142,12 +142,12 @@ jobs:
           echo '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll' | cmd
           mkdir -p dist
           (cd PublishWindows ; echo 7z a -mx=9 ../dist/rdmp-cli-win-x64.zip . | cmd)
-          (cd PublishLinux ; cmd /c 7z a -mx=9 ../dist/rdmp-cli-linux-x64.zip .)
+          (cd PublishLinux ; echo 7z a -mx=9 ../dist/rdmp-cli-linux-x64.zip . | cmd)
           mv PublishLinux rdmp-cli-linux
-          cmd /c 7z a dist/rdmp-cli-linux-x64.tar rdmp-cli-linux
-          cmd /c 7z a dist/rdmp-cli-linux-x64.tar.gz dist/rdmp-cli-linux-x64.tar
+          echo 7z a dist/rdmp-cli-linux-x64.tar rdmp-cli-linux | cmd
+          echo 7z a dist/rdmp-cli-linux-x64.tar.gz dist/rdmp-cli-linux-x64.tar | cmd
           rm dist/rdmp-cli-linux-x64.tar
-          (cd PublishWinForms ; cmd /c 7z a -mx=9 ../dist/rdmp-client.zip .)
+          (cd PublishWinForms ; echo 7z a -mx=9 ../dist/rdmp-client.zip . | cmd)
 
       - name: Nuget packages
         if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
           echo "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
-          "$signtool" Sign /f GitHubActionsWorkflow.pfx /p '${{ secrets.DIGICERT_PASSWORD }}' /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
+          "$signtool" Sign /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
-          ls -lh $signtool
+          ls -lh "$signtool"
           touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0
@@ -125,7 +125,7 @@ jobs:
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          $signtool Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
+          "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)
           (cd PublishLinux ; zip -9r ../dist/rdmp-cli-linux-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
         run: |
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
-          signtool=`echo $foo | tr / \\ | sed -e 's/^\\c/c:/'`
+          signtool=`echo $foo | sed -e 's#^/c#c:#' | tr / \\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
           echo cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"
           cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,7 +24,7 @@ jobs:
         run: |
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
-          ls -lh signtool
+          ls -lh $signtool
           touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -122,7 +122,7 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
           echo "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
-          "$signtool" Sign /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
+          "$signtool" Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
         shell: bash
         run: |
           SqlLocalDB.exe create MSSQLLocalDB -s
-          sqlcmd -l 180 -S (localdb)\MSSQLLocalDB -Q "SELECT @@VERSION;"
+          sqlcmd -l 180 -S '(localdb)\MSSQLLocalDB' -Q "SELECT @@VERSION;"
           sed -i'' -e 's/localhost/\(localdb\)\\MSSQLLocalDB/' Tests.Common/TestDatabases.txt
       - uses: shogo82148/actions-setup-mysql@v1
         with:

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -74,10 +74,8 @@ jobs:
       - name: Test with local file system
         shell: bash
         run:  |
-              cd Tests.Common
-              echo "UseFileSystemRepo: true" >> TestDatabases.txt
-              type TestDatabases.txt
-              cd ..
+              echo "UseFileSystemRepo: true" >> Tests.Common/TestDatabases.txt
+              cat Tests.Common/TestDatabases.txt
       - name: Test Reusable (with file system repo)
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -110,7 +110,9 @@ jobs:
       - name: BundleSource
         shell: bash
         run: |
-          echo "dir /s/b *.cs *.xml" | cmd | perl -pe '$_=reverse' | sort -t'\' -k1,1 -u | perl -pe '$_=reverse' > srcbits.txt
+          mkdir -p Tools/BundleUpSourceIntoZip/output
+          echo "dir /s/b *.cs *.xml > srcbitsa.txt" | cmd
+          perl -pe '$_=reverse' < srcbitsa.txt | sort -t'\' -k1,1 -u | perl -pe '$_=reverse' > srcbits.txt
           echo 7z a -mx=9 Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip @srcbits.txt | cmd
       - name: Get the version
         id: get_version
@@ -119,6 +121,7 @@ jobs:
         shell: bash
 
       - name: Sign
+        if: contains(github.ref, 'refs/tags/v')
         shell: bash
         run: |
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install MS SQL 2019
         uses: crazy-max/ghaction-chocolatey@v2
         with:
-          args: install -r sql-server-2019
+          args: install -r sql-server-2019 --no-progress
       - uses: shogo82148/actions-setup-mysql@v1
         with:
           mysql-version: '8.0'
@@ -122,7 +122,7 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
           echo "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
-          cmd /c "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
+          "$signtool" Sign /f GitHubActionsWorkflow.pfx /p '${{ secrets.DIGICERT_PASSWORD }}' /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -53,7 +53,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
-        run: dotnet Tools/rdmp/bin/Release/net6.0/rdmp.dll install localhost TEST_
+        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install localhost TEST_
       - name: Test Reusable code
         shell: bash
         run: |
@@ -79,17 +79,17 @@ jobs:
       - name: Test Reusable (with file system repo)
         shell: bash
         run: |
-          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` recodefs.lcov
       - name: Test Core (with file system repo)
         shell: bash
         run: |
-          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` corefs.lcov
       - name: Test UI (with file system repo)
         shell: bash
         run: |
-          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` uifs.lcov
       
       - name: Merge LCovs
@@ -114,6 +114,18 @@ jobs:
         # Get the tag name e.g. v5.0.0 but skip the 'v'
         run: echo ::set-output name=VERSION::${GITHUB_REF/refs\/tags\/v/}
         shell: bash
+
+      - name: Sign
+        shell: bash
+        run: |
+          echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
+          "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x64\\signtool.exe" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
+          mkdir -p dist
+          (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)
+          (cd PublishLinux ; zip -9r ../dist/rdmp-cli-linux-x64.zip .)
+          mv PublishLinux rdmp-cli-linux
+          tar cf - rdmp-cli-linux | pixz -9e > dist/rdmp-cli-linux-x64.tar.xz
+          (cd PublishWinForms ; zip -9r ../dist/rdmp-client.zip .)
 
       - name: Sign
         if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,7 +139,7 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           signtool=`echo $signtool | sed -e 's#^/c#c:#' | tr / \\\\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo cmd /c $signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
+          echo cmd /c $signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll' | cmd
           cmd /c $signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
           echo packing
           mkdir -p dist

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,17 +59,17 @@ jobs:
         run: |
           rm -rf coverage
           echo dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          mv `find coverage -type f` recode.lcov
+          echo mv `find coverage -type f` recode.lcov
       - name: Test Core code
         shell: bash
         run: |
           echo dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          mv `find coverage -type f` core.lcov
+          echo mv `find coverage -type f` core.lcov
       - name: Test UI code
         shell: bash
         run: |
           echo dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          mv `find coverage -type f` ui.lcov
+          echo mv `find coverage -type f` ui.lcov
 
       - name: Test with local file system
         shell: bash
@@ -80,21 +80,22 @@ jobs:
         shell: bash
         run: |
           echo dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          mv `find coverage -type f` recodefs.lcov
+          echo mv `find coverage -type f` recodefs.lcov
       - name: Test Core (with file system repo)
         shell: bash
         run: |
           echo dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          mv `find coverage -type f` corefs.lcov
+          echo mv `find coverage -type f` corefs.lcov
       - name: Test UI (with file system repo)
         shell: bash
         run: |
           echo dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          mv `find coverage -type f` uifs.lcov
+          echo mv `find coverage -type f` uifs.lcov
       
       - name: Merge LCovs
-        run: lcov-result-merger "{ui,core,recode}{,fs}.lcov" all.lcov
+        run: echo lcov-result-merger "{ui,core,recode}{,fs}.lcov" all.lcov
       - name: Coveralls
+        if: ${{ false }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -25,10 +25,8 @@ jobs:
           mount
           echo /:
           ls -l /
-          echo /mnt:
-          ls -l /mnt
+          ls -lh /c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe
           find / -name signtool.exe
-          ls -lh /mnt/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe
           touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
-        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install "(localdb)\MSSQLLocalDB" TEST_
+        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install --createdatabasetimeout 180 "(localdb)\MSSQLLocalDB" TEST_
       - name: Test Reusable code
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,8 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           signtool=`echo $signtool | sed -e 's#^/c#c:#' | tr / \\\\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo cmd /c \"$signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll"'
-          cmd /c '"'"$signtool"'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
+          echo cmd /c '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
+          cmd /c '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,11 +18,13 @@ jobs:
         shell: bash
         run: touch package-lock.json
       - name: Install Node for coverage reporting
+        if: ${{ false }}
         uses: actions/setup-node@v3.2.0
         with:
           node-version: '16.x'
           cache: 'npm'
       - name: LCov merger tool
+        if: ${{ false }}
         run: npm install -g lcov-result-merger
       - name: Checkout code
         uses: actions/checkout@v3
@@ -37,16 +39,19 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Install MS SQL 2010 Express LocalDB
+        if: ${{ false }}
         uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install -r sqllocaldb --no-progress
       - name: Initialise LocalDB
+        if: ${{ false }}
         shell: bash
         run: |
           SqlLocalDB.exe create MSSQLLocalDB -s
           sqlcmd -l 180 -S '(localdb)\MSSQLLocalDB' -Q "SELECT @@VERSION;"
           sed -i'' -e 's/localhost/\(localdb\)\\MSSQLLocalDB/' Tests.Common/TestDatabases.txt
       - uses: shogo82148/actions-setup-mysql@v1
+        if: ${{ false }}
         with:
           mysql-version: '8.0'
           root-password: 'YourStrong!Passw0rd'
@@ -54,47 +59,56 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
+        if: ${{ false }}
         run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install --createdatabasetimeout 180 "(localdb)\MSSQLLocalDB" TEST_
       - name: Test Reusable code
+        if: ${{ false }}
         shell: bash
         run: |
           rm -rf coverage
-          echo dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          echo mv `find coverage -type f` recode.lcov
+          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` recode.lcov
       - name: Test Core code
+        if: ${{ false }}
         shell: bash
         run: |
-          echo dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          echo mv `find coverage -type f` core.lcov
+          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` core.lcov
       - name: Test UI code
+        if: ${{ false }}
         shell: bash
         run: |
-          echo dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          echo mv `find coverage -type f` ui.lcov
+          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` ui.lcov
 
       - name: Test with local file system
+        if: ${{ false }}
         shell: bash
         run:  |
               echo "UseFileSystemRepo: true" >> Tests.Common/TestDatabases.txt
               cat Tests.Common/TestDatabases.txt
       - name: Test Reusable (with file system repo)
+        if: ${{ false }}
         shell: bash
         run: |
-          echo dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          echo mv `find coverage -type f` recodefs.lcov
+          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` recodefs.lcov
       - name: Test Core (with file system repo)
+        if: ${{ false }}
         shell: bash
         run: |
-          echo dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          echo mv `find coverage -type f` corefs.lcov
+          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` corefs.lcov
       - name: Test UI (with file system repo)
+        if: ${{ false }}
         shell: bash
         run: |
-          echo dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-          echo mv `find coverage -type f` uifs.lcov
+          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` uifs.lcov
       
       - name: Merge LCovs
-        run: echo lcov-result-merger "{ui,core,recode}{,fs}.lcov" all.lcov
+        if: ${{ false }}
+        run: lcov-result-merger "{ui,core,recode}{,fs}.lcov" all.lcov
       - name: Coveralls
         if: ${{ false }}
         uses: coverallsapp/github-action@master
@@ -105,10 +119,11 @@ jobs:
       
       - name: Package
         run: |
-          dotnet publish Application/ResearchDataManagementPlatform/ResearchDataManagementPlatform.csproj -r win-x64 -c Release -o PublishWinForms --verbosity minimal --nologo
-          dotnet publish Tools/rdmp/rdmp.csproj -r win-x64 -c Release -o PublishWindows --verbosity minimal --nologo
-          dotnet publish Tools/rdmp/rdmp.csproj -r linux-x64 -c Release -o PublishLinux --verbosity minimal --nologo
+          dotnet publish Application/ResearchDataManagementPlatform/ResearchDataManagementPlatform.csproj -r win-x64 -c Release -o PublishWinForms --verbosity minimal --nologo --self-contained
+          dotnet publish Tools/rdmp/rdmp.csproj -r win-x64 -c Release -o PublishWindows --verbosity minimal --nologo --self-contained
+          dotnet publish Tools/rdmp/rdmp.csproj -r linux-x64 -c Release -o PublishLinux --verbosity minimal --nologo --self-contained
       - name: BundleSource
+        if: ${{ false }}
         shell: cmd
         run: powershell -noexit -executionpolicy bypass "& ./BundleSourceIntoZipFile.ps1"
       - name: Get the version
@@ -122,10 +137,10 @@ jobs:
         run: |
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
-          signtool=`echo $foo | sed -e 's#^/c#c:#' | tr / \\`
+          signtool=`echo $signtool | sed -e 's#^/c#c:#' | tr / \\\\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"
-          cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"
+          echo cmd /c \"$signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll"'
+          cmd /c \"$signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll"'
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,13 +18,11 @@ jobs:
         shell: bash
         run: touch package-lock.json
       - name: Install Node for coverage reporting
-        if: ${{ false }}
         uses: actions/setup-node@v3.2.0
         with:
           node-version: '16.x'
           cache: 'npm'
       - name: LCov merger tool
-        if: ${{ false }}
         run: npm install -g lcov-result-merger
       - name: Checkout code
         uses: actions/checkout@v3
@@ -39,19 +37,16 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Install MS SQL 2019 Express LocalDB
-        if: ${{ false }}
         uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install -r sqllocaldb --no-progress
       - name: Initialise LocalDB
-        if: ${{ false }}
         shell: bash
         run: |
           SqlLocalDB.exe create MSSQLLocalDB -s
           sqlcmd -l 180 -S '(localdb)\MSSQLLocalDB' -Q "SELECT @@VERSION;"
           sed -i'' -e 's/localhost/\(localdb\)\\MSSQLLocalDB/' Tests.Common/TestDatabases.txt
       - uses: shogo82148/actions-setup-mysql@v1
-        if: ${{ false }}
         with:
           mysql-version: '8.0'
           root-password: 'YourStrong!Passw0rd'
@@ -59,58 +54,48 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
-        if: ${{ false }}
         run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install --createdatabasetimeout 180 "(localdb)\MSSQLLocalDB" TEST_
       - name: Test Reusable code
-        if: ${{ false }}
         shell: bash
         run: |
           rm -rf coverage
           dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` recode.lcov
       - name: Test Core code
-        if: ${{ false }}
         shell: bash
         run: |
           dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` core.lcov
       - name: Test UI code
-        if: ${{ false }}
         shell: bash
         run: |
           dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` ui.lcov
 
       - name: Test with local file system
-        if: ${{ false }}
         shell: bash
         run:  |
               echo "UseFileSystemRepo: true" >> Tests.Common/TestDatabases.txt
               cat Tests.Common/TestDatabases.txt
       - name: Test Reusable (with file system repo)
-        if: ${{ false }}
         shell: bash
         run: |
           dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` recodefs.lcov
       - name: Test Core (with file system repo)
-        if: ${{ false }}
         shell: bash
         run: |
           dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` corefs.lcov
       - name: Test UI (with file system repo)
-        if: ${{ false }}
         shell: bash
         run: |
           dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` uifs.lcov
       
       - name: Merge LCovs
-        if: ${{ false }}
         run: lcov-result-merger "{ui,core,recode}{,fs}.lcov" all.lcov
       - name: Coveralls
-        if: ${{ false }}
         uses: coverallsapp/github-action@master
         with:
           github-token: ${{ secrets.github_token }}
@@ -126,7 +111,7 @@ jobs:
         shell: bash
         run: |
           echo "dir /s/b *.cs *.xml" | cmd | perl -pe '$_=reverse' | sort -t'\' -k1,1 -u | perl -pe '$_=reverse' > srcbits.txt
-          echo 7z a Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip @srcbits.zip | cmd
+          echo 7z a -mx=9 Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip @srcbits.txt | cmd
       - name: Get the version
         id: get_version
         # Get the tag name e.g. v5.0.0 but skip the 'v'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,7 +22,7 @@ jobs:
       - name: Stub Node dependencies
         shell: bash
         run: |
-          echo /mnt/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe
+          ls -lh /mnt/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe
           touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -118,16 +118,22 @@ jobs:
       - name: Sign
         shell: bash
         run: |
+          echo listing
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
+          echo slicing
           signtool=${signtool[${#signtool[@]}-1]}
+          echo decoding
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
+          echo running
           "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
+          echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)
           (cd PublishLinux ; zip -9r ../dist/rdmp-cli-linux-x64.zip .)
           mv PublishLinux rdmp-cli-linux
           tar cf - rdmp-cli-linux | pixz -9e > dist/rdmp-cli-linux-x64.tar.xz
           (cd PublishWinForms ; zip -9r ../dist/rdmp-client.zip .)
+          echo done
 
       - name: Nuget packages
         if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -3,11 +3,6 @@ name: Build
 # Run this workflow every time a new commit pushed to your repository
 
 on: push
-env:
-  MSSQL_SA_PASSWORD: "YourStrong!Passw0rd"
-  ACCEPT_EULA: "Y"
-  MSSQL_PID: "developer"
-  DOTNET_NOLOGO: 1
 
 jobs:
   # Set the job key. The key is displayed as the job name
@@ -41,11 +36,14 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 6.0.x
-      - name: Install MS SQL 2019
-        if: ${{ false }}
+      - name: Install MS SQL 2010 Express LocalDB
         uses: crazy-max/ghaction-chocolatey@v2
         with:
-          args: install -r sql-server-2019 --no-progress
+          args: install -r sqllocaldb --no-progress
+      - name: Initialise LocalDB
+        run: |
+          SqlLocalDB.exe create MSSQLLocalDB -s
+          sqlcmd -l 180 -S "$db" -Q "SELECT @@VERSION;"
       - uses: shogo82148/actions-setup-mysql@v1
         with:
           mysql-version: '8.0'
@@ -54,7 +52,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
-        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install localhost TEST_
+        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install (localdb)\MSSQLLocalDB TEST_
       - name: Test Reusable code
         shell: bash
         run: |
@@ -122,7 +120,7 @@ jobs:
         run: |
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
-          signtool=`echo $foo | tr / \\ | sed -e s/^\/c/\:/`
+          signtool=`echo $foo | tr / \\ | sed -e 's/^\\c/c:/'`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
           echo cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"
           cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -21,11 +21,7 @@ jobs:
     steps:
       - name: Stub Node dependencies
         shell: bash
-        run: |
-          signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
-          signtool=${signtool[${#signtool[@]}-1]}
-          ls -lh "$signtool"
-          touch package-lock.json
+        run: touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0
         with:
@@ -133,15 +129,6 @@ jobs:
           tar cf - rdmp-cli-linux | pixz -9e > dist/rdmp-cli-linux-x64.tar.xz
           (cd PublishWinForms ; zip -9r ../dist/rdmp-client.zip .)
 
-      - name: Sign
-        if: contains(github.ref, 'refs/tags/v')
-        shell: cmd
-        run: |
-            powershell.exe -nologo -noprofile -command "& { [IO.File]::WriteAllBytes(\"GitHubActionsWorkflow.pfx\", [System.Convert]::FromBase64String(\"${{ secrets.DIGICERT_PFX }}\")); }"
-            "C:\\Program Files (x86)\\Windows Kits\\10\\bin\\x86\\signtool.exe" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
-            mkdir dist
-            powershell.exe -nologo -noprofile -command "& { Add-Type -A 'System.IO.Compression.FileSystem'; [IO.Compression.ZipFile]::CreateFromDirectory('PublishWindows', 'dist/rdmp-cli-win-x64.zip'); [IO.Compression.ZipFile]::CreateFromDirectory('PublishLinux', 'dist/rdmp-cli-linux-x64.zip'); [IO.Compression.ZipFile]::CreateFromDirectory('PublishWinForms', 'dist/rdmp-client.zip');}"
-      
       - name: Nuget packages
         if: contains(github.ref, 'refs/tags/v')
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,16 +139,15 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           signtool=`echo $signtool | sed -e 's#^/c#c:#' | tr / \\\\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
           echo '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll' | cmd
-          echo packing
           mkdir -p dist
-          (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)
-          (cd PublishLinux ; zip -9r ../dist/rdmp-cli-linux-x64.zip .)
+          (cd PublishWindows ; cmd /c 7z a -mx=9 ../dist/rdmp-cli-win-x64.zip .)
+          (cd PublishLinux ; cmd /c 7z a -mx=9 ../dist/rdmp-cli-linux-x64.zip .)
           mv PublishLinux rdmp-cli-linux
-          tar cf - rdmp-cli-linux | pixz -9e > dist/rdmp-cli-linux-x64.tar.xz
-          (cd PublishWinForms ; zip -9r ../dist/rdmp-client.zip .)
-          echo done
+          cmd /c 7z a dist/rdmp-cli-linux-x64.tar rdmp-cli-linux
+          cmd /c 7z a dist/rdmp-cli-linux-x64.tar.gz dist/rdmp-cli-linux-x64.tar
+          rm dist/rdmp-cli-linux-x64.tar
+          (cd PublishWinForms ; cmd /c 7z a -mx=9 ../dist/rdmp-client.zip .)
 
       - name: Nuget packages
         if: contains(github.ref, 'refs/tags/v')

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -23,69 +23,73 @@ jobs:
         uses: actions/setup-node@v3.2.0
         with:
           node-version: '16.x'
+          cache: 'npm'
       - name: LCov merger tool
-        run: |
-          npm install -g lcov-result-merger
+        run: npm install -g lcov-result-merger
       - name: Checkout code
         uses: actions/checkout@v3
+      - uses: actions/cache@v1
+        with:
+          path: ~/.nuget/packages
+          key: ${{ runner.os }}-nuget-${{ hashFiles('**/packages.lock.json') }}
+          restore-keys: |
+            ${{ runner.os }}-nuget-
       - name: Setup .NET Core
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 6.0.x
       - name: Install MS SQL 2019
-        run: Choco-Install -PackageName sql-server-2019 --params="'/IgnorePendingReboot'"
+        uses: crazy-max/ghaction-chocolatey@v2
+        with:
+          args: install sql-server-2019
       - uses: shogo82148/actions-setup-mysql@v1
         with:
           mysql-version: '8.0'
           root-password: 'YourStrong!Passw0rd'
           auto-start: true
       - name: Build
-        run: |
-          dotnet clean --configuration Release --nologo --verbosity minimal
-          dotnet nuget locals all --clear
-          dotnet restore -v:q
-          dotnet build --configuration Release --nologo --verbosity minimal
+        run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
         run: dotnet Tools/rdmp/bin/Release/net6.0/rdmp.dll install localhost TEST_
-      - name: Clean coverage output directory
-        run: Remove-Item coverage -Recurse -ErrorAction Ignore
       - name: Test Reusable code
-        run: dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - name: Rename Reusable lcov
         shell: bash
-        run: mv `find coverage -type f` recode.lcov
+        run: |
+          rm -rf coverage
+          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` recode.lcov
       - name: Test Core code
-        run: dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - name: Rename core lcov
         shell: bash
-        run: mv `find coverage -type f` core.lcov
+        run: |
+          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` core.lcov
       - name: Test UI code
-        run: dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - name: Rename UI lcov
         shell: bash
-        run: mv `find coverage -type f` ui.lcov
-     
+        run: |
+          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` ui.lcov
+
       - name: Test with local file system
+        shell: bash
         run:  |
               cd Tests.Common
               echo "UseFileSystemRepo: true" >> TestDatabases.txt
               type TestDatabases.txt
               cd ..
       - name: Test Reusable (with file system repo)
-        run: dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - name: Rename Reusable lcov
         shell: bash
-        run: mv `find coverage -type f` recodefs.lcov
+        run: |
+          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` recodefs.lcov
       - name: Test Core (with file system repo)
-        run: dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - name: Rename core lcov
         shell: bash
-        run: mv `find coverage -type f` corefs.lcov
+        run: |
+          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` corefs.lcov
       - name: Test UI (with file system repo)
-        run: dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
-      - name: Rename UI lcov
         shell: bash
-        run: mv `find coverage -type f` uifs.lcov
+        run: |
+          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=  -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          mv `find coverage -type f` uifs.lcov
       
       - name: Merge LCovs
         run: lcov-result-merger "{ui,core,recode}{,fs}.lcov" all.lcov

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -119,9 +119,9 @@ jobs:
       
       - name: Package
         run: |
-          dotnet publish Application/ResearchDataManagementPlatform/ResearchDataManagementPlatform.csproj -r win-x64 -c Release -o PublishWinForms --verbosity minimal --nologo --self-contained
-          dotnet publish Tools/rdmp/rdmp.csproj -r win-x64 -c Release -o PublishWindows --verbosity minimal --nologo --self-contained
-          dotnet publish Tools/rdmp/rdmp.csproj -r linux-x64 -c Release -o PublishLinux --verbosity minimal --nologo --self-contained
+          dotnet publish Application/ResearchDataManagementPlatform/ResearchDataManagementPlatform.csproj -r win-x64 --self-contained -c Release -o PublishWinForms --verbosity minimal --nologo
+          dotnet publish Tools/rdmp/rdmp.csproj -r win-x64 --self-contained -c Release -o PublishWindows --verbosity minimal --nologo
+          dotnet publish Tools/rdmp/rdmp.csproj -r linux-x64 --self-contained -c Release -o PublishLinux --verbosity minimal --nologo
       - name: BundleSource
         if: ${{ false }}
         shell: cmd
@@ -140,7 +140,7 @@ jobs:
           signtool=`echo $signtool | sed -e 's#^/c#c:#' | tr / \\\\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
           echo cmd /c \"$signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll"'
-          cmd /c \"$signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll"'
+          cmd /c '"'"$signtool"'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -121,7 +121,7 @@ jobs:
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
+          "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)
           (cd PublishLinux ; zip -9r ../dist/rdmp-cli-linux-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,11 +22,9 @@ jobs:
       - name: Stub Node dependencies
         shell: bash
         run: |
-          mount
-          echo /:
-          ls -l /
-          ls -lh /c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe
-          find / -name signtool.exe
+          signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
+          signtool=${signtool[${#signtool[@]}-1]}
+          ls -lh signtool
           touch package-lock.json
       - name: Install Node for coverage reporting
         uses: actions/setup-node@v3.2.0
@@ -124,8 +122,10 @@ jobs:
       - name: Sign
         shell: bash
         run: |
+          signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
+          signtool=${signtool[${#signtool[@]}-1]}
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          /mnt/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
+          $signtool Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 PublishWindows/*.dll PublishWindows/*.exe  PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)
           (cd PublishLinux ; zip -9r ../dist/rdmp-cli-linux-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -58,17 +58,17 @@ jobs:
         shell: bash
         run: |
           rm -rf coverage
-          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          echo dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` recode.lcov
       - name: Test Core code
         shell: bash
         run: |
-          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          echo dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` core.lcov
       - name: Test UI code
         shell: bash
         run: |
-          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          echo dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` ui.lcov
 
       - name: Test with local file system
@@ -79,17 +79,17 @@ jobs:
       - name: Test Reusable (with file system repo)
         shell: bash
         run: |
-          dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          echo dotnet test "Reusable/Tests/ReusableCodeTests/ReusableCodeTests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` recodefs.lcov
       - name: Test Core (with file system repo)
         shell: bash
         run: |
-          dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          echo dotnet test "./Rdmp.Core.Tests/Rdmp.Core.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` corefs.lcov
       - name: Test UI (with file system repo)
         shell: bash
         run: |
-          dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
+          echo dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` uifs.lcov
       
       - name: Merge LCovs
@@ -120,9 +120,10 @@ jobs:
         run: |
           signtool=(/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe)
           signtool=${signtool[${#signtool[@]}-1]}
+          signtool=`echo $foo | tr / \\ | sed -e s/^\/c/\:/`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo "$signtool" Sign /f GitHubActionsWorkflow.pfx /p ${{ secrets.DIGICERT_PASSWORD }} /fd sha256 /tr http://timestamp.digicert.com /td sha256 "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
-          "$signtool" Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' "PublishWindows/*.dll" "PublishWindows/*.exe" "PublishLinux/*.dll" "PublishWinForms/*.exe" "PublishWinForms/*.dll"
+          echo cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"
+          cmd /c \"$signtool Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p '${{ secrets.DIGICERT_PASSWORD }}' PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll\"
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
-        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install (localdb)\MSSQLLocalDB TEST_
+        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install "(localdb)\MSSQLLocalDB" TEST_
       - name: Test Reusable code
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -139,8 +139,8 @@ jobs:
           signtool=${signtool[${#signtool[@]}-1]}
           signtool=`echo $signtool | sed -e 's#^/c#c:#' | tr / \\\\`
           echo ${{ secrets.DIGICERT_PFX }} | base64 --decode > GitHubActionsWorkflow.pfx
-          echo cmd /c '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
-          cmd /c '"'$signtool'"' 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
+          echo cmd /c $signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
+          cmd /c $signtool 'Sign  /f GitHubActionsWorkflow.pfx /fd sha256 /tr http://timestamp.digicert.com /td sha256 /p ${{ secrets.DIGICERT_PASSWORD }} PublishWindows/*.dll PublishWindows/*.exe PublishLinux/*.dll PublishWinForms/*.exe PublishWinForms/*.dll'
           echo packing
           mkdir -p dist
           (cd PublishWindows ; zip -9r ../dist/rdmp-cli-win-x64.zip .)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -44,7 +44,7 @@ jobs:
       - name: Install MS SQL 2019
         uses: crazy-max/ghaction-chocolatey@v2
         with:
-          args: install sql-server-2019
+          args: install -r sql-server-2019
       - uses: shogo82148/actions-setup-mysql@v1
         with:
           mysql-version: '8.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -22,6 +22,12 @@ jobs:
       - name: Stub Node dependencies
         shell: bash
         run: |
+          mount
+          echo /:
+          ls -l /
+          echo /mnt:
+          ls -l /mnt
+          find / -name signtool.exe
           ls -lh /mnt/c/Program\ Files\ \(x86\)/Windows\ Kits/10/bin/*/x64/signtool.exe
           touch package-lock.json
       - name: Install Node for coverage reporting

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -41,9 +41,11 @@ jobs:
         with:
           args: install -r sqllocaldb --no-progress
       - name: Initialise LocalDB
+        shell: bash
         run: |
           SqlLocalDB.exe create MSSQLLocalDB -s
-          sqlcmd -l 180 -S "$db" -Q "SELECT @@VERSION;"
+          sqlcmd -l 180 -S (localdb)\MSSQLLocalDB -Q "SELECT @@VERSION;"
+          sed -i'' -e 's/localhost/\(localdb\)\\MSSQLLocalDB/' Tests.Common/TestDatabases.txt
       - uses: shogo82148/actions-setup-mysql@v1
         with:
           mysql-version: '8.0'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -42,6 +42,7 @@ jobs:
         with:
           dotnet-version: 6.0.x
       - name: Install MS SQL 2019
+        if: ${{ false }}
         uses: crazy-max/ghaction-chocolatey@v2
         with:
           args: install -r sql-server-2019 --no-progress

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -123,9 +123,10 @@ jobs:
           dotnet publish Tools/rdmp/rdmp.csproj -r win-x64 --self-contained -c Release -o PublishWindows --verbosity minimal --nologo
           dotnet publish Tools/rdmp/rdmp.csproj -r linux-x64 --self-contained -c Release -o PublishLinux --verbosity minimal --nologo
       - name: BundleSource
-        if: ${{ false }}
-        shell: cmd
-        run: powershell -noexit -executionpolicy bypass "& ./BundleSourceIntoZipFile.ps1"
+        shell: bash
+        run:
+          echo "dir /s/b *.cs *.xml" | cmd | rev | sort -t'\' -k1,1 -u | rev > srcbits.txt
+          echo 7z a Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip @srcbits.zip | cmd
       - name: Get the version
         id: get_version
         # Get the tag name e.g. v5.0.0 but skip the 'v'

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -38,7 +38,7 @@ jobs:
         uses: actions/setup-dotnet@v2
         with:
           dotnet-version: 6.0.x
-      - name: Install MS SQL 2010 Express LocalDB
+      - name: Install MS SQL 2019 Express LocalDB
         if: ${{ false }}
         uses: crazy-max/ghaction-chocolatey@v2
         with:
@@ -125,7 +125,7 @@ jobs:
       - name: BundleSource
         shell: bash
         run:
-          echo "dir /s/b *.cs *.xml" | cmd | rev | sort -t'\' -k1,1 -u | rev > srcbits.txt
+          echo "dir /s/b *.cs *.xml" | cmd | perl -pe '$_=reverse' | sort -t'\' -k1,1 -u | perl -pe '$_=reverse' > srcbits.txt
           echo 7z a Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip @srcbits.zip | cmd
       - name: Get the version
         id: get_version

--- a/BundleSourceIntoZipFile.ps1
+++ b/BundleSourceIntoZipFile.ps1
@@ -1,2 +1,0 @@
-Get-ChildItem -Path ./ -recurse | where {$_.name -match '.*\.cs$'} | Compress-Archive -DestinationPath "./Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip" -Force
-Get-ChildItem -Path ./ -recurse | where {$_.name -match '.*\.xml$'} | Select-Object -Unique | Compress-Archive -DestinationPath "./Tools/BundleUpSourceIntoZip/output/SourceCodeForSelfAwareness.zip" -Update


### PR DESCRIPTION
- Cache nuget packages where possible, since the lack of caching caused some CI failure recently
- Switch to using 7z to generate ZIP files instead of Powershell, fixing bug in file paths
- Rearrange invocation of Signtool, since the old Powershell call to it was silently failing on releases
- Add a .tgz file for the Linux release since that works better than zip (keeping zip for now since downstream uses it)