### PR TITLE
Orphans and Pipelines

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -63,15 +63,10 @@ jobs:
           DataExportConnectionString: Server=(localdb)\MSSQLLocalDB;Database=TEST_DataExport;Trusted_Connection=True;TrustServerCertificate=true;
           EOF
       - name: Run integration test scripts
-        run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
-      - name: Run integration script create_cohort.yaml
-        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml
-      - name: Run integration script create_dataload.yaml
         run: |
-           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_dataload.yaml &&
-           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- dle -l "LoadMetadata:*Biochemistry" --command check &&
-           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- dle -l "LoadMetadata:*Biochemistry" --command run
-
+            dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml &&
+            dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml &&
+            dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_dataload.yaml && 
       - name: Test Reusable code
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -65,9 +65,7 @@ jobs:
       - name: Run integration test scripts
         run: dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml
       - name: Run integration script create_cohort.yaml
-        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml&&
-           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- extract -e "ExtractionConfiguration:My First Extraction" -p "Pipeline:DATA EXPORT*CSV" --command check &&
-           dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- extract -e "ExtractionConfiguration:My First Extraction" -p "Pipeline:DATA EXPORT*CSV" --command run
+        run: dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml
       - name: Run integration script create_dataload.yaml
         run: |
            dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_dataload.yaml &&

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -67,6 +67,7 @@ jobs:
             dotnet run -c Release --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_list_destroy_catalogue.yaml &&
             dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_cohort.yaml &&
             dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/create_dataload.yaml && 
+            dotnet run -c Release --no-build --project Tools/rdmp/rdmp.csproj -- -f ./scripts/orphan_extractable_column.yaml && 
       - name: Test Reusable code
         shell: bash
         run: |

--- a/HIC.DataManagementPlatform.sln
+++ b/HIC.DataManagementPlatform.sln
@@ -1,7 +1,7 @@
 ﻿
 Microsoft Visual Studio Solution File, Format Version 12.00
-# Visual Studio Version 17
-VisualStudioVersion = 17.0.32112.339
+# Visual Studio Version 16
+VisualStudioVersion = 16.0.31729.503
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "ReusableLibraryCode", "Reusable\ReusableLibraryCode\ReusableLibraryCode.csproj", "{5AD03B2F-232A-4E0B-86FF-DC7F49146962}"
 EndProject
@@ -82,6 +82,7 @@ Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "scripts", "scripts", "{B010
 		scripts\create_cohort.yaml = scripts\create_cohort.yaml
 		scripts\create_dataload.yaml = scripts\create_dataload.yaml
 		scripts\create_list_destroy_catalogue.yaml = scripts\create_list_destroy_catalogue.yaml
+		scripts\orphan_extractable_column.yaml = scripts\orphan_extractable_column.yaml
 	EndProjectSection
 EndProject
 Global

--- a/Rdmp.Core/CommandLine/Options/ExtractionOptions.cs
+++ b/Rdmp.Core/CommandLine/Options/ExtractionOptions.cs
@@ -22,7 +22,7 @@ namespace Rdmp.Core.CommandLine.Options
         [Option('e',"ExtractionConfiguration",HelpText = "The ExtractionConfiguration ID to extract",Required = true)]
         public string ExtractionConfiguration { get; set; }
 
-        [Option('p', "Pipeline", HelpText = "The ID of the extraction Pipeline to use")]
+        [Option('p', "Pipeline", HelpText = "The ID of the extraction Pipeline to use", Required = true)]
         public string Pipeline { get; set; }
 
         [Option('s', "Datasets", HelpText = "Restrict extraction to only those ExtractableDatasets that have the provided list of IDs (must be part of the ExtractionConfiguration)")]

--- a/Rdmp.Core/CommandLine/RdmpCommandLineBootStrapper.cs
+++ b/Rdmp.Core/CommandLine/RdmpCommandLineBootStrapper.cs
@@ -1,4 +1,10 @@
-﻿using MapsDirectlyToDatabaseTable;
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using MapsDirectlyToDatabaseTable;
 using NLog;
 using Rdmp.Core.CommandExecution;
 using Rdmp.Core.CommandLine.Options;

