### PR TITLE
Fix startup errors with bad plugins

### DIFF
--- a/Rdmp.Core/CommandLine/Options/ConnectionStringsYamlFile.cs
+++ b/Rdmp.Core/CommandLine/Options/ConnectionStringsYamlFile.cs
@@ -54,7 +54,7 @@ namespace Rdmp.Core.CommandLine.Options
             var deserializer = new Deserializer();
             var toReturn = deserializer.Deserialize<ConnectionStringsYamlFile>(File.ReadAllText(f.FullName));
 
-            if(string.IsNullOrWhiteSpace(toReturn.CatalogueConnectionString))
+            if(toReturn == null || string.IsNullOrWhiteSpace(toReturn.CatalogueConnectionString))
             {
                 throw new Exception($"{nameof(CatalogueConnectionString)} is missing from the RDMP connection strings file: '{f.FullName}'");
             }

--- a/Rdmp.Core/Curation/Data/SafeDirectoryCatalog.cs
+++ b/Rdmp.Core/Curation/Data/SafeDirectoryCatalog.cs
@@ -226,7 +226,8 @@ namespace Rdmp.Core.Curation.Data
 
         private void AddTypes(FileInfo f, Assembly ass, Type[] types, ICheckNotifier listener)
         {
-            TypesByAssembly.TryAdd(ass,types.Where(t=>t != null).ToArray());
+            types = types.Where(t => t != null).ToArray();
+            TypesByAssembly.TryAdd(ass,types);
             
             foreach(var t in types)
                 if(t.FullName != null && !TypesByName.ContainsKey(t.FullName))


### PR DESCRIPTION
Seems that when there are dlls where some Types can be resolved but others have dependencies on older versions of RDMP then `Assembly.GetTypes` returns an array with some nulls in it.  There is already code to handle it in RDMP's method `void AddTypes(FileInfo f, Assembly ass, Type[] types, ICheckNotifier listener)`.  But seems that stopped working.  I have fixed the method to properly prune the nulls again.