### PR TITLE
Folder fixes

### DIFF
--- a/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
@@ -439,9 +439,9 @@ namespace Rdmp.Core.CommandExecution
                 yield return new ExecuteCommandAddNewGovernanceDocument(_activator, null) { OverrideCommandName = "Add New Governance Document" };
             }
 
-            if (Is(o,out FolderNode<LoadMetadata> _))
+            if (Is(o,out FolderNode<LoadMetadata> lmdFolder))
             {
-                yield return new ExecuteCommandCreateNewLoadMetadata(_activator);
+                yield return new ExecuteCommandCreateNewLoadMetadata(_activator) { Folder = lmdFolder.FullName};
                 yield return new ExecuteCommandImportShareDefinitionList(_activator){OverrideCommandName = "Import Load"};
             }
 

--- a/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
@@ -372,8 +372,11 @@ namespace Rdmp.Core.CommandExecution
                 yield return new ExecuteCommandClearQueryCache(_activator, cicQueryCache.User);
             }
 
-            if(Is(o,out FolderNode<CohortIdentificationConfiguration> _))
-                yield return new ExecuteCommandCreateNewCohortIdentificationConfiguration(_activator) { PromptToPickAProject=true};
+            if(Is(o,out FolderNode<CohortIdentificationConfiguration> cicFolder))
+                yield return new ExecuteCommandCreateNewCohortIdentificationConfiguration(_activator) {
+                    PromptToPickAProject=true,
+                    Folder = cicFolder.FullName
+                };
 
             if (Is(o, out IJoin j))
             {

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewCohortIdentificationConfiguration.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewCohortIdentificationConfiguration.cs
@@ -31,6 +31,11 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
         /// yet on this command.
         /// </summary>
         public bool PromptToPickAProject { get; set; } = false;
+        
+        /// <summary>
+        /// The folder to put the new <see cref="CohortIdentificationConfiguration"/> in.  Defaults to <see cref="FolderHelper.Root"/>
+        /// </summary>
+        public string Folder { get; set; } = FolderHelper.Root;
 
         /// <summary>
         /// Name to give the root component of new cics created by this command (usually an EXCEPT but not always - see Cohort Configuration Wizard)
@@ -112,6 +117,9 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
                 
             if (cic == null)
                 return;
+
+            cic.Folder = Folder;
+            cic.SaveToDatabase();
 
             if (proj != null)
             {

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewLoadMetadata.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewLoadMetadata.cs
@@ -12,6 +12,7 @@ using Rdmp.Core.Curation.Data.DataLoad;
 using Rdmp.Core.Icons.IconProvision;
 using ReusableLibraryCode.Icons.IconProvision;
 using SixLabors.ImageSharp.PixelFormats;
+using Rdmp.Core.Curation.Data.Cohort;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands
 {
@@ -19,6 +20,11 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
     {
         private Catalogue[] _availableCatalogues;
         private Catalogue _catalogue;
+
+        /// <summary>
+        /// The folder to put the new <see cref="LoadMetadata"/> in.  Defaults to <see cref="FolderHelper.Root"/>
+        /// </summary>
+        public string Folder { get; set; } = FolderHelper.Root;
 
         public ExecuteCommandCreateNewLoadMetadata(IBasicActivateItems activator,
         [DemandsInitialization("Which Catalogue does this load.  Catalogues must not be associated with an existing load")]
@@ -61,6 +67,9 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
 
                 _catalogue.LoadMetadata_ID = lmd.ID;
                 _catalogue.SaveToDatabase();
+
+                lmd.Folder = Folder;
+                lmd.SaveToDatabase();
 
                 Publish(lmd);
 

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandPutIntoFolder.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandPutIntoFolder.cs
@@ -55,12 +55,19 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands
             {
                 if(BasicActivator.IsInteractive)
                 {
+                    // if theres a single current value for the folder
+                    // of these objects (i.e. they are only operating on one item
+                    // or on several items in the same folder).  Then make the 
+                    // popup text box show the old value.  Otherwise show the root \
+                    var current = _toMove.Select(m => m.Folder).Distinct().ToArray();
+                    string oldValue = current.Length == 1 ? current[0] : "\\";
+
                     if (!BasicActivator.TypeText(new DialogArgs
                     {
                         WindowTitle = "Folder",
                         TaskDescription = "Enter a new virtual folder for the object.  Folder names should be lower case and start with a backslash ('\\')",
                         EntryLabel = "New Folder"
-                    }, 500, "\\", out f, false))
+                    }, 500, oldValue, out f, false))
                         return;
                 }
                 else

--- a/Rdmp.UI.Tests/DesignPatternTests/UserInterfaceStandardisationChecker.cs
+++ b/Rdmp.UI.Tests/DesignPatternTests/UserInterfaceStandardisationChecker.cs
@@ -110,8 +110,9 @@ namespace Rdmp.UI.Tests.DesignPatternTests
 
             //All Menus should correspond to a data class
             foreach (Type menuClass in mef.GetAllTypes().Where(t => typeof (RDMPContextMenuStrip).IsAssignableFrom(t) && !t.IsAbstract && !t.IsInterface))
-            {
-                if(menuClass == typeof(RDMPContextMenuStrip) || menuClass == typeof(CatalogueFolderMenu)) //the basic class from which all are inherited
+            { 
+                //the basic class from which all are inherited or a menu for FolderNode<X>
+                if(menuClass == typeof(RDMPContextMenuStrip) || menuClass.Name.EndsWith("FolderMenu"))
                     continue;
                 
                 //We are looking at something like AutomationServerSlotsMenu

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandCreateNewDataExtractionProject.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandCreateNewDataExtractionProject.cs
@@ -14,11 +14,17 @@ using Rdmp.UI.ItemActivation;
 using Rdmp.UI.Wizard;
 using ReusableLibraryCode.Icons.IconProvision;
 using SixLabors.ImageSharp.PixelFormats;
+using Rdmp.Core.Curation.Data;
 
 namespace Rdmp.UI.CommandExecution.AtomicCommands
 {
     public class ExecuteCommandCreateNewDataExtractionProject : BasicUICommandExecution, IAtomicCommand
     {
+        /// <summary>
+        /// The folder to put the new <see cref="Project"/> in.  Defaults to <see cref="FolderHelper.Root"/>
+        /// </summary>
+        public string Folder { get; set; } = FolderHelper.Root;
+
         public ExecuteCommandCreateNewDataExtractionProject(IActivateItems activator) : base(activator)
         {
             UseTripleDotSuffix = true;
@@ -31,6 +37,10 @@ namespace Rdmp.UI.CommandExecution.AtomicCommands
             if (wizard.ShowDialog() == DialogResult.OK && wizard.ProjectCreatedIfAny != null)
             {
                 var p = wizard.ProjectCreatedIfAny;
+
+                p.Folder = Folder;
+                p.SaveToDatabase();
+
                 Publish(p);
                 Activator.RequestItemEmphasis(this, new EmphasiseRequest(p, int.MaxValue));
 

--- a/Rdmp.UI/Menus/ProjectFolderMenu.cs
+++ b/Rdmp.UI/Menus/ProjectFolderMenu.cs
@@ -1,0 +1,25 @@
+﻿// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using Rdmp.Core.Curation.Data;
+using Rdmp.Core.DataExport.Data;
+using Rdmp.UI.CommandExecution.AtomicCommands;
+
+namespace Rdmp.UI.Menus
+{
+    [System.ComponentModel.DesignerCategory("")]
+    class ProjectFolderMenu : RDMPContextMenuStrip
+    {
+        public ProjectFolderMenu(RDMPContextMenuStripArgs args, FolderNode<Project> folder)
+            : base(args, folder)
+        {
+            Add(new ExecuteCommandCreateNewDataExtractionProject(_activator)
+            {
+                Folder = folder.FullName
+            });
+        }
+    }
+}

--- a/Rdmp.UI/Menus/ProjectMenu.cs
+++ b/Rdmp.UI/Menus/ProjectMenu.cs
@@ -27,6 +27,5 @@ namespace Rdmp.UI.Menus
 
             Add(new ExecuteCommandCreateNewCatalogueByImportingFileUI(_activator) { OverrideCommandName = "New Project Specific Catalogue From File...", SuggestedCategory = AtomicCommandFactory.Add, Weight = -1.9f });
         }
-
     }
 }


### PR DESCRIPTION
- Right clicking an object and choosing 'put in folder' now pops up showing the current path instead of `\`
- Right clicking a `FolderNode<Project>` now offers you to create a new Project
- Creating a Project, cic or lmd via right click on a folder will create the object in the correct folder (the one right clicked).  Previously would always be created on the root.