### PR TITLE
Redo ProgressLog handling

### DIFF
--- a/Rdmp.Core/Logging/DataLoadInfo.cs
+++ b/Rdmp.Core/Logging/DataLoadInfo.cs
@@ -5,8 +5,10 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.Collections.Concurrent;
 using System.Collections.Generic;
-using System.Data.Common;
+using System.Threading;
+using FAnsi;
 using FAnsi.Discovery;
 
 namespace Rdmp.Core.Logging;
@@ -19,7 +21,7 @@ namespace Rdmp.Core.Logging;
 /// (TableLoadInfo) (create these via the LogManager).  The ID property can be used if you want to reference this audit record e.g. when loading a live table
 /// you can store the ID of the load batch it appeared in. </para>
 /// </summary>
-public class DataLoadInfo : IDataLoadInfo
+public sealed class DataLoadInfo : IDataLoadInfo
 {
     private bool _isClosed = false;
     private readonly string _packageName;
@@ -27,16 +29,16 @@ public class DataLoadInfo : IDataLoadInfo
     private readonly DateTime _startTime;
     private DateTime _endTime;
     private readonly string _description;
-    private string _suggestedRollbackCommand;
+    private readonly string _suggestedRollbackCommand;
     private int _id;
-    private bool _isTest;
+    private readonly bool _isTest;
 
 
-    private DiscoveredServer _server;
+    public DiscoveredServer DatabaseSettings { get; }
 
-    public DiscoveredServer DatabaseSettings => _server;
-
-    private object oLock = new();
+    private readonly object _oLock = new();
+    private Thread _logThread = null;
+    private BlockingCollection<LogEntry> _logQueue = null;
 
 
     #region Property setup (these throw exceptions if you try to read them after the record is closed)
@@ -68,6 +70,7 @@ public class DataLoadInfo : IDataLoadInfo
 
     #endregion
 
+    public record LogEntry(string EventType, string Description, string Source, DateTime Time);
 
     /// <summary>
     /// Marks the start of a new data load in the database.  Automatically populates StartTime and UserAccount from
@@ -83,7 +86,7 @@ public class DataLoadInfo : IDataLoadInfo
         string suggestedRollbackCommand, bool isTest, DiscoveredServer settings)
     {
         if (settings != null)
-            _server = settings;
+            DatabaseSettings = settings;
 
         _packageName = packageName;
         _userAccount = Environment.UserName;
@@ -95,43 +98,97 @@ public class DataLoadInfo : IDataLoadInfo
         _isTest = isTest;
 
         RecordNewDataLoadInDatabase(dataLoadTaskName);
+        LogInit();
+    }
+
+    private void LogInit()
+    {
+        lock (_oLock)
+        {
+            // This can happen if we get called twice in quick succession: first call succeeds, so second becomes a no-op
+            if (_logQueue?.IsAddingCompleted == false)
+                return;
+
+            _logQueue?.CompleteAdding();
+            _logThread?.Join();
+            _logQueue = new BlockingCollection<LogEntry>();
+            _logThread = new Thread(new ThreadStart(LogWorker));
+            _logThread.Start();
+        }
+    }
+
+    private void LogWorker()
+    {
+        using var l=_logQueue;
+        while (!l.IsCompleted)
+        {
+            if (l.Count == 0)
+            {
+                Thread.Sleep(1000);
+                continue;
+            }
+            using var con = DatabaseSettings.BeginNewTransactedConnection();
+            if (DatabaseSettings.DatabaseType==DatabaseType.MicrosoftSQLServer)
+                using (var lockQuery = DatabaseSettings.GetCommand("SELECT TOP 1 * FROM ProgressLog WHERE 1=0", con))
+                    lockQuery.ExecuteNonQuery();
+            using var cmdRecordProgress = DatabaseSettings.GetCommand(
+                "INSERT INTO ProgressLog (dataLoadRunID,eventType,source,description,time) VALUES (@dataLoadRunID,@eventType,@source,@description,@time);",
+                con);
+
+            DatabaseSettings.AddParameterWithValueToCommand("@dataLoadRunID", cmdRecordProgress, ID);
+
+            var type=DatabaseSettings.AddParameterWithValueToCommand("@eventType", cmdRecordProgress, null);
+            var source=DatabaseSettings.AddParameterWithValueToCommand("@source", cmdRecordProgress, null);
+            var desc=DatabaseSettings.AddParameterWithValueToCommand("@description", cmdRecordProgress, null);
+            var time=DatabaseSettings.AddParameterWithValueToCommand("@time", cmdRecordProgress, null);
+            while (l.TryTake(out var entry))
+            {
+                type.Value = entry.EventType;
+                source.Value = entry.Source;
+                desc.Value = entry.Description;
+                time.Value = entry.Time;
+                cmdRecordProgress.ExecuteNonQuery();
+            }
+            con.ManagedTransaction.CommitAndCloseConnection();
+        }
+        _logQueue = null;
     }
 
     private void RecordNewDataLoadInDatabase(string dataLoadTaskName)
     {
-        using (var con = _server.GetConnection())
-        {
-            con.Open();
+        using var con = DatabaseSettings.GetConnection();
+        con.Open();
 
-            var cmd = _server.GetCommand("SELECT ID FROM DataLoadTask WHERE name=@name", con);
-            _server.AddParameterWithValueToCommand("@name", cmd, dataLoadTaskName);
-
-
-            var result = cmd.ExecuteScalar();
-
-            if (result == null || result == DBNull.Value)
-                throw new Exception($"Could not find data load task named:{dataLoadTaskName}");
-
-            //ID can come back as a decimal or an Int32 or an Int64 so whatever, just turn it into a string and then parse it
-            var parentTaskID = int.Parse(result.ToString());
-
-            cmd = _server.GetCommand(
-                @"INSERT INTO DataLoadRun (description,startTime,dataLoadTaskID,isTest,packageName,userAccount,suggestedRollbackCommand) VALUES (@description,@startTime,@dataLoadTaskID,@isTest,@packageName,@userAccount,@suggestedRollbackCommand);
-SELECT @@IDENTITY;", con);
-
-            _server.AddParameterWithValueToCommand("@description", cmd, _description);
-            _server.AddParameterWithValueToCommand("@startTime", cmd, _startTime);
-            _server.AddParameterWithValueToCommand("@dataLoadTaskID", cmd, parentTaskID);
-            _server.AddParameterWithValueToCommand("@isTest", cmd, _isTest);
-            _server.AddParameterWithValueToCommand("@packageName", cmd, _packageName);
-            _server.AddParameterWithValueToCommand("@userAccount", cmd, _userAccount);
-            _server.AddParameterWithValueToCommand("@suggestedRollbackCommand", cmd,
-                _suggestedRollbackCommand ?? string.Empty);
+        var cmd = DatabaseSettings.GetCommand("SELECT ID FROM DataLoadTask WHERE name=@name", con);
+        DatabaseSettings.AddParameterWithValueToCommand("@name", cmd, dataLoadTaskName);
 
 
-            //ID can come back as a decimal or an Int32 or an Int64 so whatever, just turn it into a string and then parse it
-            _id = int.Parse(cmd.ExecuteScalar().ToString());
-        }
+        var result = cmd.ExecuteScalar();
+
+        if (result == null || result == DBNull.Value)
+            throw new Exception($"Could not find data load task named:{dataLoadTaskName}");
+
+        //ID can come back as a decimal or an Int32 or an Int64 so whatever, just turn it into a string and then parse it
+        var parentTaskID = int.Parse(result.ToString());
+
+        cmd = DatabaseSettings.GetCommand(
+            """
+            INSERT INTO DataLoadRun (description,startTime,dataLoadTaskID,isTest,packageName,userAccount,suggestedRollbackCommand) VALUES (@description,@startTime,@dataLoadTaskID,@isTest,@packageName,@userAccount,@suggestedRollbackCommand);
+            SELECT @@IDENTITY;
+            """, con);
+
+        DatabaseSettings.AddParameterWithValueToCommand("@description", cmd, _description);
+        DatabaseSettings.AddParameterWithValueToCommand("@startTime", cmd, _startTime);
+        DatabaseSettings.AddParameterWithValueToCommand("@dataLoadTaskID", cmd, parentTaskID);
+        DatabaseSettings.AddParameterWithValueToCommand("@isTest", cmd, _isTest);
+        DatabaseSettings.AddParameterWithValueToCommand("@packageName", cmd, _packageName);
+        DatabaseSettings.AddParameterWithValueToCommand("@userAccount", cmd, _userAccount);
+        DatabaseSettings.AddParameterWithValueToCommand("@suggestedRollbackCommand", cmd,
+            _suggestedRollbackCommand ?? string.Empty);
+
+
+        //ID can come back as a decimal or an Int32 or an Int64 so whatever, just turn it into a string and then parse it
+        _id = int.Parse(cmd.ExecuteScalar().ToString());
     }
 
     /// <summary>
@@ -139,49 +196,50 @@ SELECT @@IDENTITY;", con);
     /// </summary>
     public void CloseAndMarkComplete()
     {
-        lock (oLock)
+        lock (_oLock)
         {
             //prevent double closing
             if (_isClosed)
                 return;
 
+            _logQueue.CompleteAdding();
+            _logThread.Join();
+
             _endTime = DateTime.Now;
 
-            using (var con = _server.BeginNewTransactedConnection())
+            using var con = DatabaseSettings.BeginNewTransactedConnection();
+            try
             {
-                try
-                {
-                    var cmdUpdateToClosed =
-                        _server.GetCommand("UPDATE DataLoadRun SET endTime=@endTime WHERE ID=@ID",
-                            con);
+                var cmdUpdateToClosed =
+                    DatabaseSettings.GetCommand("UPDATE DataLoadRun SET endTime=@endTime WHERE ID=@ID",
+                        con);
 
-                    _server.AddParameterWithValueToCommand("@endTime", cmdUpdateToClosed, DateTime.Now);
-                    _server.AddParameterWithValueToCommand("@ID", cmdUpdateToClosed, ID);
+                DatabaseSettings.AddParameterWithValueToCommand("@endTime", cmdUpdateToClosed, DateTime.Now);
+                DatabaseSettings.AddParameterWithValueToCommand("@ID", cmdUpdateToClosed, ID);
 
-                    var rowsAffected = cmdUpdateToClosed.ExecuteNonQuery();
+                var rowsAffected = cmdUpdateToClosed.ExecuteNonQuery();
 
-                    if (rowsAffected != 1)
-                        throw new Exception(
-                            $"Error closing off DataLoad in database, the update command resulted in {rowsAffected} rows being affected (expected 1) - will try to rollback");
+                if (rowsAffected != 1)
+                    throw new Exception(
+                        $"Error closing off DataLoad in database, the update command resulted in {rowsAffected} rows being affected (expected 1) - will try to rollback");
 
-                    con.ManagedTransaction.CommitAndCloseConnection();
+                con.ManagedTransaction.CommitAndCloseConnection();
 
-                    _isClosed = true;
-                }
-                catch (Exception)
-                {
-                    //if something goes wrong with the update, roll it back
-                    con.ManagedTransaction.AbandonAndCloseConnection();
-
-                    throw;
-                }
-
-                //once a record has been committed to the database it is redundant and no further attempts to read/change it should be made by anyone
-                foreach (var t in TableLoads.Values)
-                    //close any table loads that have not yet completed
-                    if (!t.IsClosed)
-                        t.CloseAndArchive();
+                _isClosed = true;
             }
+            catch (Exception)
+            {
+                //if something goes wrong with the update, roll it back
+                con.ManagedTransaction.AbandonAndCloseConnection();
+
+                throw;
+            }
+
+            //once a record has been committed to the database it is redundant and no further attempts to read/change it should be made by anyone
+            foreach (var t in TableLoads.Values)
+                //close any table loads that have not yet completed
+                if (!t.IsClosed)
+                    t.CloseAndArchive();
         }
     }
 
@@ -202,7 +260,7 @@ SELECT @@IDENTITY;", con);
 
     public void AddTableLoad(TableLoadInfo tableLoadInfo)
     {
-        lock (oLock)
+        lock (_oLock)
         {
             TableLoads.Add(tableLoadInfo.ID, tableLoadInfo);
         }
@@ -222,34 +280,32 @@ SELECT @@IDENTITY;", con);
     /// <param name="errorDescription">A description of the error (in SSIS try System::ErrorDescription)</param>
     public void LogFatalError(string errorSource, string errorDescription)
     {
-        using (var con = DatabaseSettings.GetConnection())
-        {
-            con.Open();
+        using var con = DatabaseSettings.GetConnection();
+        con.Open();
 
-            //look up the fatal error ID (get hte name of the Enum so that we can refactor if nessesary without breaking the code looking for a constant string)
-            var initialErrorStatus = Enum.GetName(typeof(FatalErrorStates), FatalErrorStates.Outstanding);
+        //look up the fatal error ID (get hte name of the Enum so that we can refactor if nessesary without breaking the code looking for a constant string)
+        var initialErrorStatus = Enum.GetName(typeof(FatalErrorStates), FatalErrorStates.Outstanding);
 
 
-            var cmdLookupStatusID = _server.GetCommand("SELECT ID from z_FatalErrorStatus WHERE status=@status", con);
-            _server.AddParameterWithValueToCommand("@status", cmdLookupStatusID, initialErrorStatus);
+        var cmdLookupStatusID = DatabaseSettings.GetCommand("SELECT ID from z_FatalErrorStatus WHERE status=@status", con);
+        DatabaseSettings.AddParameterWithValueToCommand("@status", cmdLookupStatusID, initialErrorStatus);
 
-            var statusID = int.Parse(cmdLookupStatusID.ExecuteScalar().ToString());
+        var statusID = int.Parse(cmdLookupStatusID.ExecuteScalar().ToString());
 
-            var cmdRecordFatalError = _server.GetCommand(
-                @"INSERT INTO FatalError (time,source,description,statusID,dataLoadRunID) VALUES (@time,@source,@description,@statusID,@dataLoadRunID);",
-                con);
-            _server.AddParameterWithValueToCommand("@time", cmdRecordFatalError, DateTime.Now);
-            _server.AddParameterWithValueToCommand("@source", cmdRecordFatalError, errorSource);
-            _server.AddParameterWithValueToCommand("@description", cmdRecordFatalError, errorDescription);
-            _server.AddParameterWithValueToCommand("@statusID", cmdRecordFatalError, statusID);
-            _server.AddParameterWithValueToCommand("@dataLoadRunID", cmdRecordFatalError, ID);
+        var cmdRecordFatalError = DatabaseSettings.GetCommand(
+            @"INSERT INTO FatalError (time,source,description,statusID,dataLoadRunID) VALUES (@time,@source,@description,@statusID,@dataLoadRunID);",
+            con);
+        DatabaseSettings.AddParameterWithValueToCommand("@time", cmdRecordFatalError, DateTime.Now);
+        DatabaseSettings.AddParameterWithValueToCommand("@source", cmdRecordFatalError, errorSource);
+        DatabaseSettings.AddParameterWithValueToCommand("@description", cmdRecordFatalError, errorDescription);
+        DatabaseSettings.AddParameterWithValueToCommand("@statusID", cmdRecordFatalError, statusID);
+        DatabaseSettings.AddParameterWithValueToCommand("@dataLoadRunID", cmdRecordFatalError, ID);
 
-            cmdRecordFatalError.ExecuteNonQuery();
+        cmdRecordFatalError.ExecuteNonQuery();
 
-            //this might get called multiple times (many errors in rapid succession as the program crashes) but only close the dataLoadInfo once
-            if (!IsClosed)
-                CloseAndMarkComplete();
-        }
+        //this might get called multiple times (many errors in rapid succession as the program crashes) but only close the dataLoadInfo once
+        if (!IsClosed)
+            CloseAndMarkComplete();
     }
 
     public enum ProgressEventType
@@ -263,21 +319,14 @@ SELECT @@IDENTITY;", con);
 
     public void LogProgress(ProgressEventType pevent, string Source, string Description)
     {
-        using (var con = DatabaseSettings.GetConnection())
-        using (var cmdRecordProgress = _server.GetCommand("INSERT INTO ProgressLog " +
-                                                          "(dataLoadRunID,eventType,source,description,time) " +
-                                                          "VALUES (@dataLoadRunID,@eventType,@source,@description,@time);",
-                   con))
+        lock (_oLock)
         {
-            con.Open();
+            if (_logQueue is null || _logQueue.IsAddingCompleted)
+                LogInit();
+            if (_logQueue is null)
+                throw new InvalidOperationException("LogInit failed to create new worker");
 
-            _server.AddParameterWithValueToCommand("@dataLoadRunID", cmdRecordProgress, ID);
-            _server.AddParameterWithValueToCommand("@eventType", cmdRecordProgress, pevent.ToString());
-            _server.AddParameterWithValueToCommand("@source", cmdRecordProgress, Source);
-            _server.AddParameterWithValueToCommand("@description", cmdRecordProgress, Description);
-            _server.AddParameterWithValueToCommand("@time", cmdRecordProgress, DateTime.Now);
-
-            cmdRecordProgress.ExecuteNonQuery();
+            _logQueue.Add(new LogEntry(pevent.ToString(),Description,Source,DateTime.Now));
         }
     }
 }

--- a/Rdmp.Core/Logging/DataLoadInfo.cs
+++ b/Rdmp.Core/Logging/DataLoadInfo.cs
@@ -15,7 +15,7 @@ namespace Rdmp.Core.Logging;
 
 /// <summary>
 /// Root object for an ongoing logged activity e.g. 'Loading Biochemistry'.  Includes the package name (exe or class name that is primarily responsible
-/// for the activity), start time, description etc.  You must call CloseAndMarkComplete once your activity is completed (whether it has failed or suceeded).
+/// for the activity), start time, description etc.  You must call CloseAndMarkComplete once your activity is completed (whether it has failed or succeeded).
 /// 
 /// <para>You should maintain a reference to DataLoadInfo in order to create logs of Progress / Errors / and table load audits
 /// (TableLoadInfo) (create these via the LogManager).  The ID property can be used if you want to reference this audit record e.g. when loading a live table

--- a/Rdmp.Core/Logging/DataLoadInfo.cs
+++ b/Rdmp.Core/Logging/DataLoadInfo.cs
@@ -129,7 +129,7 @@ public sealed class DataLoadInfo : IDataLoadInfo
             }
             using var con = DatabaseSettings.BeginNewTransactedConnection();
             if (DatabaseSettings.DatabaseType==DatabaseType.MicrosoftSQLServer)
