### PR TITLE
Fix deleting ExternalDatabaseServer with YamlRepository not clearing

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug with Commit system when working with Plugins that have custom repositories
 - Fix deleting ExternalDatabaseServer with YamlRepository not clearing default (e.g. deleting default logging server)
 - Fixed stale references in YamlRepository breaking on startup (ServerDefaults.yaml and CredentialsDictionary.yaml) 
+- Fixed empty yaml files causing errors (e.g. deleting contents of ServerDefaults.yaml)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed not being able to clear properties on PipelineComponents when Type is an Array of database objects [#1420](https://github.com/HicServices/RDMP/issues/1420)
 - Fixed bug with Commit system not refreshing after delete
 - Fixed bug with Commit system when working with Plugins that have custom repositories
+- Fix deleting ExternalDatabaseServer with YamlRepository not clearing default (e.g. deleting default logging server)
 
 ### Added
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -15,6 +15,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fixed bug with Commit system not refreshing after delete
 - Fixed bug with Commit system when working with Plugins that have custom repositories
 - Fix deleting ExternalDatabaseServer with YamlRepository not clearing default (e.g. deleting default logging server)
+- Fixed stale references in YamlRepository breaking on startup (ServerDefaults.yaml and CredentialsDictionary.yaml) 
 
 ### Added
 

--- a/Rdmp.Core.Tests/Curation/Integration/ServerDefaultsTests.cs
+++ b/Rdmp.Core.Tests/Curation/Integration/ServerDefaultsTests.cs
@@ -7,6 +7,7 @@
 using NUnit.Framework;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Curation.Data.Defaults;
+using Rdmp.Core.Databases;
 using Tests.Common;
 
 namespace Rdmp.Core.Tests.Curation.Integration
@@ -48,7 +49,29 @@ namespace Rdmp.Core.Tests.Curation.Integration
             {
                 databaseServer.DeleteInDatabase();
             }
+        }
 
+        [Test]
+        public void TestDeletingClearsDefault()
+        {
+            var eds = new ExternalDatabaseServer(CatalogueRepository, "mydb", new LoggingDatabasePatcher());
+            var old = CatalogueRepository.GetDefaultFor(PermissableDefaults.LiveLoggingServer_ID);
+
+            try
+            {
+                //make the new server the default for logging
+                CatalogueRepository.SetDefault(PermissableDefaults.LiveLoggingServer_ID,eds);
+
+                //now we deleted it!
+                eds.DeleteInDatabase();
+
+                Assert.IsNull(CatalogueRepository.GetDefaultFor(PermissableDefaults.LiveLoggingServer_ID));
+            }
+            finally
+            {
+
+                CatalogueRepository.SetDefault(PermissableDefaults.LiveLoggingServer_ID, old);
+            }            
         }
     }
 }

--- a/Rdmp.Core/Curation/Data/ExternalDatabaseServer.cs
+++ b/Rdmp.Core/Curation/Data/ExternalDatabaseServer.cs
@@ -13,6 +13,7 @@ using FAnsi.Discovery.QuerySyntax;
 using MapsDirectlyToDatabaseTable;
 using MapsDirectlyToDatabaseTable.Attributes;
 using MapsDirectlyToDatabaseTable.Versioning;
+using Rdmp.Core.Curation.Data.Defaults;
 using Rdmp.Core.Curation.Data.ImportExport;
 using Rdmp.Core.Curation.Data.Serialization;
 using Rdmp.Core.Databases;
@@ -286,6 +287,23 @@ namespace Rdmp.Core.Curation.Data
         public bool DiscoverExistence(DataAccessContext context,out string reason)
         {
             return _selfCertifyingDataAccessPoint.DiscoverExistence(context,out reason);
+        }
+
+        public override void DeleteInDatabase()
+        {
+            base.DeleteInDatabase();
+
+            // normally in database schema deleting an ExternalDatabaseServer will cascade to clear defaults
+            // but some repositories do not support this implicit removal so lets double check theres no references
+            foreach(PermissableDefaults d in Enum.GetValues(typeof(PermissableDefaults)))
+            {
+                var existingDefault = CatalogueRepository.GetDefaultFor(d);
+                if (this.Equals(existingDefault))
+                {
+                    CatalogueRepository.ClearDefault(d);
+                }
+            }
+            
         }
     }
 }

