### PR TITLE
Plugin loading adjustment (RDMP-130)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -115,14 +115,14 @@ jobs:
           do
             PluginName="$(cut -d/ -f6 <<< $plugin)"
             NAME="$(curl -s $plugin | grep "browser_download_url.*$PluginName.*nupkg" | cut -d : -f 2,3 | cut -d "\"" -f 2)"
-            echo $NAME
             curl -OL  $NAME
-            for platform in PublishWindows PublishLinux PublishWinForms
-            do
-              cp *.nupkg $platform
-            done
-            rm *.nupkg
           done
+          ls *.nupkg > rdmpplugins.txt
+          for platform in PublishWindows PublishLinux PublishWinForms
+          do
+            cp rdmpplugins.txt *.nupkg $platform
+          done
+          rm rdmpplugins.txt *.nupkg
 
       - name: Sign
         if: contains(github.ref, 'refs/tags/v') || contains('refs/heads/main refs/heads/develop',github.ref)

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -133,11 +133,11 @@ jobs:
           AzureSignTool sign -kvu "${{ secrets.AZURE_KEY_VAULT_URI }}" -kvi "${{ secrets.AZURE_CLIENT_ID }}" -kvt "${{ secrets.AZURE_TENANT_ID }}" -kvs "${{ secrets.AZURE_CLIENT_SECRET }}" -kvc ${{ secrets.AZURE_CERT_NAME }} -tr http://timestamp.digicert.com -v PublishWinForms/ResearchDataManagementPlatform.exe
           mkdir -p dist
           cmd /c wix\\build.cmd ${{ steps.version.outputs.rdmpversion }}
-          (cd PublishWindows ; echo 7z a -mx=9 ../dist/rdmp-${{ steps.version.outputs.rdmpversion }}-cli-win-x64.zip rdmp.exe NLog.config *.yaml *.nupkg | cmd)
+          (cd PublishWindows ; echo 7z a -mx=9 ../dist/rdmp-${{ steps.version.outputs.rdmpversion }}-cli-win-x64.zip rdmp.exe NLog.config *.yaml *.nupkg rdmpplugins.txt| cmd)
           (cd PublishLinux ; echo 7z a -mx=0 ../dist/rdmp-${{ steps.version.outputs.rdmpversion }}-cli-linux-x64.zip . | cmd)
           mv PublishLinux rdmp-${{ steps.version.outputs.rdmpversion }}-cli-linux
           echo 7z a dist/rdmp-${{ steps.version.outputs.rdmpversion }}-cli-linux-x64.tar rdmp-${{ steps.version.outputs.rdmpversion }}-cli-linux | cmd
-          (cd PublishWinForms ; echo 7z a -mx=9 ../dist/rdmp-${{ steps.version.outputs.rdmpversion }}-client.zip ResearchDataManagementPlatform.exe *.nupkg | cmd)
+          (cd PublishWinForms ; echo 7z a -mx=9 ../dist/rdmp-${{ steps.version.outputs.rdmpversion }}-client.zip ResearchDataManagementPlatform.exe *.nupkg rdmpplugins.txt | cmd)
 
 
       - name: Install Perl dependencies

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandPrunePlugin.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandPrunePlugin.cs
@@ -23,7 +23,7 @@ namespace Rdmp.Core.CommandExecution.AtomicCommands;
 /// dll at runtime and so these dlls will just bloat your plugin.  Use this command to prune out
 /// those files.
 /// </summary>
-public partial class ExecuteCommandPrunePlugin : BasicCommandExecution
+public sealed partial class ExecuteCommandPrunePlugin : BasicCommandExecution
 {
     private string _file;
 

--- a/Rdmp.Core/Rdmp.Core.csproj
+++ b/Rdmp.Core/Rdmp.Core.csproj
@@ -29,6 +29,7 @@
   </PropertyGroup>
   <PropertyGroup>
     <TreatWarningsAsErrors>true</TreatWarningsAsErrors>
+    <LangVersion>latest</LangVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Remove="Databases\CatalogueDatabase\up\views\**" />

--- a/Rdmp.Core/Startup/Startup.cs
+++ b/Rdmp.Core/Startup/Startup.cs
@@ -115,6 +115,7 @@ public class Startup
 
         //only load data export manager if catalogue worked
         if (!foundCatalogue) return;
+
         LoadMEF(RepositoryLocator.CatalogueRepository, notifier);
 
         //find tier 2 databases
@@ -138,10 +139,10 @@ public class Startup
                     e));
         }
 
-        FindTier3Databases(RepositoryLocator.CatalogueRepository, notifier);
+        FindTier3Databases(notifier);
     }
 
