### PR TITLE
Add SkipPatching command line option

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Added
+
+- Added command line switch `--skip-patching` to prevent running patches and launch the application as normal (can help debugging patch issues) [#1392](https://github.com/HicServices/RDMP/issues/1392)
+
 ## [8.0.0] - 2022-09-27
 
 **Contains database patch to add support for Commit system and expanded Folder support**

--- a/Rdmp.Core/CommandLine/Options/RDMPCommandLineOptions.cs
+++ b/Rdmp.Core/CommandLine/Options/RDMPCommandLineOptions.cs
@@ -57,6 +57,9 @@ namespace Rdmp.Core.CommandLine.Options
         [Option('q',"quiet",Required = false, HelpText = "Suppress all console logging not directly tied to show/get value etc")]
         public bool Quiet { get; set; }
 
+        [Option("skip-patching", Required = false, HelpText = "Do not check to see if platform databases are out of date or suggest patching them")]
+        public bool SkipPatching { get; set; }
+
         /// <summary>
         /// If <see cref="ConnectionStringsFile"/> was specified and that file existed and was succesfully loaded
         /// using <see cref="PopulateConnectionStringsFromYamlIfMissing"/> then this property will store the
@@ -69,7 +72,7 @@ namespace Rdmp.Core.CommandLine.Options
 
         public IRDMPPlatformRepositoryServiceLocator DoStartup(EnvironmentInfo env,ICheckNotifier checkNotifier)
         {
-            Startup.Startup startup = new Startup.Startup(env,GetRepositoryLocator());
+            Startup.Startup startup = new Startup.Startup(env, GetRepositoryLocator()) { SkipPatching = SkipPatching};
             startup.DoStartup(checkNotifier);
             return startup.RepositoryLocator;
         }

--- a/Rdmp.Core/Startup/Startup.cs
+++ b/Rdmp.Core/Startup/Startup.cs
@@ -53,6 +53,11 @@ namespace Rdmp.Core.Startup
         public event FoundPlatformDatabaseHandler DatabaseFound = delegate { };
         public event MEFDownloadProgressHandler MEFFileDownloaded = delegate { };
 
+        /// <summary>
+        /// Set to true to ignore unpatched platform databases
+        /// </summary>
+        public bool SkipPatching { get; set; }
+
         public PluginPatcherFoundHandler PluginPatcherFound = delegate { }; 
 
         PatcherManager _patcherManager = new PatcherManager();
@@ -197,6 +202,10 @@ namespace Rdmp.Core.Startup
                 DatabaseFound(this, new PlatformDatabaseFoundEventArgs(tableRepository, patcher, RDMPPlatformDatabaseStatus.Broken, e));
                 return false;
             }
+
+            // if we are suppressing patching
+            if (patchingRequired == Patch.PatchingState.Required && SkipPatching)
+                patchingRequired = Patch.PatchingState.NotRequired;
 
             switch(patchingRequired)
             {

--- a/Rdmp.UI/TestsAndSetup/RDMPBootStrapper.cs
+++ b/Rdmp.UI/TestsAndSetup/RDMPBootStrapper.cs
@@ -87,7 +87,7 @@ namespace Rdmp.UI.TestsAndSetup
             try
             {
                 //show the startup dialog
-                Startup startup = new Startup(_environmentInfo);
+                Startup startup = new Startup(_environmentInfo) { SkipPatching = _args.SkipPatching };
 
                 if(!string.IsNullOrWhiteSpace(_args.Dir))
                 {

--- a/Tools/rdmp/Program.cs
+++ b/Tools/rdmp/Program.cs
@@ -155,7 +155,7 @@ namespace Rdmp.Core
 
             var checker = new NLogICheckNotifier(true, false);
 
-            var start = new Startup.Startup(RdmpCommandLineBootStrapper.GetEnvironmentInfo(),repo);
+            var start = new Startup.Startup(RdmpCommandLineBootStrapper.GetEnvironmentInfo(), repo);
             bool badTimes = false;
 
             start.DatabaseFound += (s,e)=>{


### PR DESCRIPTION
Fixes #1392

To enable use `--skip-patching` flag on windows client (e.g. from a shortcut or .bat file) or CLI client