-                using (var lockQuery = DatabaseSettings.GetCommand("SELECT TOP 1 * FROM ProgressLog WHERE 1=0", con))
+                using (var lockQuery = DatabaseSettings.GetCommand("SELECT TOP 1 * FROM ProgressLog WITH (HOLDLOCK, UPDLOCK, TABLOCKX) WHERE 1=0", con))
                     lockQuery.ExecuteNonQuery();
             using var cmdRecordProgress = DatabaseSettings.GetCommand(
                 "INSERT INTO ProgressLog (dataLoadRunID,eventType,source,description,time) VALUES (@dataLoadRunID,@eventType,@source,@description,@time);",

--- a/Rdmp.Core/Logging/PastEvents/ArchivalDataLoadInfo.cs
+++ b/Rdmp.Core/Logging/PastEvents/ArchivalDataLoadInfo.cs
@@ -59,7 +59,7 @@ public class ArchivalDataLoadInfo : IArchivalLoggingRecordOfPastEvent, IComparab
     public List<ArchivalTableLoadInfo> TableLoadInfos => _knownTableInfos.Value;
 
     /// <summary>
-    /// All errors that occured during the run
+    /// All errors that occurred during the run
     /// </summary>
     public List<ArchivalFatalError> Errors => _knownErrors.Value;
 


### PR DESCRIPTION
Thread safe ProgressLog handling - retains lock while inserting multiple rows, does it all on a background worker thread, then waits for it to complete at the end of a load job. Working apart from intermittent issue within `LoggingDatabase_TestActuallyCreatingIt` (on MySQL, oddly)