### PR TITLE
Apply fixes in  #1440 to other encryption using parts of RDMP

### DIFF
--- a/Rdmp.Core/Curation/Data/DataAccessCredentials.cs
+++ b/Rdmp.Core/Curation/Data/DataAccessCredentials.cs
@@ -59,12 +59,8 @@ namespace Rdmp.Core.Curation.Data
                     return;
                 }
 
-                if (Equals(_encryptedPasswordHost.Password,value))
-                    return;
-
-                var old = _encryptedPasswordHost.Password;
                 _encryptedPasswordHost.Password = value;
-                OnPropertyChanged(old, value);
+                OnPropertyChanged(null, value);
             }
         }
 

--- a/Rdmp.Core/Curation/Data/DataAccessCredentials.cs
+++ b/Rdmp.Core/Curation/Data/DataAccessCredentials.cs
@@ -149,6 +149,9 @@ namespace Rdmp.Core.Curation.Data
         /// <inheritdoc/>
         public string GetDecryptedPassword()
         {
+            if (_encryptedPasswordHost == null)
+                throw new Exception($"Passwords cannot be decrypted until {nameof(SetEncryptedPasswordHost)} has been called and decryption strategy is established");
+
             return _encryptedPasswordHost.GetDecryptedPassword() ?? "";
         }
 

--- a/Rdmp.Core/Curation/Data/EncryptedPasswordHost.cs
+++ b/Rdmp.Core/Curation/Data/EncryptedPasswordHost.cs
@@ -7,6 +7,7 @@
 using MapsDirectlyToDatabaseTable;
 using Rdmp.Core.Repositories;
 using ReusableLibraryCode.DataAccess;
+using System;
 
 namespace Rdmp.Core.Curation.Data
 {
@@ -92,6 +93,9 @@ namespace Rdmp.Core.Curation.Data
         /// <inheritdoc/>
         public string GetDecryptedPassword()
         {
+            if (_encryptedString == null)
+                throw new Exception($"Passwords cannot be decrypted until {nameof(SetRepository)} has been called and decryption strategy is established");
+
             return _encryptedString.GetDecryptedValue() ?? "";
         }
     }

--- a/Rdmp.Core/Curation/Data/Remoting/RemoteRDMP.cs
+++ b/Rdmp.Core/Curation/Data/Remoting/RemoteRDMP.cs
@@ -32,6 +32,7 @@ namespace Rdmp.Core.Curation.Data.Remoting
         private string _username;
 
         private EncryptedPasswordHost _encryptedPasswordHost;
+        private string _tempPassword;
 
         #endregion
 
@@ -68,13 +69,16 @@ namespace Rdmp.Core.Curation.Data.Remoting
             get { return _encryptedPasswordHost.Password; }
             set
             {
-                if (_encryptedPasswordHost.Password == value)
+                // if we are being deserialized (using blank constructor)
+                if(_encryptedPasswordHost == null)
+                {
+                    // store the encrypted value from the database in a temp variable
+                    // until we get told how to decrypt (see SetRepository)
+                    _tempPassword = value;
                     return;
-
-                var old = _encryptedPasswordHost.Password;
+                }
                 _encryptedPasswordHost.Password = value;
-
-                OnPropertyChanged(old,value);
+                OnPropertyChanged(null, value);
             }
         }
 
@@ -165,6 +169,13 @@ namespace Rdmp.Core.Curation.Data.Remoting
             baseUri.Path += "/api/values/";
 
             return baseUri.ToString();
+        }
+
+
+        public void SetRepository(ICatalogueRepository repository)
+        {
+            _encryptedPasswordHost = new EncryptedPasswordHost(repository);
+            _encryptedPasswordHost.Password = _tempPassword;
         }
     }
 }

