### PR TITLE
Fix typo in Logging Server Creation Code

### DIFF
--- a/Rdmp.Core/Databases/LoggingDatabase/runAfterCreateDatabase/CreateLogging.sql
+++ b/Rdmp.Core/Databases/LoggingDatabase/runAfterCreateDatabase/CreateLogging.sql
@@ -324,7 +324,7 @@ INSERT [dbo].[z_DataLoadTaskStatus] ([ID], [status], [description]) VALUES (1, N
 GO
 INSERT [dbo].[z_DataLoadTaskStatus] ([ID], [status], [description]) VALUES (2, N'Ready', NULL)
 GO
-INSERT [dbo].[z_DataLoadTaskStatus] ([ID], [status], [description]) VALUES (3, N'Commited', NULL)
+INSERT [dbo].[z_DataLoadTaskStatus] ([ID], [status], [description]) VALUES (3, N'Committed', NULL)
 GO
 SET IDENTITY_INSERT [dbo].[z_DataLoadTaskStatus] OFF
 GO


### PR DESCRIPTION
Fixes a minor typo in the logging server where "Committed" was typo'd as "Commited".
Typo causes problems with key collisions in the logging server.

This fix does not currently modify existing logging servers, only new ones, as comments in the code strongly advise against this