### PR TITLE
Add SetDefault command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- Added `SetDefault` command for changing default logging/dqe etc servers from command line
 - Added yes/no popup for 'partial matches' when Guessing [CatalogueItem] to [ColumnInfo] mappings (e.g. when remapping metadata layer to a new underlying table) [#1400](https://github.com/HicServices/RDMP/issues/1400)
 - Added UI support for changing `UseAliasInsteadOfTransformInGroupByAggregateGraphs` user setting [#1393](https://github.com/HicServices/RDMP/issues/1393)
 - Added `DoNotUseHashJoinsForCatalogues` to `ExecuteDatasetExtractionSource` [PipelineComponent] [#1403](https://github.com/HicServices/RDMP/issues/1403)

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDescribe.cs
@@ -289,7 +289,13 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                     
                     var desc = req.DemandIfAny?.Description;
 
-                    if(string.IsNullOrWhiteSpace(desc))
+
+                    if (req.Type.IsEnum)
+                    {
+                        desc += $"Allowed Values:{string.Join(", ", Enum.GetNames(req.Type))}";
+                    }
+
+                    if (string.IsNullOrWhiteSpace(desc))
                         return $"{name} {type}";
                     else
                     {

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetDefault.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandSetDefault.cs
@@ -1,0 +1,35 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.Curation.Data.Defaults;
+
+namespace Rdmp.Core.CommandExecution.AtomicCommands
+{
+    /// <summary>
+    /// Changes the default server for a given role (e.g. Logging) to a new server (which must
+    /// already exist and have the correct schema).  Use <see cref="ExecuteCommandCreateNewExternalDatabaseServer"/>
+    /// if you want to create a new server from scratch.
+    /// </summary>
+    public class ExecuteCommandSetDefault : BasicCommandExecution
+    {
+        private readonly PermissableDefaults _toSet;
+        private readonly ExternalDatabaseServer _server;
+
+        public ExecuteCommandSetDefault(IBasicActivateItems basicActivator, PermissableDefaults toSet, ExternalDatabaseServer server):base(basicActivator)
+        {
+            this._toSet = toSet;
+            this._server = server;
+        }
+
+        public override void Execute()
+        {
+            base.Execute();
+
+            BasicActivator.ServerDefaults.SetDefault(_toSet, _server);
+        }
+    }
+}

--- a/Rdmp.Core/Providers/SearchablesMatchScorer.cs
+++ b/Rdmp.Core/Providers/SearchablesMatchScorer.cs
@@ -83,7 +83,8 @@ namespace Rdmp.Core.Providers
                 {"col",typeof (ColumnInfo)},
                 {"lmd",typeof (LoadMetadata)},
                 {"pipe",typeof(Pipeline)},
-                {"sds",typeof(SelectedDataSets)}
+                {"sds",typeof(SelectedDataSets)},
+                {"eds",typeof(ExternalDatabaseServer)}
 
             };
 


### PR DESCRIPTION
Adds command SetDefault. 

Also contains QoL improvements to CLI.

- Can pass `eds` instead of `ExternalDatabaseServer` e.g. `eds:1`
- When command takes any `Enum` the `describe` now lists the allowed values

```
PS D:\Repos\RDMP\Tools\rdmp> dotnet run -- describe SetDefault -q
Name: ExecuteCommandSetDefault

USAGE:
./rdmp.exe SetDefault <toSet> <server>

PARAMETERS:
toSet          PermissableDefaults    Allowed Values:None, LiveLoggingServer_ID, IdentifierDumpServer_ID, DQE,
                                      WebServiceQueryCachingServer_ID, RAWDataLoadServer, ANOStore,
                                      CohortIdentificationQueryCachingServer_ID
server         ExternalDatabaseServer


The following syntaxes may be used for parameters in this query:

Pick RDMP Object:
Formats:
{Type}:{ID}[,{ID2},{ID3}...]
{Type}:{NamePattern}[,{NamePattern2},{NamePattern3}...]
{Type}?{Property}:{PropertyValue}
Examples:
Catalogue:1
Catalogue:1,2,3
Catalogue:mycata*
Catalogue:mycata1,mycata2
CatalogueItem?Catalogue_ID:55
Catalogue?Folder:*edris*
```