### PR TITLE
Fix ViewLogs not working on CLI gui

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Added better error message when there are problems with naming etc of a new cohort being committed [#1408](https://github.com/HicServices/RDMP/issues/1408)
 - Fixed a null reference trying to save [TableInfo] objects in application after setting the `Database` field to null.
+- Fixed `ViewLogs` command not working from Console Gui
 
 ### Added
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandViewLogs.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandViewLogs.cs
@@ -46,8 +46,13 @@ int? Optional, if <root> is logging server this can be a specific audit id to sh
                 
                 if(obj is ILoggedActivityRootObject root)
                     RootObject =  root;
+                else
                 if(obj is ExternalDatabaseServer eds)
                     _loggingServers = new ExternalDatabaseServer[]{eds};
+                else
+                {
+                    throw new Exception($"'{obj}' is of type '{obj.GetType().Name}' which is not '{nameof(ILoggedActivityRootObject)}' so cannot be used with this command.");
+                }
             }
 
             LoggingTables table = LoggingTables.None;
@@ -64,6 +69,7 @@ int? Optional, if <root> is logging server this can be a specific audit id to sh
 
         }
 
+        [UseWithObjectConstructor]
         public ExecuteCommandViewLogs(IBasicActivateItems activator, ILoggedActivityRootObject rootObject) : base(activator)
         {
             RootObject = rootObject;


### PR DESCRIPTION
Also better error message when you pass wrong object type e.g. `Project`