### PR TITLE
RDMP-15 Use .bak files as Data Loads

### DIFF
--- a/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommandFactory.cs
@@ -545,6 +545,8 @@ public class AtomicCommandFactory : CommandFactoryBase
                 lsn.LoadMetadata, lsn.LoadStage);
             yield return new ExecuteCommandCreateNewFileBasedProcessTask(_activator, ProcessTaskType.Executable,
                 lsn.LoadMetadata, lsn.LoadStage);
+            yield return new ExecuteCommandCreateNewFileBasedProcessTask(_activator, ProcessTaskType.SQLBakFile,
+                lsn.LoadMetadata, lsn.LoadStage);
         }
 
         if (Is(o, out LoadDirectoryNode ldn))

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFileBasedProcessTask.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFileBasedProcessTask.cs
@@ -61,10 +61,8 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
             if (_taskType == ProcessTaskType.SQLBakFile)
             {
                 if (!BasicActivator.TypeText("Enter a name for the SQL Bak file", "File name", 100, "database.bak",
-                       out var selected, false))
-                {
-                    return; //user cancelled
-                }
+                       out var selected, false)) return;
+
                 var target = Path.Combine(_loadDirectory.ExecutablesPath.FullName, selected);
 
                 if (!File.Exists(target))
@@ -78,21 +76,19 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
             else if (_taskType == ProcessTaskType.SQLFile)
             {
                 if (!BasicActivator.TypeText("Enter a name for the SQL file", "File name", 100, "myscript.sql",
-                        out var selected, false))
-                {
-                    return; //user cancelled
-                }
+                        out var selected, false)) return;
+
                 var target = Path.Combine(_loadDirectory.ExecutablesPath.FullName, selected);
 
-                    if (!target.EndsWith(".sql"))
-                        target += ".sql";
+                if (!target.EndsWith(".sql"))
+                    target += ".sql";
 
-                    //create it if it doesn't exist
-                    if (!File.Exists(target))
-                        File.WriteAllText(target, "/*todo Type some SQL*/");
+                //create it if it doesn't exist
+                if (!File.Exists(target))
+                    File.WriteAllText(target, "/*todo Type some SQL*/");
 
