### PR TITLE
ExtractableColumn icons and Release engine broken

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- Icons in 'edit extraction columns' window now shows IsExtractionIdentifier and Extraction Primary Key status [#1312](https://github.com/HicServices/RDMP/issues/1312).
+
 ## [7.0.16] - 2022-07-25
 
 - Bugfix release due to build issues in releasing 7.0.15

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Icons in 'edit extraction columns' window now shows IsExtractionIdentifier and Extraction Primary Key status [#1312](https://github.com/HicServices/RDMP/issues/1312).
 
+### Fixed
+
+- Fixed Release not working from CLI (Bug introduced in 7.0.16)
+
 ## [7.0.16] - 2022-07-25
 
 - Bugfix release due to build issues in releasing 7.0.15

--- a/Rdmp.Core/CommandLine/Runners/ReleaseRunner.cs
+++ b/Rdmp.Core/CommandLine/Runners/ReleaseRunner.cs
@@ -47,7 +47,7 @@ namespace Rdmp.Core.CommandLine.Runners
             _pipeline = GetObjectFromCommandLineString<Pipeline>(RepositoryLocator, _options.Pipeline);
                         
             //get all configurations user has picked
-            _configurations = GetObjectsFromCommandLineString<IExtractionConfiguration>(RepositoryLocator,_options.Configurations).ToArray();
+            _configurations = GetObjectsFromCommandLineString<ExtractionConfiguration>(RepositoryLocator,_options.Configurations).ToArray();
 
             //some datasets only
             if(_options.SelectedDataSets != null && _options.SelectedDataSets.Any())

--- a/Rdmp.Core/Icons/IconProvision/StateBasedIconProviders/ExtractableColumnStateBasedIconProvider.cs
+++ b/Rdmp.Core/Icons/IconProvision/StateBasedIconProviders/ExtractableColumnStateBasedIconProvider.cs
@@ -37,7 +37,12 @@ namespace Rdmp.Core.Icons.IconProvision.StateBasedIconProviders
             //if the current state is to hash add the overlay
             if (col.HashOnDataRelease) 
                 toReturn = _overlayProvider.GetOverlay(toReturn, OverlayKind.Hashed);
-            
+
+            if (col.CatalogueExtractionInformation?.IsPrimaryKey ?? false)
+                toReturn = _overlayProvider.GetOverlay(toReturn, OverlayKind.Key);
+            if (col.CatalogueExtractionInformation?.IsExtractionIdentifier ?? false)
+                toReturn = _overlayProvider.GetOverlay(toReturn, OverlayKind.IsExtractionIdentifier);
+
             var ei = col.CatalogueExtractionInformation;
 
             //its parent ExtractionInformation still exists then we can determine its category


### PR DESCRIPTION
This PR has a stealth fix for ReleaseRunner too.  In fact I'm pretty sure that release from CLI is currently broken in release/develop


- Fixes #1316
- Fixes #1312 

Main fix is this:
![image](https://user-images.githubusercontent.com/31306100/182109912-9e5d7f5f-96b4-4b68-a9ba-3b0570eb2898.png)
