### PR TITLE
Task/rdmp-32 Fix Progress Log writing using excessive resources

### DIFF
--- a/Rdmp.UI/Progress/ProgressUI.cs
+++ b/Rdmp.UI/Progress/ProgressUI.cs
@@ -257,11 +257,11 @@ public partial class ProgressUI : UserControl, IDataLoadEventListener
                 _notificationQueue.Clear();
 
 
-                //AutoResizeColumns();
+                AutoResizeColumns();
             }
         }
 
-        //olvProgressEvents.Sort();
+        olvProgressEvents.Sort();
     }
 
     private void AutoResizeColumns()

--- a/Rdmp.UI/Progress/ProgressUI.cs
+++ b/Rdmp.UI/Progress/ProgressUI.cs
@@ -257,11 +257,11 @@ public partial class ProgressUI : UserControl, IDataLoadEventListener
                 _notificationQueue.Clear();
 
 
-                AutoResizeColumns();
+                //AutoResizeColumns();
             }
         }
 
-        olvProgressEvents.Sort();
+        //olvProgressEvents.Sort();
     }
 
     private void AutoResizeColumns()

--- a/Rdmp.UI/Progress/ProgressUI.cs
+++ b/Rdmp.UI/Progress/ProgressUI.cs
@@ -256,12 +256,8 @@ public partial class ProgressUI : UserControl, IDataLoadEventListener
                 olvProgressEvents.EndUpdate();
                 _notificationQueue.Clear();
 
-
-                //AutoResizeColumns();
             }
         }
-
-        //olvProgressEvents.Sort();
     }
 
     private void AutoResizeColumns()

--- a/Rdmp.UI/Progress/ProgressUI.cs
+++ b/Rdmp.UI/Progress/ProgressUI.cs
@@ -251,14 +251,17 @@ public partial class ProgressUI : UserControl, IDataLoadEventListener
         {
             if (_notificationQueue.Any())
             {
+                olvProgressEvents.BeginUpdate();
                 olvProgressEvents.AddObjects(_notificationQueue);
+                olvProgressEvents.EndUpdate();
                 _notificationQueue.Clear();
 
-                AutoResizeColumns();
+
+                //AutoResizeColumns();
             }
         }
 
-        olvProgressEvents.Sort();
+        //olvProgressEvents.Sort();
     }
 
     private void AutoResizeColumns()


### PR DESCRIPTION
When testing the CHI column  finder crashes, it turns out it was the notifications that were causing the spike in resource usage.
From some testing, the actual message gathering and reporting is okay, but the UI updates were not performant.

Have added begin/end data load markers which will stop the UI attempting to re-render while still receiving new data.
Have remove the sorting and it it is again further re-renders for minimal benefit.
Have also removed the auto column resizing as this felt unnecessary given the performance concerns