--- a/Rdmp.Core/Curation/Data/Remoting/RemoteRDMP.cs
+++ b/Rdmp.Core/Curation/Data/Remoting/RemoteRDMP.cs
@@ -85,6 +85,9 @@ namespace Rdmp.Core.Curation.Data.Remoting
         /// <inheritdoc/>
         public string GetDecryptedPassword()
         {
+            if (_encryptedPasswordHost == null)
+                throw new Exception($"Passwords cannot be decrypted until {nameof(SetRepository)} has been called and decryption strategy is established");
+
             return _encryptedPasswordHost.GetDecryptedPassword()?? "";
         }
         public RemoteRDMP()

--- a/Rdmp.Core/DataExport/Data/ExternalCohortTable.cs
+++ b/Rdmp.Core/DataExport/Data/ExternalCohortTable.cs
@@ -361,12 +361,8 @@ namespace Rdmp.Core.DataExport.Data
             get { return SelfCertifyingDataAccessPoint.Password; }
             set
             {
-                if (Equals(SelfCertifyingDataAccessPoint.Password, value))
-                    return;
-
-                var old = SelfCertifyingDataAccessPoint.Password;
                 SelfCertifyingDataAccessPoint.Password = value;
-                OnPropertyChanged(old, value);
+                OnPropertyChanged(null, value);
             }
         }
 
@@ -530,6 +526,11 @@ description as {syntax.EnsureWrapped("Description")},
         public bool DiscoverExistence(DataAccessContext context, out string reason)
         {
             return SelfCertifyingDataAccessPoint.DiscoverExistence(context,out reason);
+        }
+
+        public void SetRepository(ICatalogueRepository repository)
+        {
+            SelfCertifyingDataAccessPoint.SetRepository(repository);
         }
     }
 }

--- a/Rdmp.Core/Repositories/YamlRepository.cs
+++ b/Rdmp.Core/Repositories/YamlRepository.cs
@@ -14,6 +14,7 @@ using Rdmp.Core.Curation.Data.Aggregation;
 using Rdmp.Core.Curation.Data.Cohort;
 using Rdmp.Core.Curation.Data.Defaults;
 using Rdmp.Core.Curation.Data.Governance;
+using Rdmp.Core.Curation.Data.Remoting;
 using Rdmp.Core.DataExport.Data;
 using Rdmp.Core.Repositories.Managers;
 using ReusableLibraryCode.DataAccess;
@@ -160,6 +161,12 @@ public class YamlRepository : MemoryDataExportRepository
             case ExternalDatabaseServer eds:
                 eds.SetRepository(this);
                 break;
+            case ExternalCohortTable ect:
+                ect.SetRepository(this);
+                break;
+            case RemoteRDMP remote:
+                remote.SetRepository(this);
+                break;
             case ConcreteContainer container:
                 container.SetManager(this);
                 break;
@@ -210,6 +217,8 @@ public class YamlRepository : MemoryDataExportRepository
     public override void SaveToDatabase(IMapsDirectlyToDatabaseTable o)
     {
         base.SaveToDatabase(o);
+        
+        SetRepositoryOnObject(o);
 
         var yaml = _serializer.Serialize(o);
 

--- a/Rdmp.Core/Repositories/YamlRepository.cs
+++ b/Rdmp.Core/Repositories/YamlRepository.cs
@@ -173,7 +173,10 @@ public class YamlRepository : MemoryDataExportRepository
             case LoadModuleAssembly lma:
                 lock(lockFs)
                 {
-                    lma.Bin = File.ReadAllBytes(GetNupkgPath(lma));
+                    var file = GetNupkgPath(lma);
+
+                    if(File.Exists(file))
+                        lma.Bin = File.ReadAllBytes(file);
                     break;
                 }
         }


### PR DESCRIPTION
#1440 fixed many issues with data access credentials interacting with `YamlRepository`.  But turns out there were other classes that follow the same pattern as those tackled in the previous PR.  This PR applies the same fix pattern to the other object types.  

Also fix to ensure `protected virtual void SetRepositoryOnObject(IMapsDirectlyToDatabaseTable obj)` is called on new objects as well as those loaded from disk by YamlRepository