### PR TITLE
Use IsExtractionIdentifier column's table if there are 2+ `IsPrimaryExtractionTable` during query building

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 - Removed restriction preventing [Lookup] requiring all foreign key columns being from the same table [#1331](https://github.com/HicServices/RDMP/issues/1307)
+- If there are multiple IsPrimaryExtractionTable involved in a query then the one with the IsExtractionIdentifier column (if any) will be picked (previously QueryBuildingException was thrown) [#1365](https://github.com/HicServices/RDMP/issues/1365)
 
 ### Added
 - Added 'Set Description' command to [AggregateConfiguration] context menu

--- a/Rdmp.Core/QueryBuilding/SqlQueryBuilderHelper.cs
+++ b/Rdmp.Core/QueryBuilding/SqlQueryBuilderHelper.cs
@@ -211,7 +211,7 @@ namespace Rdmp.Core.QueryBuilding
             {
                 if (forceJoinsToTheseTables.Count(t => t.IsPrimaryExtractionTable) > 1)
                 {
-                    primaryExtractionTable = PickBestPrimaryExtractionTable(qb, forceJoinsToTheseTables)
+                    primaryExtractionTable = PickBestPrimaryExtractionTable(qb, forceJoinsToTheseTables.Where(t=>t.IsPrimaryExtractionTable).ToArray())
                         ?? throw new QueryBuildingException("Found 2+ tables marked IsPrimaryExtractionTable in force joined tables");
                 }
                 else

--- a/Rdmp.Core/QueryBuilding/SqlQueryBuilderHelper.cs
+++ b/Rdmp.Core/QueryBuilding/SqlQueryBuilderHelper.cs
@@ -207,10 +207,17 @@ namespace Rdmp.Core.QueryBuilding
 
             var toReturn = new List<ITableInfo>(forceJoinsToTheseTables ?? new ITableInfo[0]);
 
-            if (forceJoinsToTheseTables != null && forceJoinsToTheseTables.Length > 0)
+            if (forceJoinsToTheseTables != null)
             {
-                primaryExtractionTable = PickBestPrimaryExtractionTable(qb,forceJoinsToTheseTables) 
-                    ?? throw new QueryBuildingException("Found 2+ tables marked IsPrimaryExtractionTable in force joined tables");
+                if (forceJoinsToTheseTables.Count(t => t.IsPrimaryExtractionTable) > 1)
+                {
+                    primaryExtractionTable = PickBestPrimaryExtractionTable(qb, forceJoinsToTheseTables)
+                        ?? throw new QueryBuildingException("Found 2+ tables marked IsPrimaryExtractionTable in force joined tables");
+                }
+                else
+                {
+                    primaryExtractionTable = forceJoinsToTheseTables.SingleOrDefault(t => t.IsPrimaryExtractionTable);
+                }
             }
             else
                 primaryExtractionTable = null;

--- a/Rdmp.Core/QueryBuilding/SqlQueryBuilderHelper.cs
+++ b/Rdmp.Core/QueryBuilding/SqlQueryBuilderHelper.cs
@@ -207,9 +207,10 @@ namespace Rdmp.Core.QueryBuilding
 
             var toReturn = new List<ITableInfo>(forceJoinsToTheseTables ?? new ITableInfo[0]);
 
-            if (forceJoinsToTheseTables != null)
+            if (forceJoinsToTheseTables != null && forceJoinsToTheseTables.Length > 0)
             {
-                primaryExtractionTable = PickBestPrimaryExtractionTable(qb,forceJoinsToTheseTables) ?? throw new QueryBuildingException("Found 2+ tables marked IsPrimaryExtractionTable in force joined tables");
+                primaryExtractionTable = PickBestPrimaryExtractionTable(qb,forceJoinsToTheseTables) 
+                    ?? throw new QueryBuildingException("Found 2+ tables marked IsPrimaryExtractionTable in force joined tables");
             }
             else
                 primaryExtractionTable = null;


### PR DESCRIPTION
Fixes #1365