-                    _file = new FileInfo(target);
-                   
+                _file = new FileInfo(target);
+
             }
             else if (_taskType == ProcessTaskType.Executable)
             {

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFileBasedProcessTask.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFileBasedProcessTask.cs
@@ -58,7 +58,6 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
 
         if (_file == null)
         {
-            //todo make this a switch
             if (_taskType == ProcessTaskType.SQLBakFile)
             {
                 if (BasicActivator.TypeText("Enter a name for the SQL Bak file", "File name", 100, "database.bak",
@@ -68,8 +67,7 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
 
                     if (!File.Exists(target))
                     {
-                        //todo this file doesn't exist
-                        return;
+                        return; //File doesn't exist
                     }
 
                     _file = new FileInfo(target);
@@ -140,7 +138,7 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
         {
             ProcessTaskType.Executable => "Add Run .exe File Task",
             ProcessTaskType.SQLFile => "Add Run SQL Script Task",
-            ProcessTaskType.SQLBakFile => "Add SQL Bak File Task",
+            ProcessTaskType.SQLBakFile => "Add SQL backup File Task",
             _ => throw new ArgumentOutOfRangeException()
         };
     }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFileBasedProcessTask.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewFileBasedProcessTask.cs
@@ -42,7 +42,7 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
             SetImpossible("Could not construct LoadDirectory");
         }
 
-        ProcessTaskType[] AcceptedProcessTaskTypes= { ProcessTaskType.SQLFile, ProcessTaskType.Executable, ProcessTaskType.SQLBakFile };
+        ProcessTaskType[] AcceptedProcessTaskTypes = { ProcessTaskType.SQLFile, ProcessTaskType.Executable, ProcessTaskType.SQLBakFile };
         if (!AcceptedProcessTaskTypes.Contains(taskType))
             SetImpossible("Only SQLFile, SqlBakFile and Executable task types are supported by this command");
 
@@ -60,29 +60,29 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
         {
             if (_taskType == ProcessTaskType.SQLBakFile)
             {
-                if (BasicActivator.TypeText("Enter a name for the SQL Bak file", "File name", 100, "database.bak",
+                if (!BasicActivator.TypeText("Enter a name for the SQL Bak file", "File name", 100, "database.bak",
                        out var selected, false))
-                {
-                    var target = Path.Combine(_loadDirectory.ExecutablesPath.FullName, selected);
-
-                    if (!File.Exists(target))
-                    {
-                        return; //File doesn't exist
-                    }
-
-                    _file = new FileInfo(target);
-                }
-                else
                 {
                     return; //user cancelled
                 }
+                var target = Path.Combine(_loadDirectory.ExecutablesPath.FullName, selected);
+
+                if (!File.Exists(target))
+                {
+                    return; //File doesn't exist
+                }
+
+                _file = new FileInfo(target);
+
             }
             else if (_taskType == ProcessTaskType.SQLFile)
             {
-                if (BasicActivator.TypeText("Enter a name for the SQL file", "File name", 100, "myscript.sql",
+                if (!BasicActivator.TypeText("Enter a name for the SQL file", "File name", 100, "myscript.sql",
                         out var selected, false))
                 {
-                    var target = Path.Combine(_loadDirectory.ExecutablesPath.FullName, selected);
+                    return; //user cancelled
+                }
+                var target = Path.Combine(_loadDirectory.ExecutablesPath.FullName, selected);
 
                     if (!target.EndsWith(".sql"))
                         target += ".sql";
@@ -92,11 +92,7 @@ public class ExecuteCommandCreateNewFileBasedProcessTask : BasicCommandExecution
                         File.WriteAllText(target, "/*todo Type some SQL*/");
 
                     _file = new FileInfo(target);
-                }
-                else
-                {
-                    return; //user cancelled
-                }
+                   
             }
             else if (_taskType == ProcessTaskType.Executable)
             {

--- a/Rdmp.Core/Curation/Data/DataLoad/ProcessTask.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/ProcessTask.cs
@@ -374,6 +374,7 @@ public class ProcessTask : DatabaseEntity, IProcessTask, IOrderable, INamed, ICh
         {
             ProcessTaskType.Executable => true,
             ProcessTaskType.SQLFile => stage != LoadStage.GetFiles,
+            ProcessTaskType.SQLBakFile => stage != LoadStage.GetFiles,
             ProcessTaskType.Attacher => stage == LoadStage.Mounting,
             ProcessTaskType.DataProvider => true,
             ProcessTaskType.MutilateDataTable => stage != LoadStage.GetFiles,

--- a/Rdmp.Core/Curation/Data/DataLoad/ProcessTask.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/ProcessTask.cs
@@ -198,7 +198,10 @@ public class ProcessTask : DatabaseEntity, IProcessTask, IOrderable, INamed, ICh
             case ProcessTaskType.SQLFile:
                 CheckFileExistenceAndUniqueness(notifier);
                 CheckForProblemsInSQLFile(notifier);
-
+                break;
+            case ProcessTaskType.SQLBakFile:
+                //CheckFileExistenceAndUniqueness(notifier);
+                //CheckForProblemsInSQLFile(notifier);
                 break;
             case ProcessTaskType.Attacher:
                 break;

--- a/Rdmp.Core/Curation/Data/DataLoad/ProcessTask.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/ProcessTask.cs
@@ -200,8 +200,7 @@ public class ProcessTask : DatabaseEntity, IProcessTask, IOrderable, INamed, ICh
                 CheckForProblemsInSQLFile(notifier);
                 break;
             case ProcessTaskType.SQLBakFile:
-                //CheckFileExistenceAndUniqueness(notifier);
-                //CheckForProblemsInSQLFile(notifier);
+                CheckFileExistenceAndUniqueness(notifier);
                 break;
             case ProcessTaskType.Attacher:
                 break;

--- a/Rdmp.Core/Curation/Data/DataLoad/ProcessTaskType.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/ProcessTaskType.cs
@@ -23,7 +23,7 @@ public enum ProcessTaskType
     SQLFile,
 
     /// <summary>
-    /// ProcessTask is to import a SQL BAK file directly to the server
+    /// ProcessTask is to import a SQL backup file directly to the server
     /// </summary>
     SQLBakFile,
 

--- a/Rdmp.Core/Curation/Data/DataLoad/ProcessTaskType.cs
+++ b/Rdmp.Core/Curation/Data/DataLoad/ProcessTaskType.cs
@@ -23,6 +23,11 @@ public enum ProcessTaskType
     SQLFile,
 
     /// <summary>
+    /// ProcessTask is to import a SQL BAK file directly to the server
+    /// </summary>
+    SQLBakFile,
+
+    /// <summary>
     /// ProcessTask is to instantiate the IAttacher class Type specified in Path and hydrate its [DemandsInitialization] properties with values matching
     /// ProcessTaskArguments and run it in the specified load stage in an AttacherRuntimeTask wrapper.
     /// </summary>

--- a/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
+++ b/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
@@ -21,12 +21,12 @@ using Rdmp.Core.ReusableLibraryCode.Progress;
 namespace Rdmp.Core.DataLoad.Engine.LoadExecution.Components.Runtime;
 
 /// <summary>
-/// RuntimeTask that executes a single .sql file specified by the user in a ProcessTask with ProcessTaskType SQLFile.
+/// RuntimeTask that executes a single .bak file specified by the user in a ProcessTask with ProcessTaskType SQLBakFile.
 /// </summary>
 public class ExecuteSqlBakFileRuntimeTask : RuntimeTask
 {
     public string Filepath;
-    private IProcessTask _task;
+    private readonly IProcessTask _task;
 
     private LoadStage _loadStage;
 
@@ -56,6 +56,7 @@ public class ExecuteSqlBakFileRuntimeTask : RuntimeTask
         if (primaryFiles.Length != 1 || logFiles.Length != 1)
         {
             //Something has gone wrong
+            return ExitCodeType.Error;
         }
 
 

--- a/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
+++ b/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
@@ -49,13 +49,12 @@ public class ExecuteSqlBakFileRuntimeTask : RuntimeTask
         using var con = (SqlConnection)db.Server.GetConnection();
         SqlCommand cmd = new SqlCommand(fileOnlyCommand, con);
         SqlDataAdapter da = new SqlDataAdapter(cmd);
+        cmd.Dispose();
         da.Fill(fileInfo);
-
+        da.Dispose();
         DataRow[] primaryFiles = fileInfo.Select("Type = 'D'");
         DataRow[] logFiles = fileInfo.Select("Type = 'L'");
         fileInfo.Dispose();
-        cmd.Dispose();
-        da.Dispose();
         if (primaryFiles.Length != 1 || logFiles.Length != 1)
         {
             //Something has gone wrong

--- a/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
+++ b/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
@@ -53,6 +53,9 @@ public class ExecuteSqlBakFileRuntimeTask : RuntimeTask
 
         DataRow[] primaryFiles = fileInfo.Select("Type = 'D'");
         DataRow[] logFiles = fileInfo.Select("Type = 'L'");
+        fileInfo.Dispose();
+        cmd.Dispose();
+        da.Dispose();
         if (primaryFiles.Length != 1 || logFiles.Length != 1)
         {
             //Something has gone wrong

--- a/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
+++ b/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/ExecuteSqlBakFileRuntimeTask.cs
@@ -1,0 +1,108 @@
+﻿// Copyright (c) The University of Dundee 2018-2023
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+using System;
+using System.IO;
+using Rdmp.Core.Curation.Data.DataLoad;
+using Rdmp.Core.DataFlowPipeline;
+using Rdmp.Core.DataLoad.Engine.Job;
+using Rdmp.Core.DataLoad.Engine.LoadExecution.Components.Arguments;
+using Rdmp.Core.ReusableLibraryCode.Checks;
+using Rdmp.Core.ReusableLibraryCode.Progress;
+
+namespace Rdmp.Core.DataLoad.Engine.LoadExecution.Components.Runtime;
+
+/// <summary>
+/// RuntimeTask that executes a single .sql file specified by the user in a ProcessTask with ProcessTaskType SQLFile.
+/// </summary>
+public class ExecuteSqlBakFileRuntimeTask : RuntimeTask
+{
+    public string Filepath;
+    private IProcessTask _task;
+
+    private LoadStage _loadStage;
+
+    public ExecuteSqlBakFileRuntimeTask(IProcessTask task, RuntimeArgumentCollection args) : base(task, args)
+    {
+        _task = task;
+        Filepath = task.Path;
+    }
+
+    public override ExitCodeType Run(IDataLoadJob job, GracefulCancellationToken cancellationToken)
+    {
+        var db = RuntimeArguments.StageSpecificArguments.DbInfo;
+        _loadStage = RuntimeArguments.StageSpecificArguments.LoadStage;
+
+        if (!Exists())
+            throw new Exception($"The sql bak file {Filepath} does not exist");
+
+        string name = RuntimeArguments.StageSpecificArguments.DbInfo.Server.Name;
+        string restoreCommand = @$"RESTORE DATABASE {name}
+        FROM DISK = 'C:\temp\backups\backup.bak'
+        WITH MOVE 'images_1' TO 'C:\Users\jfriel001\images_1.mdf',
+        MOVE 'images_1_log' TO 'C:\Users\jfriel001\images_1.ldf' ,  NOUNLOAD,  REPLACE,  STATS = 5";
+        try
+        {
+            //    commandText = File.ReadAllText(Filepath);
+
+            //    // Any string arguments refer to tokens that are to be replaced in the SQL file
+            //    foreach (var kvp in RuntimeArguments.GetAllArgumentsOfType<string>())
+            //    {
+            //        var value = kvp.Value;
+
+            //        if (value.Contains("<DatabaseServer>"))
+            //            value = value.Replace("<DatabaseServer>",
+            //                RuntimeArguments.StageSpecificArguments.DbInfo.Server.Name);
+
+            //        if (value.Contains("<DatabaseName>"))
+            //            value = value.Replace("<DatabaseName>",
+            //                RuntimeArguments.StageSpecificArguments.DbInfo.GetRuntimeName());
+
+            //        commandText = commandText.Replace($"##{kvp.Key}##", value);
+            //    }
+        }
+        catch (Exception e)
+        {
+            throw new Exception($"Could not read the sql file at {Filepath}: {e}");
+        }
+
+        job.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information,
+            $"Executing script {Filepath} ( against {db})"));
+        var executer = new ExecuteSqlInDleStage(job, _loadStage);
+        return executer.Execute(restoreCommand, db);
+    }
+
+
+    public override bool Exists() => File.Exists(Filepath);
+
+    public override void Abort(IDataLoadEventListener postLoadEventListener)
+    {
+    }
+
+    public override void LoadCompletedSoDispose(ExitCodeType exitCode, IDataLoadEventListener postLoadEventListener)
+    {
+    }
+
+    public override void Check(ICheckNotifier notifier)
+    {
+        if (string.IsNullOrWhiteSpace(Filepath))
+        {
+            notifier.OnCheckPerformed(
+                new CheckEventArgs($"ExecuteSqlFileTask {_task} does not have a path specified",
+                    CheckResult.Fail));
+            return;
+        }
+
+        if (!File.Exists(Filepath))
+            notifier.OnCheckPerformed(
+                new CheckEventArgs(
+                    $"File '{Filepath}' does not exist! (the only time this would be legal is if you have an exe or a freaky plugin that creates this file)",
+                    CheckResult.Warning));
+        else
+            notifier.OnCheckPerformed(new CheckEventArgs($"Found File '{Filepath}'",
+                CheckResult.Success));
+    }
+}

--- a/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/RuntimeTaskFactory.cs
+++ b/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/RuntimeTaskFactory.cs
@@ -32,6 +32,7 @@ public class RuntimeTaskFactory
         {
             ProcessTaskType.Executable => new ExecutableRuntimeTask(task, args),
             ProcessTaskType.SQLFile => new ExecuteSqlFileRuntimeTask(task, args),
+            ProcessTaskType.SQLBakFile => new ExecuteSqlBakFileRuntimeTask(task, args),
             ProcessTaskType.Attacher => new AttacherRuntimeTask(task, args),
             ProcessTaskType.DataProvider => new DataProviderRuntimeTask(task, args),
             ProcessTaskType.MutilateDataTable => new MutilateDataTablesRuntimeTask(task, args),

--- a/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/RuntimeTaskFactory.cs
+++ b/Rdmp.Core/DataLoad/Engine/LoadExecution/Components/Runtime/RuntimeTaskFactory.cs
@@ -32,10 +32,10 @@ public class RuntimeTaskFactory
         {
             ProcessTaskType.Executable => new ExecutableRuntimeTask(task, args),
             ProcessTaskType.SQLFile => new ExecuteSqlFileRuntimeTask(task, args),
-            ProcessTaskType.SQLBakFile => new ExecuteSqlBakFileRuntimeTask(task, args),
             ProcessTaskType.Attacher => new AttacherRuntimeTask(task, args),
             ProcessTaskType.DataProvider => new DataProviderRuntimeTask(task, args),
             ProcessTaskType.MutilateDataTable => new MutilateDataTablesRuntimeTask(task, args),
+            ProcessTaskType.SQLBakFile => new ExecuteSqlBakFileRuntimeTask(task, args),
             _ => throw new Exception($"Cannot create runtime task: Unknown process task type '{task.ProcessTaskType}'")
         };
     }

--- a/Rdmp.Core/Icons/IconProvision/StateBasedIconProviders/ProcessTaskStateBasedIconProvider.cs
+++ b/Rdmp.Core/Icons/IconProvision/StateBasedIconProviders/ProcessTaskStateBasedIconProvider.cs
@@ -41,6 +41,7 @@ public class ProcessTaskStateBasedIconProvider : IObjectStateBasedIconProvider
             {
                 ProcessTaskType.Executable => _exe,
                 ProcessTaskType.SQLFile => _sql,
+                ProcessTaskType.SQLBakFile => _sql,
                 ProcessTaskType.Attacher => _attacher,
                 ProcessTaskType.DataProvider => _dataProvider,
                 ProcessTaskType.MutilateDataTable => _mutilateDataTables,

--- a/Rdmp.UI/CommandExecution/Proposals/ProposeExecutionWhenTargetIsLoadStageNode.cs
+++ b/Rdmp.UI/CommandExecution/Proposals/ProposeExecutionWhenTargetIsLoadStageNode.cs
@@ -42,6 +42,9 @@ internal class ProposeExecutionWhenTargetIsLoadStageNode : RDMPCommandExecutionP
                 case ".sql":
                     return new ExecuteCommandCreateNewFileBasedProcessTask(ItemActivator, ProcessTaskType.SQLFile,
                         targetStage.LoadMetadata, targetStage.LoadStage, f);
+                case ".bak":
+                    return new ExecuteCommandCreateNewFileBasedProcessTask(ItemActivator, ProcessTaskType.SQLBakFile,
+                        targetStage.LoadMetadata, targetStage.LoadStage, f);
                 case ".exe":
                     return new ExecuteCommandCreateNewFileBasedProcessTask(ItemActivator, ProcessTaskType.Executable,
                         targetStage.LoadMetadata, targetStage.LoadStage, f);

--- a/Rdmp.UI/CommandExecution/Proposals/ProposeExecutionWhenTargetIsProcessTask.cs
+++ b/Rdmp.UI/CommandExecution/Proposals/ProposeExecutionWhenTargetIsProcessTask.cs
@@ -32,6 +32,9 @@ internal class ProposeExecutionWhenTargetIsProcessTask : RDMPCommandExecutionPro
             case ProcessTaskType.SQLFile:
                 ItemActivator.Activate<SqlProcessTaskUI, ProcessTask>(processTask);
                 break;
+            case ProcessTaskType.SQLBakFile:
+                ItemActivator.Activate<SqlProcessTaskUI, ProcessTask>(processTask);
+                break;
         }
     }
 


### PR DESCRIPTION
Allows for .bak files to be mounted into _RAW and used as a data load
N.B. some wrangling of the tables may be required in _Raw/_Staging