--- a/Rdmp.Core/CommandLine/RdmpCommandLineBootStrapper.cs
+++ b/Rdmp.Core/CommandLine/RdmpCommandLineBootStrapper.cs
@@ -1,0 +1,206 @@
+﻿using MapsDirectlyToDatabaseTable;
+using NLog;
+using Rdmp.Core.CommandExecution;
+using Rdmp.Core.CommandLine.Options;
+using Rdmp.Core.CommandLine.Runners;
+using Rdmp.Core.DataFlowPipeline;
+using Rdmp.Core.Logging.Listeners.NLogListeners;
+using Rdmp.Core.Repositories;
+using Rdmp.Core.Startup;
+using ReusableLibraryCode;
+using ReusableLibraryCode.Checks;
+using System;
+using System.Collections.Generic;
+using System.IO;
+using System.Linq;
+using System.Text;
+using System.Threading.Tasks;
+using YamlDotNet.Serialization;
+using CommandLine;
+
+namespace Rdmp.Core.CommandLine
+{
+    /// <summary>
+    /// Parses strings into relevant <see cref="RDMPCommandLineOptions"/> subclasses 
+    /// and runs appropriate <see cref="Runners.Runner"/>
+    /// </summary>
+    public class RdmpCommandLineBootStrapper
+    {
+
+        public static int HandleArgumentsWithStandardRunner(string[] args, Logger logger,IRDMPPlatformRepositoryServiceLocator existingLocator = null)
+        {
+            int returnCode;
+            try
+            {
+                returnCode =
+                    UsefulStuff.GetParser()
+                        .ParseArguments<
+                            DleOptions,
+                            DqeOptions,
+                            CacheOptions,
+                            ExtractionOptions,
+                            ReleaseOptions,
+                            CohortCreationOptions,
+                            ExecuteCommandOptions>(args)
+                        .MapResult(
+                            //Add new verbs as options here and invoke relevant runner
+                            (DleOptions opts) => Run(opts,null, existingLocator),
+                            (DqeOptions opts) => Run(opts, null, existingLocator),
+                            (CacheOptions opts) => Run(opts, null, existingLocator),
+                            (ExtractionOptions opts) => Run(opts, null, existingLocator),
+                            (ReleaseOptions opts) => Run(opts, null, existingLocator),
+                            (CohortCreationOptions opts) => Run(opts, null, existingLocator),
+                            (ExecuteCommandOptions opts) => RunCmd(opts, existingLocator),
+                            errs => 1);
+
+                logger.Info("Exiting with code " + returnCode);
+                return returnCode;
+            }
+            catch (Exception e)
+            {
+                logger.Error(e.Message);
+                logger.Info(e, "Fatal error occurred so returning -1");
+                return -1;
+            }
+        }
+
+        public static int RunCmd(ExecuteCommandOptions opts, IRDMPPlatformRepositoryServiceLocator existingLocator = null)
+        {
+            if (!string.IsNullOrWhiteSpace(opts.File))
+            {
+                if (!File.Exists(opts.File))
+                {
+                    Console.WriteLine($"Could not find file '{opts.File}'");
+                    return -55;
+                }
+
+                var content = File.ReadAllText(opts.File);
+
+                if (string.IsNullOrWhiteSpace(content))
+                {
+                    Console.WriteLine($"File is empty ('{opts.File}')");
+                    return -56;
+                }
+
+                try
+                {
+                    var d = new Deserializer();
+                    opts.Script = d.Deserialize<RdmpScript>(content);
+                }
+                catch (Exception ex)
+                {
+                    Console.WriteLine($"Error deserializing '{opts.File}': {ex.Message}");
+                    return -57;
+                }
+            }
+
+            return Run((RDMPCommandLineOptions)opts,null, existingLocator);
+        }
+
+        public static int Run(RDMPCommandLineOptions opts, IRunner explicitRunner = null, IRDMPPlatformRepositoryServiceLocator existingLocator = null)
+        {
+            // if we have already done startup great!
+            var repositoryLocator = existingLocator;
+
+            var listener = new NLogIDataLoadEventListener(false);
+            var checker = new NLogICheckNotifier(true, false);
+
+            var factory = new RunnerFactory();
+
+            // not done startup so check that we can reach stuff
+            if (repositoryLocator == null)
+            {
+                opts.PopulateConnectionStringsFromYamlIfMissing(new ThrowImmediatelyCheckNotifier());
+
+                // where RDMP objects are stored
+                repositoryLocator = opts.GetRepositoryLocator();
+
+                if (!CheckRepo(repositoryLocator))
+                {
+                    return REPO_ERROR;
+                }
+
+                CatalogueRepository.SuppressHelpLoading = false;
+                opts.DoStartup(GetEnvironmentInfo(), opts.LogStartup ? (ICheckNotifier)checker : new IgnoreAllErrorsCheckNotifier());
+            }
+
+            //if user wants to run checking chances are they don't want checks to fail becasue of errors logged during startup (MEF shows lots of errors!)
+            if (opts.LogStartup && opts.Command == CommandLineActivity.check)
+                checker.Worst = LogLevel.Info;
+
+            var runner = explicitRunner ??
+                         factory.CreateRunner(new ThrowImmediatelyActivator(repositoryLocator, checker), opts);
+
+            // Let's not worry about global errors during the CreateRunner process
+            // These are mainly UI/GUI and unrelated to the actual process to run
+            if (checker.Worst > LogLevel.Warn)
+                checker.Worst = LogLevel.Warn;
+
+            int runExitCode = runner.Run(repositoryLocator, listener, checker, new GracefulCancellationToken());
+
+            if (opts.Command == CommandLineActivity.check)
+                checker.OnCheckPerformed(checker.Worst <= LogLevel.Warn
+                    ? new CheckEventArgs("Checks Passed", CheckResult.Success)
+                    : new CheckEventArgs("Checks Failed", CheckResult.Fail));
+
+            if (runExitCode != 0)
+                return runExitCode;
+
+            //or if either listener reports error
+            if (listener.Worst >= LogLevel.Error || checker.Worst >= LogLevel.Error)
+                return -1;
+
+            if (opts.FailOnWarnings && (listener.Worst >= LogLevel.Warn || checker.Worst >= LogLevel.Warn))
+                return 1;
+
+            return 0;
+        }
+
+        /// <summary>
+        /// The error to return when there is a problem contacting the repository databases
+        /// </summary>
+        public const int REPO_ERROR = 7;
+
+        public static EnvironmentInfo GetEnvironmentInfo()
+        {
+            return new EnvironmentInfo(PluginFolders.Main);
+        }
+        public static bool CheckRepo(IRDMPPlatformRepositoryServiceLocator repo)
+        {
+            var logger = LogManager.GetCurrentClassLogger();
+            if (repo is LinkedRepositoryProvider l)
+            {
+                if (l.CatalogueRepository is TableRepository c)
+                {
+                    try
+                    {
+                        c.DiscoveredServer.TestConnection(15_000);
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(ex, $"Could not reach {c.DiscoveredServer} (Database:{c.DiscoveredServer.GetCurrentDatabase()}).  Ensure that you have configured RDMP database connections in Databases.yaml correctly and/or that you have run install to setup platform databases");
+                        return false;
+                    }
+                }
+
+                if (l.DataExportRepository is TableRepository d)
+                {
+                    try
+                    {
+                        d.DiscoveredServer.TestConnection();
+                    }
+                    catch (Exception ex)
+                    {
+                        logger.Error(ex, $"Could not reach {d.DiscoveredServer} (Database:{d.DiscoveredServer.GetCurrentDatabase()}).  Ensure that you have configured RDMP database connections in Databases.yaml correctly and/or that you have run install to setup platform databases");
+                        return false;
+
+                    }
+                }
+            }
+
+            return true;
+        }
+
+    }
+
+}

