### PR TITLE
Aliases

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -64,6 +64,8 @@ jobs:
           EOF
       - name: Run integration test scripts
         run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
+      - name: Run integration script create_cohort.yaml
+        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml
       - name: Test Reusable code
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,6 +55,14 @@ jobs:
         run: dotnet build --configuration Release --nologo --verbosity minimal
       - name: Initialise RDMP
         run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install --createdatabasetimeout 180 "(localdb)\MSSQLLocalDB" TEST_ -e
+      - name: Populate Databases.yaml 
+        run: |
+          cat > Databases.yaml << EOF
+          CatalogueConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_Catalogue;Trusted_Connection=True;Trust     Server        Certificate=true;
+          DataExportConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_DataExport;Trusted_Connection=True;Trust       Server      Certificate=true;
+          EOF
+      - name: Run integration test scripts
+        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
       - name: Test Reusable code
         shell: bash
         run: |
@@ -71,7 +79,6 @@ jobs:
         run: |
           dotnet test "./Rdmp.UI.Tests/Rdmp.UI.Tests.csproj" --nologo --collect:"XPlat Code Coverage" --no-build --verbosity minimal -c Release -r coverage -- DataCollectionRunSettings.DataCollectors.DataCollector.Configuration.Format=lcov
           mv `find coverage -type f` ui.lcov
-
       - name: Test with local file system
         shell: bash
         run:  |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -59,11 +59,11 @@ jobs:
         shell: bash
         run: |
           cat > ./Tools/rdmp/Databases.yaml << EOF
-          CatalogueConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_Catalogue;Trusted_Connection=True;Trust     Server        Certificate=true;
-          DataExportConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_DataExport;Trusted_Connection=True;Trust       Server      Certificate=true;
+          CatalogueConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_Catalogue;Trusted_Connection=True;TrustServerCertificate=true;
+          DataExportConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_DataExport;Trusted_Connection=True;TrustServerCertificate=true;
           EOF
       - name: Run integration test scripts
-        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
+        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
       - name: Test Reusable code
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -56,8 +56,9 @@ jobs:
       - name: Initialise RDMP
         run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- install --createdatabasetimeout 180 "(localdb)\MSSQLLocalDB" TEST_ -e
       - name: Populate Databases.yaml 
+        shell: bash
         run: |
-          cat > Databases.yaml << EOF
+          cat > ./Tools/rdmp/Databases.yaml << EOF
           CatalogueConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_Catalogue;Trusted_Connection=True;Trust     Server        Certificate=true;
           DataExportConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_DataExport;Trusted_Connection=True;Trust       Server      Certificate=true;
           EOF

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,7 +67,11 @@ jobs:
       - name: Run integration script create_cohort.yaml
         run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml
       - name: Run integration script create_dataload.yaml
-        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_dataload.yaml
+        run: |
+           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_dataload.yaml &&
+           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- dle -l "LoadMetadata:*Biochemistry" --command check &&
+           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- dle -l "LoadMetadata:*Biochemistry" --command run
+
       - name: Test Reusable code
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,7 +63,7 @@ jobs:
           DataExportConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_DataExport;Trusted_Connection=True;TrustServerCertificate=true;
           EOF
       - name: Run integration test scripts
-        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
+        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
       - name: Test Reusable code
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -66,6 +66,8 @@ jobs:
         run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
       - name: Run integration script create_cohort.yaml
         run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml
+      - name: Run integration script create_dataload.yaml
+        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_dataload.yaml
       - name: Test Reusable code
         shell: bash
         run: |

