### PR TITLE
Hide source control button when not available during exception show

### DIFF
--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.Designer.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.Designer.cs
@@ -112,6 +112,7 @@ namespace Rdmp.UI.SimpleDialogs
             // 
             this.btnViewSourceCode.Anchor = ((System.Windows.Forms.AnchorStyles)((System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right)));
             this.btnViewSourceCode.Enabled = false;
+            this.btnViewSourceCode.Visible = false;
             this.btnViewSourceCode.Image = ((System.Drawing.Image)(resources.GetObject("btnViewSourceCode.Image")));
             this.btnViewSourceCode.ImageAlign = System.Drawing.ContentAlignment.MiddleLeft;
             this.btnViewSourceCode.Location = new System.Drawing.Point(692, 0);

--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
@@ -68,6 +68,7 @@ public partial class WideMessageBox : Form
 
         //can only write to clipboard in STA threads
         btnCopyToClipboard.Visible = Thread.CurrentThread.GetApartmentState() == ApartmentState.STA;
+        btnViewStackTrace.Visible = true;
 
         //try to resize form to fit bounds
         Size = GetPreferredSizeOfTextControl(richTextBox1);
@@ -148,11 +149,13 @@ public partial class WideMessageBox : Form
             ViewSourceCodeDialog.SourceCodeIsAvailableFor($"{title}.cs"))
         {
             btnViewSourceCode.Enabled = true;
+            btnViewSourceCode.Visible = true;
             btnViewSourceCode.Tag = $"{title}.cs";
         }
         else
         {
             btnViewSourceCode.Enabled = false;
+            btnViewSourceCode.Visible = false;
         }
     }
 


### PR DESCRIPTION
Minor PR to remove sourcecode button in the exception viewer when there is no source class.