-    private void FindTier3Databases(ICatalogueRepository catalogueRepository, ICheckNotifier notifier)
+    private void FindTier3Databases(ICheckNotifier notifier)
     {
         foreach (var patcher in _patcherManager.GetTier3Patchers(PluginPatcherFound))
             FindWithPatcher(patcher, notifier);
@@ -241,12 +242,7 @@ public class Startup
     /// <param name="notifier"></param>
     private static void LoadMEF(ICatalogueRepository catalogueRepository, ICheckNotifier notifier)
     {
-        var pluginsList = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "rdmpplugins.txt");
-        var packageFiles = File.Exists(pluginsList)
-            ? File.ReadAllLines(pluginsList)
-                .Select(static name => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, name))
-            : Directory.EnumerateFiles(AppDomain.CurrentDomain.BaseDirectory, "*.nupkg");
-        foreach (var (name, body) in packageFiles.SelectMany(LoadModuleAssembly.GetContents))
+        foreach (var (name, body) in LoadModuleAssembly.PluginFiles().SelectMany(LoadModuleAssembly.GetContents))
             try
             {
                 AssemblyLoadContext.Default.LoadFromStream(body);

--- a/Rdmp.Core/Startup/Startup.cs
+++ b/Rdmp.Core/Startup/Startup.cs
@@ -241,8 +241,12 @@ public class Startup
     /// <param name="notifier"></param>
     private static void LoadMEF(ICatalogueRepository catalogueRepository, ICheckNotifier notifier)
     {
-        foreach (var (name, body) in Directory.EnumerateFiles(AppDomain.CurrentDomain.BaseDirectory, "*.nupkg")
-                     .SelectMany(LoadModuleAssembly.GetContents))
+        var pluginsList = Path.Combine(AppDomain.CurrentDomain.BaseDirectory, "rdmpplugins.txt");
+        var packageFiles = File.Exists(pluginsList)
+            ? File.ReadAllLines(pluginsList)
+                .Select(static name => Path.Combine(AppDomain.CurrentDomain.BaseDirectory, name))
+            : Directory.EnumerateFiles(AppDomain.CurrentDomain.BaseDirectory, "*.nupkg");
+        foreach (var (name, body) in packageFiles.SelectMany(LoadModuleAssembly.GetContents))
             try
             {
                 AssemblyLoadContext.Default.LoadFromStream(body);

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandDeletePlugin.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandDeletePlugin.cs
@@ -11,11 +11,13 @@ using Rdmp.UI.ItemActivation;
 using SixLabors.ImageSharp;
 using SixLabors.ImageSharp.PixelFormats;
 using System;
+
 namespace Rdmp.UI.CommandExecution.AtomicCommands;
 
-public class ExecuteCommandDeletePlugin : BasicUICommandExecution
+public sealed class ExecuteCommandDeletePlugin : BasicUICommandExecution
 {
     private readonly LoadModuleAssembly _assembly;
+
     public ExecuteCommandDeletePlugin(IActivateItems activator, LoadModuleAssembly assembly) : base(activator)
     {
         _assembly = assembly;
@@ -27,18 +29,16 @@ public class ExecuteCommandDeletePlugin : BasicUICommandExecution
     public override void Execute()
     {
         base.Execute();
-        if (YesNo($"Are you sure you want to delete {_assembly}?", "Delete Plugin"))
+        if (!YesNo($"Are you sure you want to delete {_assembly}?", "Delete Plugin")) return;
+
+        try
         {
             _assembly.Delete();
-            try
-            {
-                _assembly.Delete();
-                Show("Changes will take effect on restart");
-            }
-            catch (SystemException ex)
-            {
-                Show($"Could not delete the {_assembly} plugin.", ex);
-            }
+            Show("Changes will take effect on restart");
+        }
+        catch (SystemException ex)
+        {
+            Show($"Could not delete the {_assembly} plugin.", ex);
         }
     }
 }

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -12,4 +12,4 @@ using System.Reflection;
 
 [assembly: AssemblyVersion("8.1.2")]
 [assembly: AssemblyFileVersion("8.1.2")]
-[assembly: AssemblyInformationalVersion("8.1.2-rc1")]
+[assembly: AssemblyInformationalVersion("8.1.2-rc2")]

--- a/rdmp-client.xml
+++ b/rdmp-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
-    <version>8.1.1.0</version>
-    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.1/rdmp-8.1.1-client.zip</url>
+    <version>8.1.2.0</version>
+    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2/rdmp-8.1.2-rc1-client.zip</url>
     <changelog>https://github.com/HicServices/RDMP/blob/main/CHANGELOG.md#810</changelog>
     <mandatory>true</mandatory>
 </item>

--- a/rdmp-client.xml
+++ b/rdmp-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
     <version>8.1.2.0</version>
-    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2-rc2/rdmp-8.1.2-rc1-client.zip</url>
+    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2-rc2/rdmp-8.1.2-rc2-client.zip</url>
     <changelog>https://github.com/HicServices/RDMP/blob/main/CHANGELOG.md#810</changelog>
     <mandatory>true</mandatory>
 </item>

--- a/rdmp-client.xml
+++ b/rdmp-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
     <version>8.1.2.0</version>
-    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2-rc2/rdmp-8.1.2-rc2-client.zip</url>
+    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2-rc2/rdmp-8.1.2-rc1-client.zip</url>
     <changelog>https://github.com/HicServices/RDMP/blob/main/CHANGELOG.md#810</changelog>
     <mandatory>true</mandatory>
 </item>

--- a/rdmp-client.xml
+++ b/rdmp-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
     <version>8.1.2.0</version>
-    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2-rc1/rdmp-8.1.2-rc1-client.zip</url>
+    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2-rc2/rdmp-8.1.2-rc2-client.zip</url>
     <changelog>https://github.com/HicServices/RDMP/blob/main/CHANGELOG.md#810</changelog>
     <mandatory>true</mandatory>
 </item>

--- a/rdmp-client.xml
+++ b/rdmp-client.xml
@@ -1,7 +1,7 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <item>
     <version>8.1.2.0</version>
-    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2/rdmp-8.1.2-rc1-client.zip</url>
+    <url>https://github.com/HicServices/RDMP/releases/download/v8.1.2-rc1/rdmp-8.1.2-rc1-client.zip</url>
     <changelog>https://github.com/HicServices/RDMP/blob/main/CHANGELOG.md#810</changelog>
     <mandatory>true</mandatory>
 </item>


### PR DESCRIPTION
Use rdmpplugins.txt to control plugin loading instead of blindly loading any old nupkg file, workaround for autoupdater leaving old plugin files (and other debris which we should address better at some point!) lying around.
Falls back on previous behaviour (load *.nupkg) if no rdmpplugins.txt file exists.