### PR TITLE
Make file locator handle Unix and DOS style paths more smartly

### DIFF
--- a/Rdmp.Core/DataLoad/Modules/Attachers/MDFAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/MDFAttacher.cs
@@ -18,7 +18,7 @@ using ReusableLibraryCode.Progress;
 namespace Rdmp.Core.DataLoad.Modules.Attachers;
 
 /// <summary>
-/// Data load component for loading a detatched database file into RAW.  This attacher does not load RAW tables normally (like AnySeparatorFileAttacher etc)
+/// Data load component for loading a detached database file into RAW.  This attacher does not load RAW tables normally (like AnySeparatorFileAttacher etc)
 /// instead it specifies that it is itself going to act as RAW.  Using this component requires that the computer running the data load has file system access
 /// to the RAW Sql Server data directory (and that the path is the same).
 /// 
@@ -37,7 +37,7 @@ public class MDFAttacher : Attacher,IPluginAttacher
     [DemandsInitialization("Set this only if your RAW server is NOT localhost.  This is the network path to the DATA directory of your RAW database server you can find the DATA directory by running 'select * FROM sys.master_files'")]
     public string OverrideMDFFileCopyDestination{ get; set; }
 
-    [DemandsInitialization(@"There are multiple ways to attach a mdf files to an SQL server, the first stage is always to copy the mdf and ldf files to the DATA directory of your server but after that it get's flexible.  
+    [DemandsInitialization(@"There are multiple ways to attach a mdf files to an SQL server, the first stage is always to copy the mdf and ldf files to the DATA directory of your server but after that it gets flexible.  
 1. AttachWithConnectionString attempts to do the attaching as part of connection by specifying the AttachDBFilename keyword in the connection string
 2. ExecuteCreateDatabaseForAttachSql attempts to connect to 'master' and execute CREATE DATABASE sql with the FILENAME property set to your mdf file in the DATA directory of your database server")]
     public MdfAttachStrategy AttachStrategy { get; set; }

--- a/Rdmp.Core/DataLoad/Modules/Attachers/MdfFileAttachLocations.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/MdfFileAttachLocations.cs
@@ -49,14 +49,14 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
             if (databaseDirectoryFromPerspectiveOfDatabaseServer.Contains('/'))
             {
                 // Unix-style paths
-                AttachMdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}/{Path.GetFileName(OriginLocationMdf)}";
-                AttachLdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}/{Path.GetFileName(OriginLocationLdf)}";
+                AttachMdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer.TrimEnd('/')}/{Path.GetFileName(OriginLocationMdf)}";
+                AttachLdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer.TrimEnd('/')}/{Path.GetFileName(OriginLocationLdf)}";
             }
             else
             {
                 // DOS-style paths
-                AttachMdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}\\{Path.GetFileName(OriginLocationMdf)}";
-                AttachLdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}\\{Path.GetFileName(OriginLocationLdf)}";
+                AttachMdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer.TrimEnd('\\')}\\{Path.GetFileName(OriginLocationMdf)}";
+                AttachLdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer.TrimEnd('\\')}\\{Path.GetFileName(OriginLocationLdf)}";
             }
         }
 

--- a/Rdmp.Core/DataLoad/Modules/Attachers/MdfFileAttachLocations.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/MdfFileAttachLocations.cs
@@ -18,32 +18,46 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers
     {
         public MdfFileAttachLocations(DirectoryInfo originDirectory, string databaseDirectoryFromPerspectiveOfDatabaseServer, string copyToDirectoryOrNullIfDatabaseIsLocalhost)
         {
-            if (databaseDirectoryFromPerspectiveOfDatabaseServer == null)
-                throw new ArgumentNullException("databaseDirectoryFromPerspectiveOfDatabaseServer");
+            ArgumentNullException.ThrowIfNull(databaseDirectoryFromPerspectiveOfDatabaseServer);
 
             var copyToDirectory = copyToDirectoryOrNullIfDatabaseIsLocalhost ?? databaseDirectoryFromPerspectiveOfDatabaseServer;
             
             var filesThatWeCouldLoad = originDirectory.GetFiles("*.mdf").ToArray();
 
-            if(filesThatWeCouldLoad.Length == 0)
-                throw new FileNotFoundException("Could not find any MDF files in the directory " + originDirectory.FullName);
+            switch (filesThatWeCouldLoad.Length)
+            {
+                case 0:
+                    throw new FileNotFoundException(
+                        $"Could not find any MDF files in the directory {originDirectory.FullName}");
+                case > 1:
+                    throw new MultipleMatchingFilesException(
+                        $"Did not know which MDF file to attach, found multiple :{string.Join(",", filesThatWeCouldLoad.Select(f => f.Name))}");
+            }
 
-            if(filesThatWeCouldLoad.Length > 1)
-                throw new MultipleMatchingFilesException("Did not know which MDF file to attach, found multiple :" + string.Join(",",filesThatWeCouldLoad.Select(f=>f.Name)));
-
-            OriginLocationMdf =filesThatWeCouldLoad[0].FullName;
+            OriginLocationMdf = filesThatWeCouldLoad[0].FullName;
        
-            //veryify log file exists
-            OriginLocationLdf = Path.Combine(Path.GetDirectoryName(OriginLocationMdf), Path.GetFileNameWithoutExtension(OriginLocationMdf) + "_log.ldf");
+            //verify log file exists
+            OriginLocationLdf = Path.Combine(Path.GetDirectoryName(OriginLocationMdf),
+                $"{Path.GetFileNameWithoutExtension(OriginLocationMdf)}_log.ldf");
 
             if (!File.Exists(OriginLocationLdf))
-                throw new FileNotFoundException("Cannot attach database, LOG file was not found:" + OriginLocationLdf, OriginLocationLdf);
+                throw new FileNotFoundException($"Cannot attach database, LOG file was not found:{OriginLocationLdf}", OriginLocationLdf);
 
             CopyToMdf = Path.Combine(copyToDirectory, Path.GetFileName(OriginLocationMdf));
             CopyToLdf = Path.Combine(copyToDirectory, Path.GetFileName(OriginLocationLdf));
 
-            AttachMdfPath = Path.Combine(databaseDirectoryFromPerspectiveOfDatabaseServer,Path.GetFileName(OriginLocationMdf));
-            AttachLdfPath = Path.Combine(databaseDirectoryFromPerspectiveOfDatabaseServer, Path.GetFileName(OriginLocationLdf));
+            if (databaseDirectoryFromPerspectiveOfDatabaseServer.Contains('/'))
+            {
+                // Unix-style paths
+                AttachMdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}/{Path.GetFileName(OriginLocationMdf)}";
+                AttachLdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}/{Path.GetFileName(OriginLocationLdf)}";
+            }
+            else
+            {
+                // DOS-style paths
+                AttachMdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}\\{Path.GetFileName(OriginLocationMdf)}";
+                AttachLdfPath = $"{databaseDirectoryFromPerspectiveOfDatabaseServer}\\{Path.GetFileName(OriginLocationLdf)}";
+            }
         }
 
         public string OriginLocationMdf {get; set; }


### PR DESCRIPTION
Finish previous fix - autodetect whether to use Unix or DOS style paths and adjust separator accordingly. Can't rely on Path.Combine - that gets it right for the local machine, not the remote one!