--- a/Rdmp.Core/Repositories/CatalogueRepository.cs
+++ b/Rdmp.Core/Repositories/CatalogueRepository.cs
@@ -286,7 +286,11 @@ select 0", con.Connection, con.Transaction))
                 throw new ArgumentException("toChange cannot be None", "toChange");
 
             if (externalDatabaseServer == null)
+            {
                 ClearDefault(toChange);
+                return;
+            }
+                
 
             var oldValue = GetDefaultFor(toChange);
 

--- a/Rdmp.Core/Repositories/CatalogueRepository.cs
+++ b/Rdmp.Core/Repositories/CatalogueRepository.cs
@@ -285,6 +285,9 @@ select 0", con.Connection, con.Transaction))
             if (toChange == PermissableDefaults.None)
                 throw new ArgumentException("toChange cannot be None", "toChange");
 
+            if (externalDatabaseServer == null)
+                ClearDefault(toChange);
+
             var oldValue = GetDefaultFor(toChange);
 
             if (oldValue == null)

--- a/Rdmp.Core/Repositories/MemoryCatalogueRepository.cs
+++ b/Rdmp.Core/Repositories/MemoryCatalogueRepository.cs
@@ -184,17 +184,20 @@ namespace Rdmp.Core.Repositories
 
         public IExternalDatabaseServer GetDefaultFor(PermissableDefaults field)
         {
-            return Defaults[field];
+            return Defaults.TryGetValue(field, out var result) ? result : null;
         }
 
         public void ClearDefault(PermissableDefaults toDelete)
         {
-            Defaults[toDelete] = null;
+            SetDefault(toDelete, null);
         }
 
         public virtual void SetDefault(PermissableDefaults toChange, IExternalDatabaseServer externalDatabaseServer)
         {
-            Defaults[toChange] = externalDatabaseServer;
+            if (Defaults.ContainsKey(toChange))
+                Defaults[toChange] = externalDatabaseServer;
+            else
+                Defaults.Add(toChange, externalDatabaseServer);
         }
         
         public override void Clear()

--- a/Rdmp.Core/Repositories/YamlRepository.cs
+++ b/Rdmp.Core/Repositories/YamlRepository.cs
@@ -293,7 +293,25 @@ public class YamlRepository : MemoryDataExportRepository
             var objectIds = deserializer.Deserialize<Dictionary<PermissableDefaults, int>>(yaml);
             Defaults = objectIds.ToDictionary(
                 k=>k.Key,
-                v=>v.Value == 0 ? null : (IExternalDatabaseServer)GetObjectByID<ExternalDatabaseServer>(v.Value));
+                v=>v.Value == 0 ? null : (IExternalDatabaseServer)GetObjectByIDIfExists<ExternalDatabaseServer>(v.Value));
+        }
+    }
+
+    /// <summary>
+    /// Returns the object referenced or null if it has been deleted on the sly (e.g. by user deleting .yaml files on disk)
+    /// </summary>
+    /// <typeparam name="T"></typeparam>
+    /// <param name="id"></param>
+    /// <returns></returns>
+    private T GetObjectByIDIfExists<T>(int id) where T:DatabaseEntity
+    {
+        try
+        {
+            return GetObjectByID<T>(id);
+        }
+        catch (KeyNotFoundException)
+        {
+            return null;
         }
     }
     #endregion

--- a/Tests.Common/TestDatabases.txt
+++ b/Tests.Common/TestDatabases.txt
@@ -8,6 +8,8 @@
 
 Prefix:	TEST_
 ServerName:	(localdb)\MSSQLLocalDB
+#Uncomment to run tests with a YamlRepository
+#UseFileSystemRepo: true
 MySql:	server=127.0.0.1;Uid=root;Pwd=YourStrong!Passw0rd;AllowPublicKeyRetrieval=True
 PostgreSql:	User ID=postgres;Password=;Host=127.0.0.1;Port=5432
 Oracle: 


### PR DESCRIPTION
Sql Server schema for RDMP has a CASCADE constraint that automatically deletes default declarations when an ExternalDatabaseServer (e.g. logging server) is deleted.

This PR adds a test and a fix for YamlRepository which did not have the same behaviour and left hanging references when deleting