### PR TITLE
Fix ViewLogs with eds

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Fixed
+
+- Fixed `ViewLogs` command not working properly on command line when passed an [ExternalDatabaseServer](logging server) [#1447](https://github.com/HicServices/RDMP/issues/1447)
+
+
 ## [8.0.2] - 2022-10-03
 
 ### Fixed

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandViewLogs.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandViewLogs.cs
@@ -112,7 +112,7 @@ int? Optional, if <root> is logging server this can be a specific audit id to sh
             else
             {
                 var server = SelectOne(_loggingServers,null,true);
-                BasicActivator.ShowLogs(server,_filter);
+                BasicActivator.ShowLogs(server,_filter?? new LogViewerFilter(LoggingTables.DataLoadRun));
             }
         }
 

--- a/Rdmp.Core/CommandLine/Interactive/ConsoleInputManager.cs
+++ b/Rdmp.Core/CommandLine/Interactive/ConsoleInputManager.cs
@@ -216,7 +216,14 @@ namespace Rdmp.Core.CommandLine.Interactive
         public override IMapsDirectlyToDatabaseTable SelectOne(DialogArgs args, IMapsDirectlyToDatabaseTable[] availableObjects)
         {
             if (DisallowInput)
-                throw new InputDisallowedException($"Value required for '{args}'");
+            {
+                if (args.AllowAutoSelect && availableObjects.Length == 1)
+                {
+                    return availableObjects[0];
+                }
+                else
+                    throw new InputDisallowedException($"Value required for '{args}'");
+            }
 
             if (availableObjects.Length == 0)
                 throw new Exception("No available objects found");


### PR DESCRIPTION
Fixes #1447

Changes behaviour of `SelectOne` when `DisallowInput` is true and `AllowAutoSelect` is true (and theres only one object).  In this case the sole value is returned. 

If passed a logging server but no filter then `ViewLogs` will deafult to showing the `DataLoadRun` table.