### PR TITLE
Fix for null RepositoryLocator on CLI

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Datasets in extraction UI are no longer expanded by default (i.e. to show Supporting Documents/Sql) [#1264](https://github.com/HicServices/RDMP/issues/1264)
 
+### Fixed
+
+- Running RDMP cli without supplying repository connection details (and after deleting `Databases.yaml`) now results in a specific error message instead of null reference [#1346]https://github.com/HicServices/RDMP/issues/1346
+
 ## [7.0.17] - 2022-08-01
 
 ### Added

--- a/Rdmp.Core/CommandLine/RdmpCommandLineBootStrapper.cs
+++ b/Rdmp.Core/CommandLine/RdmpCommandLineBootStrapper.cs
@@ -23,6 +23,7 @@ using System.Text;
 using System.Threading.Tasks;
 using YamlDotNet.Serialization;
 using CommandLine;
+using ReusableLibraryCode.Progress;
 
 namespace Rdmp.Core.CommandLine
 {
@@ -120,6 +121,13 @@ namespace Rdmp.Core.CommandLine
 
                 // where RDMP objects are stored
                 repositoryLocator = opts.GetRepositoryLocator();
+
+                if(repositoryLocator == null || repositoryLocator.CatalogueRepository == null)
+                {
+                    listener.OnNotify(typeof(RdmpCommandLineBootStrapper), new NotifyEventArgs(ProgressEventType.Error, "No repository has been specified.  Either create a Databases.yaml file or provide repository connection strings/paths as command line arguments"));
+                    return REPO_ERROR;
+                }
+                    
 
                 if (!CheckRepo(repositoryLocator))
                 {


### PR DESCRIPTION
Fixes #1346

Running without repo now shows 

> ERROR No repository has been specified.  Either create a Databases.yaml file or provide repository connection strings/paths as command line arguments .

```
PS D:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> rm .\Databases.yaml
PS D:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> ./rdmp ScriptTables "TableInfo:*smi*table*" MySql smi "./creation.sql"
2022-08-09 09:26:30.4630 INFO Dotnet Version:6.0.7 .
2022-08-09 09:26:30.4812 INFO RDMP Version:7.0.17.0 .
2022-08-09 09:26:30.5954 ERROR No repository has been specified.  Either create a Databases.yaml file or provide repository connection strings/paths as command line arguments .
2022-08-09 09:26:30.5954 INFO Exiting with code 7 .
```