### PR TITLE
Special-case filename of 'null' for console and TUI

### DIFF
--- a/Rdmp.Core/CommandLine/Interactive/ConsoleInputManager.cs
+++ b/Rdmp.Core/CommandLine/Interactive/ConsoleInputManager.cs
@@ -10,6 +10,7 @@ using System.Diagnostics;
 using System.Globalization;
 using System.IO;
 using System.Linq;
+using System.Runtime.InteropServices;
 using FAnsi.Discovery;
 using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.CohortCommitting.Pipeline;
@@ -272,9 +273,6 @@ namespace Rdmp.Core.CommandLine.Interactive
 
         public override FileInfo SelectFile(string prompt)
         {
-            if (DisallowInput)
-                throw new InputDisallowedException($"Value required for '{prompt}'");
-
             return SelectFile(prompt, null, null);
         }
 
@@ -285,11 +283,13 @@ namespace Rdmp.Core.CommandLine.Interactive
 
             Console.WriteLine(prompt);
             var file = Console.ReadLine();
-            
-            if(file != null)
-                return new FileInfo(file);
 
-            return null;
+            if (string.IsNullOrWhiteSpace(file)) return null;
+            if (file.Equals("null", StringComparison.CurrentCultureIgnoreCase))
+                return new FileInfo(System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(OSPlatform.Windows)
+                    ? "NUL"
+                    : "/dev/null");
+            return new FileInfo(file);
         }
         
         public override FileInfo[] SelectFiles(string prompt, string patternDescription, string pattern)

--- a/Tools/rdmp/CommandLine/Gui/ConsoleGuiActivator.cs
+++ b/Tools/rdmp/CommandLine/Gui/ConsoleGuiActivator.cs
@@ -5,12 +5,10 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
-using System.Collections.Generic;
 using System.Diagnostics;
 using System.IO;
 using System.Linq;
 using System.Text.RegularExpressions;
-using System.Threading.Tasks;
 using FAnsi.Discovery;
 using MapsDirectlyToDatabaseTable;
 using MapsDirectlyToDatabaseTable.Revertable;
@@ -228,9 +226,14 @@ namespace Rdmp.Core.CommandLine.Gui
             
             Application.Run(openDir, ConsoleMainWindow.ExceptionPopup);
 
-            var selected = openDir.FilePaths.FirstOrDefault();
+            var file = openDir.FilePaths.FirstOrDefault();
             
-            return selected == null ? null : new FileInfo(selected);
+            if (string.IsNullOrWhiteSpace(file)) return null;
+            if (file.Equals("null", StringComparison.CurrentCultureIgnoreCase))
+                return new FileInfo(System.Runtime.InteropServices.RuntimeInformation.IsOSPlatform(System.Runtime.InteropServices.OSPlatform.Windows)
+                    ? "NUL"
+                    : "/dev/null");
+            return new FileInfo(file);
         }
 
         public override FileInfo SelectFile(string prompt, string patternDescription, string pattern)


### PR DESCRIPTION
Let the user direct output to a filename of 'null' as a synonym for `/dev/null` (sane platforms) or `NUL` (Windows) instead of creating an actual file named `null` to resolve #1363 