### PR TITLE
Bugfix/rdmp 30 missing predictor

### DIFF
--- a/Rdmp.Core/Databases/CatalogueDatabase/up/077_MigrateXmlPredictor.sql
+++ b/Rdmp.Core/Databases/CatalogueDatabase/up/077_MigrateXmlPredictor.sql
@@ -1,0 +1,7 @@
+---Version:8.1.0
+--Description: Migrate ValuePredictsOtherValueNullness Predictor to ValuePredictsOtherValueNullity
+BEGIN
+UPDATE Catalogue
+SET ValidatorXML = REPLACE(ValidatorXML, 'ValuePredictsOtherValueNullness','ValuePredictsOtherValueNullity')
+WHERE ValidatorXML IS NOT NULL
+END

--- a/Rdmp.Core/Validation/Constraints/Secondary/Predictor/ValuePredictsOtherValueNullness.cs
+++ b/Rdmp.Core/Validation/Constraints/Secondary/Predictor/ValuePredictsOtherValueNullness.cs
@@ -1,4 +1,4 @@
-// Copyright (c) The University of Dundee 2018-2019
+// Copyright (c) The University of Dundee 2018-2023
 // This file is part of the Research Data Management Platform (RDMP).
 // RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.

--- a/Rdmp.Core/Validation/Constraints/Secondary/Predictor/ValuePredictsOtherValueNullness.cs
+++ b/Rdmp.Core/Validation/Constraints/Secondary/Predictor/ValuePredictsOtherValueNullness.cs
@@ -7,14 +7,14 @@
 namespace Rdmp.Core.Validation.Constraints.Secondary.Predictor;
 
 /// <summary>
-/// Validation rule for use with a Prediction Constraint.  Indicates that the 'nullity' of the columns must match (i.e. if one is null the other must be too)
+/// Validation rule for use with a Prediction Constraint.  Indicates that the 'nullness' of the columns must match (i.e. if one is null the other must be too)
 /// </summary>
 public class ValuePredictsOtherValueNullness : PredictionRule
 {
     public override ValidationFailure Predict(IConstraint parent, object value, object targetValue) =>
         value == null != (targetValue == null)
             ? new ValidationFailure(
-                $"Nullity did not match, when one value is null, the other must be null.  When one value has a value the other must also have a value.  Nullity of ConstrainedColumn:{value == null}. Nullity of TargetColumn:{targetValue == null}",
+                $"Nullity did not match, when one value is null, the other must be null.  When one value has a value the other must also have a value.  Nullness of ConstrainedColumn:{value == null}. Nullity of TargetColumn:{targetValue == null}",
                 parent)
             : null;
 }

--- a/Rdmp.Core/Validation/Constraints/Secondary/Predictor/ValuePredictsOtherValueNullness.cs
+++ b/Rdmp.Core/Validation/Constraints/Secondary/Predictor/ValuePredictsOtherValueNullness.cs
@@ -1,0 +1,20 @@
+// Copyright (c) The University of Dundee 2018-2019
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+namespace Rdmp.Core.Validation.Constraints.Secondary.Predictor;
+
+/// <summary>
+/// Validation rule for use with a Prediction Constraint.  Indicates that the 'nullity' of the columns must match (i.e. if one is null the other must be too)
+/// </summary>
+public class ValuePredictsOtherValueNullness : PredictionRule
+{
+    public override ValidationFailure Predict(IConstraint parent, object value, object targetValue) =>
+        value == null != (targetValue == null)
+            ? new ValidationFailure(
+                $"Nullity did not match, when one value is null, the other must be null.  When one value has a value the other must also have a value.  Nullity of ConstrainedColumn:{value == null}. Nullity of TargetColumn:{targetValue == null}",
+                parent)
+            : null;
+}


### PR DESCRIPTION
Re-adds the `ValuePredictsOtherValueNullness` Prediction rule that was renamed to `ValuePredictsOtherValueNullity` in rc4.
While the files are functionally identical, there was no migration for existing Catalogue.ValidatorXML entries, which caused existing validators using this rule to fail.

Fix adds a migration to replace existing ValidatorXML that contain `ValuePredictsOtherValueNullness` with `ValuePredictsOtherValueNullity`.