--- a/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
@@ -196,7 +196,9 @@ namespace Rdmp.Core.CommandLine.Runners
                     {
                         if(StartsWithEngineVerb(s))
                         {
-                            RdmpCommandLineBootStrapper.HandleArgumentsWithStandardRunner(SplitCommandLine(s).ToArray(), LogManager.GetCurrentClassLogger(), repositoryLocator);
+                            var exitCode = RdmpCommandLineBootStrapper.HandleArgumentsWithStandardRunner(SplitCommandLine(s).ToArray(), LogManager.GetCurrentClassLogger(), repositoryLocator);
+                            if (exitCode != 0)
+                                throw new Exception("Exit code from runner was non zero");
                         }
                         else
                         {

--- a/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ExecuteCommandRunner.cs
@@ -194,8 +194,15 @@ namespace Rdmp.Core.CommandLine.Runners
                 {
                     try
                     {
-                        var cmd = GetCommandAndPickerFromLine(s, out _picker, repositoryLocator);
-                        RunCommand(cmd);
+                        if(StartsWithEngineVerb(s))
+                        {
+                            RdmpCommandLineBootStrapper.HandleArgumentsWithStandardRunner(SplitCommandLine(s).ToArray(), LogManager.GetCurrentClassLogger(), repositoryLocator);
+                        }
+                        else
+                        {
+                            var cmd = GetCommandAndPickerFromLine(s, out _picker, repositoryLocator);
+                            RunCommand(cmd);
+                        }
                     }
                     catch (Exception ex)
                     {
@@ -206,6 +213,18 @@ namespace Rdmp.Core.CommandLine.Runners
                 
         }
 
+        private bool StartsWithEngineVerb(string s)
+        {
+            var verbs = new[] { "cache", "cohort", "dle", "dqe", "extract", "release" };
+            return verbs.Any(v => s.TrimStart().StartsWith(v, StringComparison.CurrentCultureIgnoreCase));
+        }
+
+        /// <summary>
+        /// Splits a command line string into a sequence of discrete arguments as you would get in Program.cs main
+        /// string[] args.  Includes support for wrapping arguments in spaces and escaping etc
+        /// </summary>
+        /// <param name="commandLine"></param>
+        /// <returns></returns>
         public static IEnumerable<string> SplitCommandLine(string commandLine)
         {
             char? inQuotes = null;

--- a/Tools/rdmp/Program.cs
+++ b/Tools/rdmp/Program.cs
@@ -13,6 +13,7 @@ using MapsDirectlyToDatabaseTable;
 using MapsDirectlyToDatabaseTable.Versioning;
 using NLog;
 using Rdmp.Core.CommandExecution;
+using Rdmp.Core.CommandLine;
 using Rdmp.Core.CommandLine.DatabaseCreation;
 using Rdmp.Core.CommandLine.Gui;
 using Rdmp.Core.CommandLine.Options;
@@ -30,13 +31,6 @@ namespace Rdmp.Core
 {
     class Program
     {
-        const int REPO_ERROR = 7;
-
-        private static EnvironmentInfo GetEnvironmentInfo()
-        {
-            return new EnvironmentInfo(PluginFolders.Main);
-        }
-        
         static int Main(string[] args)
         {
             try
@@ -76,36 +70,36 @@ namespace Rdmp.Core
 
         private static int HandleArguments(string[] args, Logger logger)
         {
+            int returnCode;
             try
             {
-                var returnCode =
+                returnCode =
                     UsefulStuff.GetParser()
                         .ParseArguments<
+                            PackOptions,
+                            ConsoleGuiOptions,
+                            PlatformDatabaseCreationOptions,
+                            PatchDatabaseOptions,
                             DleOptions,
                             DqeOptions,
                             CacheOptions,
                             ExtractionOptions,
                             ReleaseOptions,
                             CohortCreationOptions,
-                            PackOptions,
-                            ExecuteCommandOptions,
-                            ConsoleGuiOptions,
-                            PlatformDatabaseCreationOptions,
-                            PatchDatabaseOptions>(args)
+                            ExecuteCommandOptions> (args)
                         .MapResult(
-                            //Add new verbs as options here and invoke relevant runner
-                            (DleOptions opts) => Run(opts),
-                            (DqeOptions opts) => Run(opts),
-                            (CacheOptions opts) => Run(opts),
-                            (ExtractionOptions opts) => Run(opts),
-                            (ReleaseOptions opts) => Run(opts),
-                            (CohortCreationOptions opts) => Run(opts),
-                            (PackOptions opts) => Run(opts),
-                            (PlatformDatabaseCreationOptions opts) => Run(opts),
-                            (ExecuteCommandOptions opts) => RunCmd(opts),
-                            (ConsoleGuiOptions opts) => Run(opts),
+                            (PackOptions opts) => RdmpCommandLineBootStrapper.Run(opts),
+                            (ConsoleGuiOptions opts) => RdmpCommandLineBootStrapper.Run(opts,new ConsoleGuiRunner(opts)),
+                            (PlatformDatabaseCreationOptions opts) => Run(opts),                            
                             (PatchDatabaseOptions opts) => Run(opts),
-                            errs => 1);
+                            (DleOptions opts) => RdmpCommandLineBootStrapper.Run(opts),
+                            (DqeOptions opts) => RdmpCommandLineBootStrapper.Run(opts),
+                            (CacheOptions opts) => RdmpCommandLineBootStrapper.Run(opts),
+                            (ExtractionOptions opts) => RdmpCommandLineBootStrapper.Run(opts),
+                            (ReleaseOptions opts) => RdmpCommandLineBootStrapper.Run(opts),
+                            (CohortCreationOptions opts) => RdmpCommandLineBootStrapper.Run(opts),
+                            (ExecuteCommandOptions opts) => RdmpCommandLineBootStrapper.RunCmd(opts),
+                            errs => returnCode = RdmpCommandLineBootStrapper.HandleArgumentsWithStandardRunner(args,logger));
 
                 logger.Info("Exiting with code " + returnCode);
                 return returnCode;
@@ -117,6 +111,8 @@ namespace Rdmp.Core
                 return -1;
             }
         }
+
+    
 
         private static int Run(PlatformDatabaseCreationOptions opts)
         {
@@ -138,91 +134,6 @@ namespace Rdmp.Core
             return 0;
         }
 
-        private static int RunCmd(ExecuteCommandOptions opts)
-        {
-            if(!string.IsNullOrWhiteSpace(opts.File))
-            {
-                if(!File.Exists(opts.File))
-                {
-                    Console.WriteLine($"Could not find file '{opts.File}'");
-                    return -55;
-                }
-
-                var content = File.ReadAllText(opts.File);
-
-                if (string.IsNullOrWhiteSpace(content))
-                {
-                    Console.WriteLine($"File is empty ('{opts.File}')");
-                    return -56;
-                }
-
-                try
-                {
-                    var d = new Deserializer();
-                    opts.Script = d.Deserialize<RdmpScript>(content);
-                }
-                catch(Exception ex)
-                {
-                    Console.WriteLine($"Error deserializing '{opts.File}': {ex.Message}");
-                    return -57;                    
-                }
-            }
-
-            return Run((RDMPCommandLineOptions) opts);
-        }
-
-        private static int Run(RDMPCommandLineOptions opts)
-        {
-            opts.PopulateConnectionStringsFromYamlIfMissing(new ThrowImmediatelyCheckNotifier());
-
-            // where RDMP objects are stored
-            var repositoryLocator = opts.GetRepositoryLocator();
-
-            if (!CheckRepo(repositoryLocator))
-            {
-                return REPO_ERROR;
-            }
-
-            var listener = new NLogIDataLoadEventListener(false);
-            var checker = new NLogICheckNotifier(true, false);
-
-            CatalogueRepository.SuppressHelpLoading = false;
-
-            var factory = new RunnerFactory();
-            opts.DoStartup(GetEnvironmentInfo(),opts.LogStartup ? (ICheckNotifier)checker: new IgnoreAllErrorsCheckNotifier());
-
-            //if user wants to run checking chances are they don't want checks to fail becasue of errors logged during startup (MEF shows lots of errors!)
-            if(opts.LogStartup && opts.Command == CommandLineActivity.check)
-                checker.Worst = LogLevel.Info;
-           
-            var runner = opts is ConsoleGuiOptions g ? 
-                        new ConsoleGuiRunner(g):
-                         factory.CreateRunner(new ThrowImmediatelyActivator(repositoryLocator,checker),opts);
-
-            // Let's not worry about global errors during the CreateRunner process
-            // These are mainly UI/GUI and unrelated to the actual process to run
-            if (checker.Worst > LogLevel.Warn)
-                checker.Worst = LogLevel.Warn;
-
-            int runExitCode = runner.Run(repositoryLocator, listener, checker, new GracefulCancellationToken());
-
-            if (opts.Command == CommandLineActivity.check)
-                checker.OnCheckPerformed(checker.Worst <= LogLevel.Warn
-                    ? new CheckEventArgs("Checks Passed", CheckResult.Success)
-                    : new CheckEventArgs("Checks Failed", CheckResult.Fail));
-
-            if (runExitCode != 0)
-                return runExitCode;
-
-            //or if either listener reports error
-            if (listener.Worst >= LogLevel.Error || checker.Worst >= LogLevel.Error)
-                return -1;
-
-            if (opts.FailOnWarnings && (listener.Worst >= LogLevel.Warn || checker.Worst >= LogLevel.Warn))
-                return 1;
-
-            return 0;
-        }
         
         private static int Run(PatchDatabaseOptions opts)
         {
@@ -230,14 +141,14 @@ namespace Rdmp.Core
 
             var repo = opts.GetRepositoryLocator();
 
-            if(!CheckRepo(repo))
+            if(!RdmpCommandLineBootStrapper.CheckRepo(repo))
             {
-                return REPO_ERROR;
+                return RdmpCommandLineBootStrapper.REPO_ERROR;
             }
 
             var checker = new NLogICheckNotifier(true, false);
 
-            var start = new Startup.Startup(GetEnvironmentInfo(),repo);
+            var start = new Startup.Startup(RdmpCommandLineBootStrapper.GetEnvironmentInfo(),repo);
             bool badTimes = false;
 
             start.DatabaseFound += (s,e)=>{
@@ -260,42 +171,6 @@ namespace Rdmp.Core
             start.DoStartup(new IgnoreAllErrorsCheckNotifier());
 
             return badTimes ? -1 :0;
-        }
-
-        private static bool CheckRepo(Repositories.IRDMPPlatformRepositoryServiceLocator repo)
-        {
-            var logger = LogManager.GetCurrentClassLogger();
-            if(repo is LinkedRepositoryProvider l)
-            {
-                if(l.CatalogueRepository is TableRepository c)
-                {
-                    try
-                    {
-                        c.DiscoveredServer.TestConnection(15_000);
-                    }
-                    catch (Exception ex)
-                    {
-                        logger.Error(ex,$"Could not reach {c.DiscoveredServer} (Database:{c.DiscoveredServer.GetCurrentDatabase()}).  Ensure that you have configured RDMP database connections in Databases.yaml correctly and/or that you have run install to setup platform databases");
-                        return false;
-                    }
-                }
-
-                if (l.DataExportRepository is TableRepository d)
-                {
-                    try
-                    {
-                        d.DiscoveredServer.TestConnection();
-                    }
-                    catch(Exception ex)
-                    {
-                        logger.Error(ex,$"Could not reach {d.DiscoveredServer} (Database:{d.DiscoveredServer.GetCurrentDatabase()}).  Ensure that you have configured RDMP database connections in Databases.yaml correctly and/or that you have run install to setup platform databases");
-                        return false;
-
-                    }
-                }
-            }
-
-            return true;
         }
     }
 }

--- a/scripts/create_cohort.yaml
+++ b/scripts/create_cohort.yaml
@@ -29,5 +29,6 @@ Commands:
   - AddDatasetsToConfiguration ExtractableDataSet:Biochemistry ExtractionConfiguration
   - AddDatasetsToConfiguration ExtractableDataSet:Prescribing ExtractionConfiguration  
 
-  # this extraction can be run using the following (see build.yml):
-  # rdmp extract -e "ExtractionConfiguration:My First Extraction" -p "Pipeline:DATA EXPORT*CSV" --command run
+  # Run the extraction
+  - extract -e "ExtractionConfiguration:My First Extraction" -p "Pipeline:DATA EXPORT*CSV" --command check
+  - extract -e "ExtractionConfiguration:My First Extraction" -p "Pipeline:DATA EXPORT*CSV" --command run

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -23,6 +23,6 @@ Commands:
   - SetArgument ProcessTask FilePattern "*.csv"
   - SetArgument ProcessTask TableToLoad TableInfo:*Biochemistry*
 
-  # Chekc and run the load
+  # Check and run the load
   - dle -l "LoadMetadata:*Biochemistry" --command check
   - dle -l "LoadMetadata:*Biochemistry" --command run

--- a/scripts/create_dataload.yaml
+++ b/scripts/create_dataload.yaml
@@ -23,5 +23,6 @@ Commands:
   - SetArgument ProcessTask FilePattern "*.csv"
   - SetArgument ProcessTask TableToLoad TableInfo:*Biochemistry*
 
-  # this load can be run using the following (see build.yml):
-  # dle -l "LoadMetadata:*Biochemistry" --command run
+  # Chekc and run the load
+  - dle -l "LoadMetadata:*Biochemistry" --command check
+  - dle -l "LoadMetadata:*Biochemistry" --command run

--- a/scripts/orphan_extractable_column.yaml
+++ b/scripts/orphan_extractable_column.yaml
@@ -1,0 +1,9 @@
+Commands:
+  
+  # Make this column (in the Biochemistry example dataset) no longer extractable
+  - Delete ExtractionInformation:ArithmeticComparator
+
+  # Clone the ExtractionConfiguration created in example datasets
+  - CloneExtractionConfiguration "ExtractionConfiguration:Project 123*2018 Refresh"
+  - Set ExtractionConfiguration Name "New Clone"
+  - Check "ExtractionConfiguration:New Clone"

--- a/scripts/orphan_extractable_column.yaml
+++ b/scripts/orphan_extractable_column.yaml
@@ -6,4 +6,9 @@ Commands:
   # Clone the ExtractionConfiguration created in example datasets
   - CloneExtractionConfiguration "ExtractionConfiguration:Project 123*2018 Refresh"
   - Set ExtractionConfiguration Name "New Clone"
-  - Check "ExtractionConfiguration:New Clone"
+
+  # TODO: we should detect and fail in this situation unless user sets specific error message suppression
+
+  # check and execute the config
+  - extract -e "ExtractionConfiguration:New Clone" -p "Pipeline:DATA EXPORT*To CSV" --command check
+  - extract -e "ExtractionConfiguration:New Clone" -p "Pipeline:DATA EXPORT*To CSV" --command run


### PR DESCRIPTION
fixes #1301

Two fixes in this PR

- Allows running pipelines from RDMP scripts directly e.g.

```
Commands:
   # Clone the ExtractionConfiguration created in example datasets
  - CloneExtractionConfiguration "ExtractionConfiguration:Project 123*2018 Refresh"
  - Set ExtractionConfiguration Name "New Clone"
 
  # check and execute the config
  - extract -e "ExtractionConfiguration:New Clone" --command check
  - extract -e "ExtractionConfiguration:New Clone" --command run
```

- Digs into #1299 with new CI script orphan_extractable_column.yaml