### PR TITLE
Fix logging server lookup logic

### DIFF
--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -519,17 +519,10 @@ public class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<C
 
     /// <inheritdoc/>
     [NoMappingToDatabase]
-     public ExternalDatabaseServer LiveLoggingServer {
-        get{
-            if(LiveLoggingServer_ID != null){  
-                ExternalDatabaseServer[] dbs = Repository.GetAllObjectsWhere<ExternalDatabaseServer>("id",(int)LiveLoggingServer_ID);
-                if(dbs.Length > 0){
-                    return dbs.First();
-                }                         
-            }
-            return null;
-        }
-     }
+     public ExternalDatabaseServer LiveLoggingServer =>
+       LiveLoggingServer_ID == null
+                   ? null
+                   : Repository.GetObjectByID<ExternalDatabaseServer>((int)LiveLoggingServer_ID);
 
     /// <inheritdoc/>
     [NoMappingToDatabase]


### PR DESCRIPTION
* Fix apparent regression from PR #1589 in Rdmp.Core/Curation/Data/Catalogue.cs which made it search for "id" instead of "ID", breaking RdmpDicom.