### PR TITLE
Add -e option to initial install in CI

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -54,7 +54,7 @@ jobs:
       - name: Build
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
-        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install --createdatabasetimeout 180 "(localdb)\MSSQLLocalDB" TEST_
+        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install --createdatabasetimeout 180 "(localdb)\MSSQLLocalDB" TEST_ -e
       - name: Test Reusable code
         shell: bash
         run: |

--- a/Rdmp.Core/CommandLine/DatabaseCreation/ExampleDatasetsCreation.cs
+++ b/Rdmp.Core/CommandLine/DatabaseCreation/ExampleDatasetsCreation.cs
@@ -6,7 +6,10 @@
 
 using BadMedicine;
 using BadMedicine.Datasets;
+using FAnsi;
 using FAnsi.Discovery;
+using FAnsi.Discovery.ConnectionStringDefaults;
+using Microsoft.Data.SqlClient;
 using Rdmp.Core.CohortCommitting;
 using Rdmp.Core.CohortCommitting.Pipeline;
 using Rdmp.Core.CohortCommitting.Pipeline.Sources;
@@ -29,6 +32,7 @@ using Rdmp.Core.Repositories;
 using ReusableLibraryCode.Checks;
 using ReusableLibraryCode.Progress;
 using System;
+using System.Collections.Generic;
 using System.Data;
 using System.IO;
 using System.Linq;
@@ -61,6 +65,16 @@ namespace Rdmp.Core.CommandLine.DatabaseCreation
                 else
                     throw new Exception("Database " + db.GetRuntimeName() + " already exists and allowDrop option was not specified");
             
+            if(db.Server.Builder is SqlConnectionStringBuilder b)
+            {
+                var keywords = _repos.CatalogueRepository
+                    .GetAllObjects<ConnectionStringKeyword>()
+                    .Where(k=>k.DatabaseType == DatabaseType.MicrosoftSQLServer)
+                    .ToArray();
+
+                AddKeywordIfSpecified(b.TrustServerCertificate, nameof(b.TrustServerCertificate),keywords);
+            }
+
             notifier.OnCheckPerformed(new CheckEventArgs("About to create "+ db.GetRuntimeName(),CheckResult.Success));
             //create a new database for the datasets
             db.Create();
@@ -226,6 +240,18 @@ namespace Rdmp.Core.CommandLine.DatabaseCreation
                     }
                 }
 
+            }
+        }
+
+        private void AddKeywordIfSpecified(bool isEnabled, string name, ConnectionStringKeyword[] alreadyDeclared)
+        {
+            if (isEnabled && !alreadyDeclared.Any(k => k.Name.Equals(name)))
+            {
+                var keyword = new ConnectionStringKeyword(_activator.RepositoryLocator.CatalogueRepository,
+                    DatabaseType.MicrosoftSQLServer, name, "true");
+
+                //pass it into the system wide static keyword collection for use with all databases of this type all the time
+                DiscoveredServerHelper.AddConnectionStringKeyword(keyword.DatabaseType, keyword.Name, keyword.Value, ConnectionStringKeywordPriority.SystemDefaultMedium);
             }
         }
 


### PR DESCRIPTION
This PR fixes the fact that installing on linux or docker etc with the `TrustServerCertificate` setting enabled does not work for example datasets.  This is because there is no `ConnectionStringKeyword` created that would force RDMP to always use that setting when connecting to a DBMS of the sql server type.

This PR updates the install process so that when `TrustServerCertificate` is specified it is created as a permenant rule in the resulting databases.

CI does not bring this issue out because it is using localdb which doesn't require `TrustServerCertificate` of true.