--- a/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
+++ b/Application/ResearchDataManagementPlatform/Menus/RDMPTopMenuStripUI.cs
@@ -211,7 +211,7 @@ namespace ResearchDataManagementPlatform.Menus
 
         private void generateTestDataToolStripMenuItem_Click(object sender, EventArgs e)
         {
-            new ExecuteCommandGenerateTestData(Activator).Execute();
+            new ExecuteCommandGenerateTestDataUI(Activator).Execute();
         }
         
         private void showPerformanceCounterToolStripMenuItem_Click(object sender, EventArgs e)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 
 - Added checkbox for show/hide ProjectSpecific Catalogue columns in extraction configuration UI [#1265](https://github.com/HicServices/RDMP/issues/1265)
+- Integration tests and example scripts that can be run using RDMP command line `-f` option
 
 ### Fixed
 
@@ -21,6 +22,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - Pasted column name(s) with spaces e.g. `[my cool col]` now work
 - Fixed null reference in extraction checks when extracting a dataset where the original [ExtractionInformation] has been deleted [#1253](https://github.com/HicServices/RDMP/issues/1253)
 - Added an error provider message for when too many characters are entered in UIs with databindings [#1268](https://github.com/HicServices/RDMP/issues/1268).
+- Fixed running on command line with `-f somefile.yaml` being considered 'interactive' (i.e. RDMP would pause to ask you questions like 'are you sure?')
 
 ## [7.0.14] - 2022-06-27
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added checkbox for show/hide ProjectSpecific Catalogue columns in extraction configuration UI [#1265](https://github.com/HicServices/RDMP/issues/1265)
 - Integration tests and example scripts that can be run using RDMP command line `-f` option
+- The `Set` command no longer cares about property capitalization
 
 ### Fixed
 

--- a/Documentation/CodeTutorials/RdmpCommandLine.md
+++ b/Documentation/CodeTutorials/RdmpCommandLine.md
@@ -60,15 +60,22 @@ DataExportConnectionString: Server=<yourserver>;Database=RDMP_DataExport;Trusted
 In addition to running engines, many commands can be run from the CLI.  To see what commands are available use
 
 ```
-./rdmp cmd ListSupportedCommands
+./rdmp ListSupportedCommands
 ```
 *Listing commands requires valid connection settings, see [installation](#install)*
 
 For example you can view a list of what Catalogues you have by running:
 
 ```
-./rdmp cmd list Catalogue
+./rdmp list Catalogue
 ```
+*Lists all Catalogues in RDMP along with their IDs*
+
+To see the arguments of a command use 'describe' e.g.:
+```
+./rdmp describe confirmlogs
+```
+*Displays help for the command 'ConfirmLogs'*
 
 Some commands require specifying a database (e.g. `CreateNewCatalogueByImportingFile`).  The following table shows the syntax for such parameters
 
@@ -92,6 +99,11 @@ You can access an interactive terminal similar to the RDMP gui client by running
 ```
 rdmp gui
 ```
+
+## Scripting
+
+You can run a sequence of commands all at once by using the 
+
 
 [Pipeline]: ./Glossary.md#Pipeline
 [Catalogue]: ./Glossary.md#Catalogue

--- a/HIC.DataManagementPlatform.sln
+++ b/HIC.DataManagementPlatform.sln
@@ -79,6 +79,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{B010E3F1-3124-437A-8F09-06C3840C46BD}"
 	ProjectSection(SolutionItems) = preProject
+		scripts\create_cohort.yaml = scripts\create_cohort.yaml
 		scripts\create_list_destroy_catalogue.yaml = scripts\create_list_destroy_catalogue.yaml
 	EndProjectSection
 EndProject

--- a/HIC.DataManagementPlatform.sln
+++ b/HIC.DataManagementPlatform.sln
@@ -80,6 +80,7 @@ EndProject
 Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{B010E3F1-3124-437A-8F09-06C3840C46BD}"
 	ProjectSection(SolutionItems) = preProject
 		scripts\create_cohort.yaml = scripts\create_cohort.yaml
+		scripts\create_dataload.yaml = scripts\create_dataload.yaml
 		scripts\create_list_destroy_catalogue.yaml = scripts\create_list_destroy_catalogue.yaml
 	EndProjectSection
 EndProject

--- a/HIC.DataManagementPlatform.sln
+++ b/HIC.DataManagementPlatform.sln
@@ -77,6 +77,11 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Documentation", "Documentat
 		Documentation\CodeTutorials\Validation.md = Documentation\CodeTutorials\Validation.md
 	EndProjectSection
 EndProject
+Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{B010E3F1-3124-437A-8F09-06C3840C46BD}"
+	ProjectSection(SolutionItems) = preProject
+		scripts\create_list_destroy_catalogue.yaml = scripts\create_list_destroy_catalogue.yaml
+	EndProjectSection
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|Any CPU = Debug|Any CPU

--- a/Rdmp.Core.Tests/CommandExecution/CommandInvokerTests.cs
+++ b/Rdmp.Core.Tests/CommandExecution/CommandInvokerTests.cs
@@ -30,7 +30,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         [Timeout(5000)]
         public void Test_ListSupportedCommands_NoPicker()
         {
-            var mgr = new ConsoleInputManager(RepositoryLocator,new ThrowImmediatelyCheckNotifier());
+            var mgr =  GetActivator();
             var invoker = new CommandInvoker(mgr);
             
             invoker.ExecuteCommand(typeof(ExecuteCommandListSupportedCommands),null);
@@ -53,7 +53,7 @@ namespace Rdmp.Core.Tests.CommandExecution
         [Timeout(5000)]
         public void Test_Generic_WithPicker()
         {
-            var mgr = new ConsoleInputManager(RepositoryLocator,new ThrowImmediatelyCheckNotifier());
+            var mgr = GetActivator();
             var invoker = new CommandInvoker(mgr);
 
             WhenIHaveA<Catalogue>();

--- a/Rdmp.Core.Tests/DataLoad/Engine/Integration/HICPipelineTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Integration/HICPipelineTests.cs
@@ -256,7 +256,7 @@ namespace Rdmp.Core.Tests.DataLoad.Engine.Integration
                 }
 
                 var options = new DleOptions();
-                options.LoadMetadata = catalogueEntities.LoadMetadata.ID;
+                options.LoadMetadata = catalogueEntities.LoadMetadata.ID.ToString();
                 options.Command = CommandLineActivity.check;
 
                 //run checks (with ignore errors if we are sending dodgy credentials)

--- a/Rdmp.Core/CommandExecution/AliasAttribute.cs
+++ b/Rdmp.Core/CommandExecution/AliasAttribute.cs
@@ -4,35 +4,23 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
-using System.Text;
-using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.CommandExecution.AtomicCommands;
+using System;
 
-namespace Rdmp.Core.CommandExecution.AtomicCommands
+namespace Rdmp.Core.CommandExecution
 {
     /// <summary>
-    /// Lists all the objects in RDMP that match search term.
+    /// Defines an alternative name for <see cref="IAtomicCommand"/> that can be used
+    /// e.g. "ls" instead of "List"
     /// </summary>
-    [Alias("ls")]
-    public class ExecuteCommandList : BasicCommandExecution
+    [System.AttributeUsage(AttributeTargets.Class)]
+    public class AliasAttribute : System.Attribute
     {
-        private IMapsDirectlyToDatabaseTable[] _toList;
 
-        public ExecuteCommandList(IBasicActivateItems activator,
-            
-            IMapsDirectlyToDatabaseTable[] toList):base(activator)
+        public string Name { get; }
+        public AliasAttribute(string name)
         {
-            _toList = toList;
-        }
-
-        public override void Execute()
-        {
-            base.Execute();
-
-            StringBuilder sb = new StringBuilder();
-            foreach (var m in _toList)
-                sb.AppendLine(m.ID + ":" + m);
-
-            BasicActivator.Show(sb.ToString());
+            Name = name;
         }
     }
 }

--- a/Rdmp.Core/CommandExecution/AliasAttribute.cs
+++ b/Rdmp.Core/CommandExecution/AliasAttribute.cs
@@ -13,7 +13,7 @@ namespace Rdmp.Core.CommandExecution
     /// Defines an alternative name for <see cref="IAtomicCommand"/> that can be used
     /// e.g. "ls" instead of "List"
     /// </summary>
-    [System.AttributeUsage(AttributeTargets.Class)]
+    [System.AttributeUsage(AttributeTargets.Class,AllowMultiple = true)]
     public class AliasAttribute : System.Attribute
     {
 

--- a/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
@@ -718,7 +718,7 @@ namespace Rdmp.Core.CommandExecution
 
             if (Is(o, out CohortAggregateContainer cohortAggregateContainer))
             {
-                yield return new ExecuteCommandAddCatalogueToCohortIdentificationSetContainer(_activator, cohortAggregateContainer) { SuggestedCategory = Add, OverrideCommandName = "Catalogue" };
+                yield return new ExecuteCommandAddCatalogueToCohortIdentificationSetContainer(_activator, cohortAggregateContainer,null,null) { SuggestedCategory = Add, OverrideCommandName = "Catalogue" };
                 yield return new ExecuteCommandAddCohortSubContainer(_activator, cohortAggregateContainer) { SuggestedCategory = Add,  OverrideCommandName = "Sub Container" };
                 yield return new ExecuteCommandAddAggregateConfigurationToCohortIdentificationSetContainer(_activator, cohortAggregateContainer, true) { SuggestedCategory = Add, OverrideCommandName = "Existing Cohort Set (copy of)" };
                 yield return new ExecuteCommandAddAggregateConfigurationToCohortIdentificationSetContainer(_activator, cohortAggregateContainer, false) { SuggestedCategory = Add, OverrideCommandName = "Aggregate" };

--- a/Rdmp.Core/CommandExecution/AtomicCommands/Alter/ExecuteCommandAlterTableCreatePrimaryKey.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/Alter/ExecuteCommandAlterTableCreatePrimaryKey.cs
@@ -4,10 +4,13 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System.Collections.Generic;
 using System.Linq;
 using System.Threading;
 using System.Threading.Tasks;
+using Rdmp.Core.CommandLine.Interactive.Picking;
 using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Repositories.Construction;
 using ReusableLibraryCode.DataAccess;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands.Alter
@@ -17,6 +20,25 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands.Alter
     /// </summary>
     public class ExecuteCommandAlterTableCreatePrimaryKey : AlterTableCommandExecution
     {
+        private ColumnInfo[] _columnInfos;
+
+        [UseWithCommandLine( ParameterHelpList = "<TableInfo> <ColumnInfo1> <ColumnInfo2> etc",
+            ParameterHelpBreakdown = @"TableInfo    The table you want to create a primary key on e.g. TableInfo:*Biochem*
+ColumnInfos List of columns that should form the primary key (1 for simple primary key, 2+ for composite primary key)")]
+        public ExecuteCommandAlterTableCreatePrimaryKey(IBasicActivateItems activator, CommandLineObjectPicker picker) :
+            this(activator, (TableInfo)picker[0].GetValueForParameterOfType(typeof(TableInfo)))
+        {
+            if (IsImpossible)
+                return;
+
+            var pick = new List<ColumnInfo>();
+            for (int i = 1; i < picker.Length; i++)
+            {
+                pick.Add((ColumnInfo)picker[i].GetValueForParameterOfType(typeof(ColumnInfo)));
+            }
+
+            _columnInfos = pick.ToArray();
+        }
         public ExecuteCommandAlterTableCreatePrimaryKey(IBasicActivateItems activator, TableInfo tableInfo):base(activator,tableInfo)
         {
             if(IsImpossible)
@@ -35,19 +57,23 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands.Alter
 
             Synchronize();
 
-            if (SelectMany(TableInfo.ColumnInfos, out ColumnInfo[] selected))
-            {
-                var cts = new CancellationTokenSource();
+            var cols = _columnInfos;
 
-                var task = Task.Run(() =>
-                    Table.CreatePrimaryKey(selected.Select(c => c.Discover(DataAccessContext.DataLoad)).ToArray()));
-                
-                Wait("Creating Primary Key...",task, cts);
+            if (cols == null && SelectMany(TableInfo.ColumnInfos, out ColumnInfo[] selected))
+                cols = selected;
 
-                if(task.IsFaulted)
-                    ShowException("Create Primary Key Failed",task.Exception);
-            }
+            if (cols == null || cols.Length == 0)
+                return;
+            
+            var cts = new CancellationTokenSource();
+
+            var task = Task.Run(() =>
+                Table.CreatePrimaryKey(cols.Select(c => c.Discover(DataAccessContext.DataLoad)).ToArray()));
                 
+            Wait("Creating Primary Key...",task, cts);
+
+            if(task.IsFaulted)
+                ShowException("Create Primary Key Failed",task.Exception);
             
             Synchronize();
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewLoadMetadata.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewLoadMetadata.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
 using System.Drawing;
 using System.Linq;
 using Rdmp.Core.Curation.Data;
@@ -18,12 +19,19 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         private Catalogue[] _availableCatalogues;
         private Catalogue _catalogue;
 
-        public ExecuteCommandCreateNewLoadMetadata(IBasicActivateItems activator) : base(activator)
+        public ExecuteCommandCreateNewLoadMetadata(IBasicActivateItems activator,
+        [DemandsInitialization("Which Catalogue does this load.  Catalogues must not be associated with an existing load")]
+         Catalogue catalogue = null) : base(activator)
         {
             _availableCatalogues = activator.CoreChildProvider.AllCatalogues.Where(c => c.LoadMetadata_ID == null).ToArray();
 
             if (!_availableCatalogues.Any())
                 SetImpossible("There are no Catalogues that are not associated with another Load already");
+
+            if(catalogue != null)
+            {
+                SetTarget(catalogue);
+            }
 
             UseTripleDotSuffix = true;
         }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
@@ -51,7 +51,13 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             }
             else
             {
-                SetImpossible("Did not recognise parameter as a valid command");
+                // Maybe they typed the alias or name of a command
+                _nonDatabaseObjectToDescribe = new CommandInvoker(BasicActivator).GetSupportedCommands()
+                .FirstOrDefault(t=>BasicCommandExecution.HasCommandNameOrAlias(t,picker[0].RawValue));
+                
+                    
+                if(_nonDatabaseObjectToDescribe == null)
+                    SetImpossible("Did not recognise parameter as a valid command");
             }
         }
 
@@ -345,6 +351,13 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
             // Basic info about command
             sb.AppendLine("Name: " + commandType.Name);
+
+
+            var aliases = commandType.GetCustomAttributes(false).OfType<AliasAttribute>().ToArray();
+            if(aliases.Any())
+            {
+                sb.AppendLine("Aliases:" + string.Join(',',aliases.Select(a=>a.Name).ToArray()));
+            }
                 
             var helpText = help.GetTypeDocumentationIfExists(commandType);
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
@@ -340,8 +340,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
         private void PopulateBasicCommandInfo(StringBuilder sb,Type commandType)
         {
-            var help = new CommentStore();
-            help.ReadComments(Environment.CurrentDirectory);
+            var help = BasicActivator.CommentStore;
 
             // Basic info about command
             sb.AppendLine("Name: " + commandType.Name);

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
@@ -153,7 +153,8 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             if (o is Type t)
             {
                 title = t.Name;
-                var docs = BasicActivator.CommentStore.GetTypeDocumentationIfExists(t, true, true);
+                var help = BasicActivator.CommentStore ?? CreateCommentStore();
+                var docs = help.GetTypeDocumentationIfExists(t, true, true);
                 return docs?.Trim() ?? "";
             }
 
@@ -340,7 +341,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
         private void PopulateBasicCommandInfo(StringBuilder sb,Type commandType)
         {
-            var help = BasicActivator.CommentStore;
+            var help = BasicActivator.CommentStore ?? CreateCommentStore();
 
             // Basic info about command
             sb.AppendLine("Name: " + commandType.Name);
@@ -362,6 +363,13 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             sb.Append(BasicCommandExecution.GetCommandName(commandType.Name));
             sb.Append(" ");
 
+        }
+
+        private CommentStore CreateCommentStore()
+        {
+            var help = new CommentStore();
+            help.ReadComments(Environment.CurrentDirectory);
+            return help;
         }
     }
 }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
@@ -365,11 +365,5 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
         }
 
-        private CommentStore CreateCommentStore()
-        {
-            var help = new CommentStore();
-            help.ReadComments(Environment.CurrentDirectory);
-            return help;
-        }
     }
 }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandGenerateTestData.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandGenerateTestData.cs
@@ -1,0 +1,61 @@
+// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using System.Linq;
+using BadMedicine;
+using BadMedicine.Datasets;
+
+namespace Rdmp.Core.CommandExecution.AtomicCommands
+{
+    /// <summary>
+    /// Generates CSV files on disk for RDMP example datasets (based on BadMedicine library)
+    /// </summary>
+    public class ExecuteCommandGenerateTestData : BasicCommandExecution
+    {
+        private readonly string _datasetName;
+        private readonly int _numberOfPeople;
+        private readonly int _numberOfRecords;
+        private readonly string _toFile;
+        private Random _r;
+        private IDataGenerator _generator;
+
+        public ExecuteCommandGenerateTestData(IBasicActivateItems activator, string datasetName, int numberOfPeople, int numberOfRecords, int seed, string toFile):base(activator)
+        {
+            this._datasetName = datasetName;
+            this._numberOfPeople = numberOfPeople;
+            this._numberOfRecords = numberOfRecords;
+            this._toFile = toFile;
+
+            var dataGeneratorFactory = new DataGeneratorFactory();
+            var match = dataGeneratorFactory.GetAvailableGenerators().FirstOrDefault(g=>g.Name.Contains(datasetName,StringComparison.InvariantCultureIgnoreCase));
+
+            if(match == null)
+            {
+                SetImpossible($"Unknown dataset '{datasetName}'.  Known datasets are:{Environment.NewLine}{string.Join(Environment.NewLine,dataGeneratorFactory.GetAvailableGenerators().Select(g=>g.Name).ToArray())}");
+                return;
+            }
+            _r = new Random(seed);
+            _generator = dataGeneratorFactory.Create(match,_r);
+        }
+
+        public override void Execute()
+        {
+            base.Execute();
+
+            var people = new PersonCollection();
+            people.GeneratePeople(_numberOfPeople,_r);
+
+            var f = new FileInfo(_toFile);
+
+            if(!f.Directory.Exists)
+                f.Directory.Create();
+
+            _generator.GenerateTestDataFile(people,f,_numberOfRecords);
+        }
+    }
+}

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandList.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandList.cs
@@ -4,8 +4,12 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System;
+using System.Collections.Generic;
 using System.Text;
 using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Repositories.Construction;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands
 {
@@ -17,9 +21,10 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
     {
         private IMapsDirectlyToDatabaseTable[] _toList;
 
+        [UseWithObjectConstructor]
         public ExecuteCommandList(IBasicActivateItems activator,
-            
-            IMapsDirectlyToDatabaseTable[] toList):base(activator)
+            [DemandsInitialization("The objects you want listed e.g. Catalogue:*bob* or a type e.g. TableInfo or blank to list everything")]
+            IMapsDirectlyToDatabaseTable[] toList = null):base(activator)
         {
             _toList = toList;
         }
@@ -28,9 +33,30 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         {
             base.Execute();
 
+            if(_toList == null)
+            {
+                ListEveryone();
+                return;
+            }
+
             StringBuilder sb = new StringBuilder();
             foreach (var m in _toList)
                 sb.AppendLine(m.ID + ":" + m);
+
+            BasicActivator.Show(sb.ToString());
+        }
+
+        private void ListEveryone()
+        {
+            StringBuilder sb = new StringBuilder();
+            
+            foreach(var repo in BasicActivator.RepositoryLocator.GetAllRepositories())
+            {
+                foreach(var o in repo.GetAllObjectsInDatabase())
+                {
+                    sb.AppendLine($"{o.GetType().Name}:{o.ID}:{o}");
+                }
+            }
 
             BasicActivator.Show(sb.ToString());
         }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandList.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandList.cs
@@ -9,11 +9,16 @@ using MapsDirectlyToDatabaseTable;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands
 {
+    /// <summary>
+    /// Lists all the objects in RDMP that match search term.
+    /// </summary>
     public class ExecuteCommandList : BasicCommandExecution
     {
         private IMapsDirectlyToDatabaseTable[] _toList;
 
-        public ExecuteCommandList(IBasicActivateItems activator,IMapsDirectlyToDatabaseTable[] toList):base(activator)
+        public ExecuteCommandList(IBasicActivateItems activator,
+            
+            IMapsDirectlyToDatabaseTable[] toList):base(activator)
         {
             _toList = toList;
         }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandListSupportedCommands.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandListSupportedCommands.cs
@@ -79,7 +79,6 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 }
             }
 
-            var sb = new StringBuilder();
             bool showAll = onlyShowIndexes.Count == 0;
             var outputCommandDictionary = new Dictionary<string,string>();
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandListSupportedCommands.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandListSupportedCommands.cs
@@ -5,27 +5,98 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Generic;
 using System.Linq;
+using System.Text;
+using Rdmp.Core.Curation.Data;
+using ReusableLibraryCode.Checks;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands
 {
+    /// <summary>
+    /// Lists all known commands, optionally restricted to those matching pattern
+    /// </summary>
+    [Alias("lc")]
+    [Alias("ListCommands")]
     class ExecuteCommandListSupportedCommands:BasicCommandExecution
     {
-        public ExecuteCommandListSupportedCommands(IBasicActivateItems basicActivator):base(basicActivator)
+        private readonly string _pattern;
+        private readonly bool _verbose;
+
+        public ExecuteCommandListSupportedCommands(IBasicActivateItems basicActivator, 
+            [DemandsInitialization("Optional. A term to look for in command names.  Supports wildcards e.g. new*cata.  If not supplied then all will be shown")]
+            string pattern=null,
+            [DemandsInitialization("Optional. Set to true to display information about the command.  If specified with pattern then pattern will also search the description")]
+            bool verbose = false):base(basicActivator)
         {
-            
+            this._pattern = pattern;
+            this._verbose = verbose;
         }
 
         public override void Execute()
         {
             var commandCaller = new CommandInvoker(BasicActivator);
 
-            string commands = string.Join(Environment.NewLine,
-                commandCaller.GetSupportedCommands()
-                    .Select(t => BasicCommandExecution.GetCommandName(t.Name))
+            
+            var commands = commandCaller.GetSupportedCommands().ToArray();
+            var names = commands.Select(c=>BasicCommandExecution.GetCommandName(c.Name)).ToArray();
+            string[] descriptions;
+            
+             
+            if(_verbose)
+            {
+                var help = BasicActivator.CommentStore ?? CreateCommentStore();
+                descriptions = commands.Select(c=>help.GetTypeDocumentationIfExists(c)).ToArray();
+            }
+            else
+            {
+                descriptions = new string[commands.Length];
+            }
+
+            var onlyShowIndexes = new HashSet<int>();
+
+            if(!string.IsNullOrWhiteSpace(_pattern))
+            {
+                var tokens = _pattern.Split('*',StringSplitOptions.RemoveEmptyEntries);
+
+                for(int i=0;i<commands.Length;i++)
+                {
+                    if(tokens.All(t=>names[i].Contains(t,StringComparison.InvariantCultureIgnoreCase)))
+                    {
+                        onlyShowIndexes.Add(i);
+                    }
+                    if(tokens.All(t=>descriptions[i]?.Contains(t,StringComparison.InvariantCultureIgnoreCase) ?? false))
+                    {
+                        onlyShowIndexes.Add(i);
+                    }
+                }
+
+                // Nothing matches pattern
+                if(!onlyShowIndexes.Any())
+                {
+                    BasicActivator.GlobalErrorCheckNotifier.OnCheckPerformed(new CheckEventArgs("No commands matched supplied pattern",CheckResult.Warning));
+                    return;
+                }
+            }
+
+            var sb = new StringBuilder();
+            bool showAll = onlyShowIndexes.Count == 0;
+            var outputCommandDictionary = new Dictionary<string,string>();
+
+            for(int i=0;i<commands.Length;i++)
+            {
+                if(showAll || onlyShowIndexes.Contains(i))
+                {
+                    var desc = string.IsNullOrWhiteSpace(descriptions[i]) ? "" : $"{Environment.NewLine}{descriptions[i]}{Environment.NewLine}";
+                    outputCommandDictionary.Add(names[i],desc);
+                }
+            }
+
+            string output = string.Join(Environment.NewLine,
+                    outputCommandDictionary.Select(kvp => kvp.Key+kvp.Value)
                         .OrderBy(s=>s));
 
-            BasicActivator.Show(commands);
+            BasicActivator.Show(output);
 
             base.Execute();
         }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSet.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSet.cs
@@ -101,7 +101,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             var props = setOn.GetType().GetProperties();
             
             return props.FirstOrDefault(p => string.Equals(p.Name, property)) ??
-                   props.FirstOrDefault(p => string.Equals(p.Name, property,StringComparison.CurrentCultureIgnoreCase));
+                   props.FirstOrDefault(p => string.Equals(p.Name, property,StringComparison.InvariantCultureIgnoreCase));
 
         }
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSet.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSet.cs
@@ -58,7 +58,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         {
             _setOn = setOn;
 
-            _property = _setOn.GetType().GetProperty(property);
+            _property = GetProperty(_setOn, property);
 
             if(_setOn is IMightBeReadOnly m)
             {
@@ -95,6 +95,16 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                     NewValue = picker[0].GetValueForParameterOfType(_property.PropertyType);
             }
         }
+
+        private PropertyInfo GetProperty(IMapsDirectlyToDatabaseTable setOn, string property)
+        {
+            var props = setOn.GetType().GetProperties();
+            
+            return props.FirstOrDefault(p => string.Equals(p.Name, property)) ??
+                   props.FirstOrDefault(p => string.Equals(p.Name, property,StringComparison.CurrentCultureIgnoreCase));
+
+        }
+
         public ExecuteCommandSet(IBasicActivateItems activator,IMapsDirectlyToDatabaseTable setOn,PropertyInfo property):base(activator)
         {
             _setOn = setOn;

--- a/Rdmp.Core/CommandExecution/BasicCommandExecution.cs
+++ b/Rdmp.Core/CommandExecution/BasicCommandExecution.cs
@@ -22,6 +22,7 @@ using Rdmp.Core.DataViewing;
 using Rdmp.Core.Repositories.Construction;
 using ReusableLibraryCode;
 using ReusableLibraryCode.Checks;
+using ReusableLibraryCode.Comments;
 using ReusableLibraryCode.DataAccess;
 using ReusableLibraryCode.Icons.IconProvision;
 
@@ -508,6 +509,13 @@ namespace Rdmp.Core.CommandExecution
         public override string ToString()
         {
             return GetCommandName();
+        }
+
+        protected CommentStore CreateCommentStore()
+        {
+            var help = new CommentStore();
+            help.ReadComments(Environment.CurrentDirectory);
+            return help;
         }
     }
 }

--- a/Rdmp.Core/CommandExecution/BasicCommandExecution.cs
+++ b/Rdmp.Core/CommandExecution/BasicCommandExecution.cs
@@ -517,5 +517,21 @@ namespace Rdmp.Core.CommandExecution
             help.ReadComments(Environment.CurrentDirectory);
             return help;
         }
+
+        /// <summary>
+        /// Returns true if the supplied command Type is known (directly or via alias)
+        /// as <paramref name="name"/>
+        /// </summary>
+        public static bool HasCommandNameOrAlias(Type commandType, string name)
+        {
+            return 
+                    commandType.Name.Equals(BasicCommandExecution.ExecuteCommandPrefix + name,StringComparison.InvariantCultureIgnoreCase) 
+                    || 
+                    commandType.Name.Equals(name,StringComparison.InvariantCultureIgnoreCase) 
+                    || 
+                    commandType.GetCustomAttributes<AliasAttribute>(false)
+                    .Any(a=>a.Name.Equals(name,StringComparison.InvariantCultureIgnoreCase));
+        }
+
     }
 }

--- a/Rdmp.Core/CommandExecution/CommandInvoker.cs
+++ b/Rdmp.Core/CommandExecution/CommandInvoker.cs
@@ -351,13 +351,19 @@ namespace Rdmp.Core.CommandExecution
             var match =  _argumentDelegates.FirstOrDefault(k=>k.CanHandle(required.Type));
 
             if(match != null)
-                return match;
+            {
+                // prefer delegate if no user input required or running in interactive mode
+                if(match.IsAuto || _basicActivator.IsInteractive)
+                    return match;
+            }
 
-            if(required.HasDefaultValue && required.DefaultValue != null)
-                return new CommandInvokerFixedValueDelegate(required.DefaultValue);
 
-            return null;
+            // use the default value (preferred if non interactive)
+            if(required.HasDefaultValue)
+                return new CommandInvokerFixedValueDelegate(required.Type, required.DefaultValue);
 
+            // return delegate anyway (could be null)
+            return match;
         }
         public bool IsSupported(Type t)
         {

--- a/Rdmp.Core/CommandExecution/CommandInvokerFixedValueDelegate.cs
+++ b/Rdmp.Core/CommandExecution/CommandInvokerFixedValueDelegate.cs
@@ -14,9 +14,14 @@ namespace Rdmp.Core.CommandExecution
     /// </summary>
     class CommandInvokerFixedValueDelegate : CommandInvokerDelegate
     {
-        public CommandInvokerFixedValueDelegate(object o):base(o.GetType(),true,(p)=>o)
+        public CommandInvokerFixedValueDelegate(Type type,object o):base(type,true,(p)=>o)
         {
             
+        }
+
+        public override bool CanHandle(Type t)
+        {
+            return true;
         }
     }
 }

--- a/Rdmp.Core/CommandExecution/CommandInvokerFixedValueDelegate.cs
+++ b/Rdmp.Core/CommandExecution/CommandInvokerFixedValueDelegate.cs
@@ -14,7 +14,7 @@ namespace Rdmp.Core.CommandExecution
     /// </summary>
     class CommandInvokerFixedValueDelegate : CommandInvokerDelegate
     {
-        public CommandInvokerFixedValueDelegate(Type type,object o):base(type,true,(p)=>o)
+        public CommandInvokerFixedValueDelegate(Type type,object o):base(type,false,(p)=>o)
         {
             
         }

--- a/Rdmp.Core/CommandLine/Options/DleOptions.cs
+++ b/Rdmp.Core/CommandLine/Options/DleOptions.cs
@@ -16,8 +16,8 @@ namespace Rdmp.Core.CommandLine.Options
     [Verb("dle", HelpText = "Runs the Data Load Engine")]
     public class DleOptions : RDMPCommandLineOptions
     {
-        [Option('l',"LoadMetadata",HelpText = "The ID of the LoadMetadata you want to run", Required = false, Default = 0)]
-        public int LoadMetadata { get; set; }
+        [Option('l',"LoadMetadata",HelpText = "The ID of the LoadMetadata you want to run or pattern e.g. LoadMetadata:Load*bob", Required = false, Default = 0)]
+        public string LoadMetadata { get; set; }
 
         [Option('p', "LoadProgress", HelpText = "If your LoadMetadata has multiple LoadProgresses, you can run only one of them by specifying the ID of the LoadProgress to run here", Required = false, Default = 0)]
         public int LoadProgress { get; set; }
@@ -42,9 +42,9 @@ namespace Rdmp.Core.CommandLine.Options
         {
             get
             {
-                yield return new Example("Run load LoadMetadata with ID 30",new DleOptions(){Command = CommandLineActivity.run,LoadMetadata = 30});
-                yield return new Example("Override for RDMP platform databases (specified in .config)", new DleOptions() { Command = CommandLineActivity.run, LoadMetadata = 30, ServerName = @"localhost\sqlexpress", CatalogueDatabaseName = "RDMP_Catalogue", DataExportDatabaseName = "RDMP_DataExport" });
-                yield return new Example("Use explicit connection strings to RDMP databases", new DleOptions() { Command = CommandLineActivity.run, LoadMetadata = 30, CatalogueConnectionString = ExampleCatalogueConnectionString,DataExportConnectionString = ExampleDataExportConnectionString});
+                yield return new Example("Run load LoadMetadata with ID 30",new DleOptions(){Command = CommandLineActivity.run,LoadMetadata = "30"});
+                yield return new Example("Override for RDMP platform databases (specified in .config)", new DleOptions() { Command = CommandLineActivity.run, LoadMetadata = "LoadMetadata:Loading*Biochem*", ServerName = @"localhost\sqlexpress", CatalogueDatabaseName = "RDMP_Catalogue", DataExportDatabaseName = "RDMP_DataExport" });
+                yield return new Example("Use explicit connection strings to RDMP databases", new DleOptions() { Command = CommandLineActivity.run, LoadMetadata = "30", CatalogueConnectionString = ExampleCatalogueConnectionString,DataExportConnectionString = ExampleDataExportConnectionString});
             }
         }
     }

--- a/Rdmp.Core/CommandLine/Runners/DleRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/DleRunner.cs
@@ -25,10 +25,11 @@ using ReusableLibraryCode.Progress;
 
 namespace Rdmp.Core.CommandLine.Runners
 {
+
     /// <summary>
     /// <see cref="IRunner"/> for the Data Load Engine.  Supports both check and execute commands.
     /// </summary>
-    public class DleRunner:IRunner
+    public class DleRunner:Runner
     {
         private readonly DleOptions _options;
 
@@ -37,10 +38,10 @@ namespace Rdmp.Core.CommandLine.Runners
             _options = options;
         }
         
-        public int Run(IRDMPPlatformRepositoryServiceLocator locator, IDataLoadEventListener listener, ICheckNotifier checkNotifier,GracefulCancellationToken token)
+        public override int Run(IRDMPPlatformRepositoryServiceLocator locator, IDataLoadEventListener listener, ICheckNotifier checkNotifier,GracefulCancellationToken token)
         {
             ILoadProgress loadProgress = locator.CatalogueRepository.GetObjectByID<LoadProgress>(_options.LoadProgress);
-            ILoadMetadata loadMetadata = locator.CatalogueRepository.GetObjectByID<LoadMetadata>(_options.LoadMetadata);
+            ILoadMetadata loadMetadata = GetObjectFromCommandLineString<LoadMetadata>(locator,_options.LoadMetadata);
 
             if (loadMetadata == null && loadProgress != null)
                     loadMetadata = loadProgress.LoadMetadata;
@@ -102,5 +103,7 @@ namespace Rdmp.Core.CommandLine.Runners
                     throw new ArgumentOutOfRangeException();
             }
         }
+
+        
     }
 }

--- a/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
@@ -44,6 +44,12 @@ namespace Rdmp.Core.CommandLine.Runners
             // but allow it if the input is ./rdmp cmd (i.e. run in a loop prompting for commands)
             _input.DisallowInput = !string.IsNullOrWhiteSpace(_options.CommandName);
 
+            // prevent user input if we are running a script file
+            if(!string.IsNullOrWhiteSpace(_options.File))
+            {
+                _input.DisallowInput = true;
+            }
+
             var log = LogManager.GetCurrentClassLogger();
 
             _listener = listener;

--- a/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
@@ -107,7 +107,10 @@ namespace Rdmp.Core.CommandLine.Runners
         private void RunCommand(string command)
         {
             if(_commands.ContainsKey(command))
+            {
+                _listener.OnNotify(this,new NotifyEventArgs(ProgressEventType.Trace,$"Running Command '{_commands[command].Name}'"));
                 _invoker.ExecuteCommand(_commands[command],_picker);
+            }
             else
             {
                 var suggestions =

--- a/Rdmp.Core/CommandLine/Runners/Runner.cs
+++ b/Rdmp.Core/CommandLine/Runners/Runner.cs
@@ -1,0 +1,46 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using MapsDirectlyToDatabaseTable;
+using Rdmp.Core.CommandExecution;
+using Rdmp.Core.CommandLine.Interactive.Picking;
+using Rdmp.Core.DataFlowPipeline;
+using Rdmp.Core.Repositories;
+using ReusableLibraryCode.Checks;
+using ReusableLibraryCode.Progress;
+
+namespace Rdmp.Core.CommandLine.Runners
+{
+    /// <summary>
+    /// Abstract base implementation of <see cref="IRunner"/> with convenience methods
+    /// </summary>
+    public abstract class Runner: IRunner
+    {
+        public abstract int Run(IRDMPPlatformRepositoryServiceLocator repositoryLocator, IDataLoadEventListener listener, ICheckNotifier checkNotifier, GracefulCancellationToken token);
+
+        /// <summary>
+        /// Translates a string <paramref name="arg"/> into an object of type <typeparamref name="T"/>.  String can 
+        /// just be the ID e.g. "5" or could be an RDMP command line expression e.g. "LoadMetadata:*Load*Biochemistry*"
+        /// </summary>
+        /// <typeparam name="T"></typeparam>
+        /// <param name="locator"></param>
+        /// <param name="arg"></param>
+        /// <returns></returns>
+        /// <exception cref="ArgumentException">Thrown if it is not possible to parse <paramref name="arg"/> into an existing object</exception>
+        protected T GetObjectFromCommandLineString<T>(IRDMPPlatformRepositoryServiceLocator locator, string arg) where T : IMapsDirectlyToDatabaseTable
+        {
+            if (int.TryParse(arg, out var id))
+                return locator.CatalogueRepository.GetObjectByID<T>(id);
+
+            var picker = new CommandLineObjectPicker(new[] { arg }, new ThrowImmediatelyActivator(locator));
+            if (!picker[0].HasValueOfType(typeof(T)))
+                throw new ArgumentException($"Could not translate '{arg}' into a valid object of Type '{typeof(T).Name}'.  The referenced object may not exist or has been renamed.");
+
+            return (T)picker[0].GetValueForParameterOfType(typeof(T));
+        }
+    }
+}

--- a/Rdmp.Core/DataExport/DataExtraction/ExtractTableVerbatim.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/ExtractTableVerbatim.cs
@@ -220,6 +220,12 @@ namespace Rdmp.Core.DataExport.DataExtraction
         {
             var point = collection.GetDataAccessPoint();
             var db = DataAccessPortal.GetInstance().ExpectDatabase(point,context);
+
+            if(!toFile.Directory.Exists)
+            {
+                toFile.Directory.Create();
+            }
+
             using (var fs = File.OpenWrite(toFile.FullName))
             {
                 var toRun = new ExtractTableVerbatim(db.Server, collection.GetSql(), fs, ",", null);

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandGenerateTestDataUI.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandGenerateTestDataUI.cs
@@ -9,9 +9,9 @@ using Rdmp.UI.SimpleDialogs.Reports;
 
 namespace Rdmp.UI.CommandExecution.AtomicCommands
 {
-    public class ExecuteCommandGenerateTestData : BasicUICommandExecution
+    public class ExecuteCommandGenerateTestDataUI : BasicUICommandExecution
     {
-        public ExecuteCommandGenerateTestData(IActivateItems activator) : base(activator)
+        public ExecuteCommandGenerateTestDataUI(IActivateItems activator) : base(activator)
         {
         }
 

--- a/Rdmp.UI/CommandExecution/Proposals/ProposeExecutionWhenTargetIsCohortAggregateContainer.cs
+++ b/Rdmp.UI/CommandExecution/Proposals/ProposeExecutionWhenTargetIsCohortAggregateContainer.cs
@@ -28,7 +28,7 @@ namespace Rdmp.UI.CommandExecution.Proposals
 
         public override void Activate(CohortAggregateContainer target)
         {
-            var cmd = new ExecuteCommandAddCatalogueToCohortIdentificationSetContainer(ItemActivator, target);
+            var cmd = new ExecuteCommandAddCatalogueToCohortIdentificationSetContainer(ItemActivator, target,null);
             if(!cmd.IsImpossible)
                 cmd.Execute();
         }

--- a/Rdmp.UI/LoadExecutionUIs/ExecuteLoadMetadataUI.cs
+++ b/Rdmp.UI/LoadExecutionUIs/ExecuteLoadMetadataUI.cs
@@ -129,7 +129,7 @@ namespace Rdmp.UI.LoadExecutionUIs
             var options = new DleOptions
             {
                 Command = activityRequested,
-                LoadMetadata = _loadMetadata.ID,
+                LoadMetadata = _loadMetadata.ID.ToString(),
                 Iterative = cbRunIteratively.Checked,
                 DaysToLoad = Convert.ToInt32(udDaysPerJob.Value),
                 DoNotArchiveData = debugOpts != DebugOptions.RunNormally,

--- a/Rdmp.UI/Tutorials/TutorialTracker.cs
+++ b/Rdmp.UI/Tutorials/TutorialTracker.cs
@@ -36,7 +36,7 @@ namespace Rdmp.UI.Tutorials
         {
             TutorialsAvailable = new List<Tutorial>();
             
-            TutorialsAvailable.Add(new Tutorial("1. Generate Test Data", new ExecuteCommandGenerateTestData(_activator), new Guid("8255fb4e-94a4-4bbc-9e8d-edec5ecebab0")));
+            TutorialsAvailable.Add(new Tutorial("1. Generate Test Data", new ExecuteCommandGenerateTestDataUI(_activator), new Guid("8255fb4e-94a4-4bbc-9e8d-edec5ecebab0")));
             TutorialsAvailable.Add(new Tutorial("2. Import a file", new ExecuteCommandCreateNewCatalogueByImportingFile(_activator), new Guid("5d71a169-5c08-4c33-8f88-8ee123222a3b")));
 
             //var executeExtraction = new Tutorial("4. Execute DataSet Extraction",

--- a/Tests.Common/Scenarios/TestsRequiringADle.cs
+++ b/Tests.Common/Scenarios/TestsRequiringADle.cs
@@ -75,7 +75,7 @@ namespace Tests.Common.Scenarios
             CreateFlatFileAttacher(TestLoadMetadata,"*.csv",TestCatalogue.GetTableInfoList(false).Single(),",");
             
             //Get DleRunner to run pre load checks (includes trigger creation etc)
-            var runner = new DleRunner(new DleOptions() { LoadMetadata = TestLoadMetadata.ID,Command = CommandLineActivity.check});
+            var runner = new DleRunner(new DleOptions() { LoadMetadata = TestLoadMetadata.ID.ToString(),Command = CommandLineActivity.check});
             runner.Run(RepositoryLocator,new ThrowImmediatelyDataLoadEventListener(), new AcceptAllCheckNotifier(), new GracefulCancellationToken());
         }
 
@@ -165,11 +165,11 @@ namespace Tests.Common.Scenarios
             if(checks)
             {
                 //Get DleRunner to run pre load checks (includes trigger creation etc)
-                var checker = new DleRunner(new DleOptions() { LoadMetadata = lmd.ID,Command = CommandLineActivity.check});
+                var checker = new DleRunner(new DleOptions() { LoadMetadata = lmd.ID.ToString(), Command = CommandLineActivity.check});
                 checker.Run(RepositoryLocator,new ThrowImmediatelyDataLoadEventListener(), new AcceptAllCheckNotifier(), new GracefulCancellationToken());
             }
 
-            var runner = new DleRunner(new DleOptions() { LoadMetadata = lmd.ID,Command = CommandLineActivity.run});
+            var runner = new DleRunner(new DleOptions() { LoadMetadata = lmd.ID.ToString(), Command = CommandLineActivity.run});
             runner.Run(RepositoryLocator,new ThrowImmediatelyDataLoadEventListener(), new ThrowImmediatelyCheckNotifier(), new GracefulCancellationToken());
         }
     }

--- a/Tools/rdmp/CommandLine/Gui/Windows/RunnerWindows/RunDleWindow.cs
+++ b/Tools/rdmp/CommandLine/Gui/Windows/RunnerWindows/RunDleWindow.cs
@@ -28,7 +28,7 @@ namespace Rdmp.Core.CommandLine.Gui.Windows.RunnerWindows
         {
             return new DleOptions()
             {
-                LoadMetadata = lmd.ID,
+                LoadMetadata = lmd.ID.ToString(),
                 Iterative = false,
             };
         }

--- a/Tools/rdmp/Program.cs
+++ b/Tools/rdmp/Program.cs
@@ -272,7 +272,7 @@ namespace Rdmp.Core
                 {
                     try
                     {
-                        c.DiscoveredServer.TestConnection();
+                        c.DiscoveredServer.TestConnection(15_000);
                     }
                     catch (Exception ex)
                     {

--- a/scripts/create_cohort.yaml
+++ b/scripts/create_cohort.yaml
@@ -1,0 +1,22 @@
+Commands:
+  # Create a new cohort builder query with a single inclusion criteria
+  - CreateNewCohortIdentificationConfiguration "My cic"
+  - AddCatalogueToCohortIdentificationSetContainer "CohortAggregateContainer:Inclusion Criteria" Catalogue:Biochemistry
+  
+  # Create a filter on Healthboard='T'
+  - CreateNewFilter AggregateConfiguration:*Biochemistry
+  - Set AggregateFilter Name "Tayside Patients Only"
+  - Set AggregateFilter WhereSql "Healthboard='T'"
+  - ViewData "CohortIdentificationConfiguration:My cic"
+
+  # Create a Project for extracting data/storing cohort lists
+  - NewObject Project "Example Project"
+  - Set Project ProjectNumber 23
+  - Set Project ExtractionDirectory "./out/"
+
+  # Commit the cohort identifier list
+  - CreateNewCohortByExecutingACohortIdentificationConfiguration "CohortIdentificationConfiguration:My cic" ExternalCohortTable "Test cohort of Biochemistry Tayside Patients" "Project:Example Project" "Pipeline:CREATE COHORT*Cohort Identification Configuration"
+  - ViewData ExtractableCohort All ./out/cohort.csv
+  # Clean up
+  - delete "CohortIdentificationConfiguration:My cic" true
+  - delete "Project:Example Project" true

--- a/scripts/create_cohort.yaml
+++ b/scripts/create_cohort.yaml
@@ -3,11 +3,14 @@ Commands:
   - CreateNewCohortIdentificationConfiguration "My cic"
   - AddCatalogueToCohortIdentificationSetContainer "CohortAggregateContainer:Inclusion Criteria" Catalogue:Biochemistry
   
+  # Ignore this warning
+  - SetUserSetting StrictValidationForCohortBuilderContainers false
+
   # Create a filter on Healthboard='T'
   - CreateNewFilter AggregateConfiguration:*Biochemistry
   - Set AggregateFilter Name "Tayside Patients Only"
   - Set AggregateFilter WhereSql "Healthboard='T'"
-  - ViewData "CohortIdentificationConfiguration:My cic"
+  - ViewData "CohortIdentificationConfiguration:My cic" All
 
   # Create a Project for extracting data/storing cohort lists
   - NewObject Project "Example Project"

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -1,0 +1,7 @@
+Commands:
+  # One off bulk insert of data into the TEST_ExampleData database
+  - GenerateTestData biochemistry 100 100 100 ./Biochemistry2.csv
+  - CreateNewCatalogueByImportingFile ./Biochemistry2.csv chi "DatabaseType:MicrosoftSQLServer:Server=(localdb)\MSSQLLocalDB;Database=TEST_ExampleData;Trusted_Connection=True;TrustServerCertificate=true" "Pipeline:BULK INSERT*automated" false
+  
+  # Create a repeatable load in RDMP to load updates to the dataset
+  - CreateNewLoadMetadata Catalogue:Biochemistry2

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -20,5 +20,5 @@ Commands:
   # Add CSV data reading component
   - CreateNewClassBasedProcessTask LoadMetadata:*Biochemistry Mounting AnySeparatorFileAttacher
   - SetArgument ProcessTask Separator ","
-  - SetArgument ProcessTask FilePattern ","
+  - SetArgument ProcessTask FilePattern "*.csv"
   - SetArgument ProcessTask TableToLoad TableInfo:*Biochemistry*

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -10,6 +10,7 @@ Commands:
   # Create a repeatable load in RDMP to load updates to the dataset
   - CreateNewLoadMetadata Catalogue:Biochemistry2
   - Set LoadMetadata Name "Loading Biochemistry"
+  - CreateNewDataLoadDirectory LoadMetadata ./Loading
   
   # Add file copy component (from landing to ForLoading dir)
   - CreateNewClassBasedProcessTask LoadMetadata:*Biochemistry GetFiles ImportFilesDataProvider

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -5,7 +5,7 @@ Commands:
   - CreateNewCatalogueByImportingFile ./Biochemistry2.csv chi "DatabaseType:MicrosoftSQLServer:Server=(localdb)\MSSQLLocalDB;Database=TEST_ExampleData;Trusted_Connection=True;TrustServerCertificate=true" "Pipeline:*BULK INSERT*automated*" null
   
   # Create primary key
-  - AlterTableCreatePrimaryKey TableInfo:Biochemistry2 ColumnInfo:chi ColumnInfo:Healthboard ColumnInfo:SampleDate ColumnInfo:TestCode
+  - AlterTableCreatePrimaryKey TableInfo:*Biochemistry2* ColumnInfo:*chi* ColumnInfo:*Healthboard* ColumnInfo:*SampleDate* ColumnInfo:*TestCode*
 
   # Create a repeatable load in RDMP to load updates to the dataset
   - CreateNewLoadMetadata Catalogue:Biochemistry2

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -1,7 +1,7 @@
 Commands:
   # One off bulk insert of data into the TEST_ExampleData database
   - GenerateTestData biochemistry 100 100 100 ./Biochemistry2.csv
-  - CreateNewCatalogueByImportingFile ./Biochemistry2.csv chi "DatabaseType:MicrosoftSQLServer:Server=(localdb)\MSSQLLocalDB;Database=TEST_ExampleData;Trusted_Connection=True;TrustServerCertificate=true" "Pipeline:BULK INSERT*automated" false
+  - CreateNewCatalogueByImportingFile ./Biochemistry2.csv chi "DatabaseType:MicrosoftSQLServer:Server=(localdb)\MSSQLLocalDB;Database=TEST_ExampleData;Trusted_Connection=True;TrustServerCertificate=true" "Pipeline:*BULK INSERT*automated*" false
   
   # Create a repeatable load in RDMP to load updates to the dataset
   - CreateNewLoadMetadata Catalogue:Biochemistry2

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -1,7 +1,7 @@
 Commands:
   # One off bulk insert of data into the TEST_ExampleData database
   - GenerateTestData biochemistry 100 100 100 ./Biochemistry2.csv
-  - CreateNewCatalogueByImportingFile ./Biochemistry2.csv chi "DatabaseType:MicrosoftSQLServer:Server=(localdb)\MSSQLLocalDB;Database=TEST_ExampleData;Trusted_Connection=True;TrustServerCertificate=true" "Pipeline:*BULK INSERT*automated*" false
+  - CreateNewCatalogueByImportingFile ./Biochemistry2.csv chi "DatabaseType:MicrosoftSQLServer:Server=(localdb)\MSSQLLocalDB;Database=TEST_ExampleData;Trusted_Connection=True;TrustServerCertificate=true" "Pipeline:*BULK INSERT*automated*" null
   
   # Create a repeatable load in RDMP to load updates to the dataset
   - CreateNewLoadMetadata Catalogue:Biochemistry2

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -20,4 +20,4 @@ Commands:
   - CreateNewClassBasedProcessTask LoadMetadata:*Biochemistry Mounting AnySeparatorFileAttacher
   - SetArgument ProcessTask Separator ","
   - SetArgument ProcessTask FilePattern ","
-  - SetArgument ProcessTask TableToLoad TableInfo:Biochemistry2
+  - SetArgument ProcessTask TableToLoad TableInfo:*Biochemistry*

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -13,11 +13,11 @@ Commands:
   
   # Add file copy component (from landing to ForLoading dir)
   - CreateNewClassBasedProcessTask LoadMetadata:*Biochemistry GetFiles ImportFilesDataProvider
-  - SetArgument ProcessTask ProcessTaskArgument:DirectoryPath ./loadme
-  - SetArgument ProcessTask ProcessTaskArgument:FilePattern *.csv
+  - SetArgument ProcessTask DirectoryPath ./loadme
+  - SetArgument ProcessTask FilePattern *.csv
 
   # Add CSV data reading component
   - CreateNewClassBasedProcessTask LoadMetadata:*Biochemistry Mounting AnySeparatorFileAttacher
-  - SetArgument ProcessTask ProcessTaskArgument:Separator ","
-  - SetArgument ProcessTask ProcessTaskArgument:FilePattern ","
-  - SetArgument ProcessTask ProcessTaskArgument:TableToLoad TableInfo:Biochemistry2
+  - SetArgument ProcessTask Separator ","
+  - SetArgument ProcessTask FilePattern ","
+  - SetArgument ProcessTask TableToLoad TableInfo:Biochemistry2

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -1,7 +1,23 @@
 Commands:
   # One off bulk insert of data into the TEST_ExampleData database
   - GenerateTestData biochemistry 100 100 100 ./Biochemistry2.csv
+  - GenerateTestData biochemistry 100 100 100 ./loadme/MoreBiochemistry.csv
   - CreateNewCatalogueByImportingFile ./Biochemistry2.csv chi "DatabaseType:MicrosoftSQLServer:Server=(localdb)\MSSQLLocalDB;Database=TEST_ExampleData;Trusted_Connection=True;TrustServerCertificate=true" "Pipeline:*BULK INSERT*automated*" null
   
+  # Create primary key
+  - AlterTableCreatePrimaryKey TableInfo:Biochemistry2 ColumnInfo:chi ColumnInfo:Healthboard ColumnInfo:SampleDate ColumnInfo:TestCode
+
   # Create a repeatable load in RDMP to load updates to the dataset
   - CreateNewLoadMetadata Catalogue:Biochemistry2
+  - Set LoadMetadata Name "Loading Biochemistry"
+  
+  # Add file copy component (from landing to ForLoading dir)
+  - CreateNewClassBasedProcessTask LoadMetadata:*Biochemistry GetFiles ImportFilesDataProvider
+  - SetArgument ProcessTask ProcessTaskArgument:DirectoryPath ./loadme
+  - SetArgument ProcessTask ProcessTaskArgument:FilePattern *.csv
+
+  # Add CSV data reading component
+  - CreateNewClassBasedProcessTask LoadMetadata:*Biochemistry Mounting AnySeparatorFileAttacher
+  - SetArgument ProcessTask ProcessTaskArgument:Separator ","
+  - SetArgument ProcessTask ProcessTaskArgument:FilePattern ","
+  - SetArgument ProcessTask ProcessTaskArgument:TableToLoad TableInfo:Biochemistry2

--- a/scripts/create_list_destroy_catalogue.yaml
+++ b/scripts/create_list_destroy_catalogue.yaml
@@ -1,0 +1,6 @@
+# Allows
+Commands:
+  - list Catalogue
+  - newobject Catalogue "hey its me"
+  - describe "Catalogue:hey*me"
+  - delete "Catalogue:hey*me" true


### PR DESCRIPTION
Follows on from #1281

Further improvements to command line scripting for output capture

Example of the new coolness:
```
./rdmp -q lc new*cata
AddNewCatalogueItem
CreateNewCatalogueByExecutingAnAggregateConfiguration
CreateNewCatalogueByImportingExistingDataTable
CreateNewCatalogueByImportingFile
CreateNewCatalogueFromTableInfo
CreateNewCohortFromCatalogue
CreateNewEmptyCatalogue
CreateNewFilterFromCatalogue
PasteClipboardAsNewCatalogueItems
```