### PR TITLE
Task/rdmp 32 Name DataTable Chunks

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [8.1.1] - WIP
+
 ...
 
 ### Changed

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -563,7 +563,6 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
         toReturn.EndLoadData();
 
         con.Close();
-        toReturn.EndLoadData();
 
         return toReturn;
     }

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -207,16 +207,12 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
         try
         {
             chunk = _hostedSource.GetChunk(listener, cancellationToken);
-            try
-            {
-                chunk.TableName = Request.DatasetBundle.DataSet.Catalogue.Name;
-            }
-            catch (Exception)
-            {
-                //failed to grab the catalogue name
-            }
+
 
             chunk = _peeker.AddPeekedRowsIfAny(chunk);
+
+            if (Request != null && Request.DatasetBundle.DataSet is not null && chunk is not null)
+                chunk.TableName = $"{Request.DatasetBundle.DataSet}";
 
             //if we are trying to distinct the records in memory based on release id
             if (DistinctStrategy == DistinctStrategy.OrderByAndDistinctInMemory)
@@ -564,7 +560,7 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
 
         //get up to 1000 records
         da.Fill(0, 1000, toReturn);
-            toReturn.EndLoadData();
+        toReturn.EndLoadData();
 
         con.Close();
         toReturn.EndLoadData();

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -207,6 +207,14 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
         try
         {
             chunk = _hostedSource.GetChunk(listener, cancellationToken);
+            try
+            {
+                chunk.TableName = Request.DatasetBundle.DataSet.Catalogue.Name;
+            }
+            catch (Exception)
+            {
+                //failed to grab the catalogue name
+            }
 
             chunk = _peeker.AddPeekedRowsIfAny(chunk);
 

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -10,6 +10,6 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("8.1.0")]
-[assembly: AssemblyFileVersion("8.1.0")]
-[assembly: AssemblyInformationalVersion("8.1.0")]
+[assembly: AssemblyVersion("8.1.1")]
+[assembly: AssemblyFileVersion("8.1.1")]
+[assembly: AssemblyInformationalVersion("8.1.1-rc1")]


### PR DESCRIPTION
Small update to give the extraction processing chunks names.
This is to be used with some additions to the CHI column finder where it wants to know where the current processing chunk came from.

Also bump to v8.1.1-rc1