### PR TITLE
Fix passing wrong object to Plugins when right is an empty area of a tree collection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,12 +8,17 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ...
 
+### Fixed
+
+- Fixed right clicking in empty space of a collection not passing correct object to UI Plugins
+
 ## [8.0.4] - 2022-10-24
 
 ### Added
 
 - Added IgnoreMissingTables setting for [RemoteDatabaseAttacher] which allows you to load only the tables that exist on the remote (and in the load)
 - Add overrides for mdf/ldf local paths to MDFAttacher
+- Added 'Persistent RAW' setting for [LoadMetadata]
 
 ### Fixed
 

--- a/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
+++ b/Rdmp.UI/Collections/RDMPCollectionCommonFunctionality.cs
@@ -47,6 +47,12 @@ namespace Rdmp.UI.Collections
     {
         private RDMPCollection _collection;
 
+
+        /// <summary>
+        /// The collection if any that this <see cref="Tree"/> represents in the UI
+        /// </summary>
+        public RDMPCollection Collection => _collection;
+
         private IActivateItems _activator;
         public TreeListView Tree;
 

--- a/Rdmp.UI/Menus/RDMPContextMenuStrip.cs
+++ b/Rdmp.UI/Menus/RDMPContextMenuStrip.cs
@@ -181,7 +181,8 @@ namespace Rdmp.UI.Menus
             {
                 try
                 {
-                    foreach (var cmd in plugin.GetAdditionalRightClickMenuItems(_o))
+                    foreach (var cmd in plugin.GetAdditionalRightClickMenuItems(
+                        _o is RDMPCollectionCommonFunctionality c ? c.Collection : _o))
                         Add(cmd);
                 }
                 catch (Exception ex)


### PR DESCRIPTION
Prior to this PR the plugin menu items from dicom were not showing, now they are:

![image](https://user-images.githubusercontent.com/31306100/198021887-dd33509f-4897-44d9-a7c7-54373407e8ac.png)
