### PR TITLE
Fixes YamlRepository encryption on ExternalDatabaseServer objects

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed not being able to clear properties on PipelineComponents when Type is an Array of database objects [#1420](https://github.com/HicServices/RDMP/issues/1420)
 - Fixed bug with Commit system not refreshing after delete
 - Fixed bug with Commit system when working with Plugins that have custom repositories
+- Fixed string encryption on [ExternalDatabaseServer] objects created with YamlRepository
 
 ### Added
 

--- a/Rdmp.Core/Curation/Data/ExternalDatabaseServer.cs
+++ b/Rdmp.Core/Curation/Data/ExternalDatabaseServer.cs
@@ -116,12 +116,8 @@ namespace Rdmp.Core.Curation.Data
             get { return _selfCertifyingDataAccessPoint.Password; }
             set
             {
-                if (Equals(_selfCertifyingDataAccessPoint.Password, value))
-                    return;
-
-                var old = _selfCertifyingDataAccessPoint.Password;
                 _selfCertifyingDataAccessPoint.Password = value;
-                OnPropertyChanged(old, value);
+                OnPropertyChanged(null, value);
             }
         }
 
@@ -286,6 +282,11 @@ namespace Rdmp.Core.Curation.Data
         public bool DiscoverExistence(DataAccessContext context,out string reason)
         {
             return _selfCertifyingDataAccessPoint.DiscoverExistence(context,out reason);
+        }
+
+        public void SetRepository(ICatalogueRepository repository)
+        {
+            _selfCertifyingDataAccessPoint.SetRepository(repository);
         }
     }
 }

--- a/Rdmp.Core/DataLoad/Modules/DataProvider/WebServiceConfiguration.cs
+++ b/Rdmp.Core/DataLoad/Modules/DataProvider/WebServiceConfiguration.cs
@@ -22,6 +22,8 @@ namespace Rdmp.Core.DataLoad.Modules.DataProvider
     
     public class WebServiceConfiguration : EncryptedPasswordHost, ICustomUIDrivenClass
     {
+        private ICatalogueRepository _repository;
+
         /// <summary>
         /// For XML Serialization
         /// </summary>
@@ -31,6 +33,7 @@ namespace Rdmp.Core.DataLoad.Modules.DataProvider
 
         public WebServiceConfiguration(ICatalogueRepository repository) : base(repository)
         {
+            _repository = repository;
         }
 
         public string Endpoint { get; set; }
@@ -51,6 +54,7 @@ namespace Rdmp.Core.DataLoad.Modules.DataProvider
             try
             {
                 var deserialized = (WebServiceConfiguration)deserializer.Deserialize(new StringReader(value));
+                deserialized.SetRepository(_repository);
 
                 Endpoint = deserialized.Endpoint;
                 Username = deserialized.Username;

--- a/Rdmp.Core/Repositories/MemoryCatalogueRepository.cs
+++ b/Rdmp.Core/Repositories/MemoryCatalogueRepository.cs
@@ -521,15 +521,7 @@ namespace Rdmp.Core.Repositories
         #endregion
 
         #region IEncryptionManager
-        public IEncryptStrings GetEncrypter()
-        {
-            return new SimpleStringValueEncryption(null);
-        }
-        public void ClearAllInjections()
-        {
-
-        }
-
+     
         public virtual void SetEncryptionKeyPath(string fullName)
         {
             EncryptionKeyPath = fullName;

--- a/Rdmp.Core/Repositories/YamlRepository.cs
+++ b/Rdmp.Core/Repositories/YamlRepository.cs
@@ -157,6 +157,9 @@ public class YamlRepository : MemoryDataExportRepository
             case DataAccessCredentials creds:
                 creds.SetEncryptedPasswordHost(new EncryptedPasswordHost(this));
                 break;
+            case ExternalDatabaseServer eds:
+                eds.SetRepository(this);
+                break;
             case ConcreteContainer container:
                 container.SetManager(this);
                 break;


### PR DESCRIPTION
YamlRepository requires to deserialize objects using blank constructor.  That means no access to `IRepository` at that time.  Hence all the blank constructors for objects like `Catalogue`.  Encryption logic is determined by `IRepository`.  To avoid this there was a class added called `FakeEncryptedString`.  But that was never replaced with the real one when it came to `ExternalDatabaseServer`.

Implementation is actually correct for `DataAccessCredentials`  where YamlRepository updates after construction:

```csharp
case DataAccessCredentials creds:
                creds.SetEncryptedPasswordHost(new EncryptedPasswordHost(this));
                break;
```

This PR does the following
- Add a `throw` when attempting to read a password when `FakeEncryptedString` is installed.  This will prevent the issue going undetected in future
- Add a new method `SetRepository` to `ExternalDatabaseServer` which updates the instance with the correct environmental decryption routine

There is one behaviour change which is the OnPropertyChanged on `Password` which no longer reports the old (encrypted) value in the callback.  Now it always reports a change from `null` to `encrypted new value`.  This prevents having to read from object during construction (which would throw because of the new `FakeEncryptedString` check.

Now working as intended:
```
PS D:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> ./rdmp describe eds --dir .\rdmp-yaml\ -q
Name:New ExternalDatabaseServer 30ffc904-e7b6-40ca-9bd6-845c17a9a551
CreatedByAssembly:NULL
MappedDataPath:NULL
Server:NULL
Database:NULL
Username:fish
Password:33-A9-13-8E-68-21-93-DF-C4-BB-CC-49-0D-DF-1E-1B-F2-F1-A5-90-12-7C-BB-E1-77-48-E1-B9-EA-FA-37-39-C6-82-BE-87-20-36-DD-B6-9F-01-C7-79-5B-94-3C-E1
DatabaseType:MicrosoftSQLServer
ID:2
-----------------------------------------

PS D:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> ./rdmp set eds Password fish --dir .\rdmp-yaml\ -q
PS D:\Repos\RDMP\Tools\rdmp\bin\Debug\net6.0> ./rdmp describe eds --dir .\rdmp-yaml\ -q
Name:New ExternalDatabaseServer 30ffc904-e7b6-40ca-9bd6-845c17a9a551
CreatedByAssembly:NULL
MappedDataPath:NULL
Server:NULL
Database:NULL
Username:fish
Password:32-63-D2-C0-8F-E0-6A-91-CD-93-A4-A5-4A-EA-28-EA-D5-C8-6B-E2-58-9B-7F-5A-61-00-17-58-76-96-04-F6-67-68-19-AF-45-AB-E8-74-F2-F8-E0-6F-C6-FB-84-CB
DatabaseType:MicrosoftSQLServer
ID:2
-----------------------------------------
```