### PR TITLE
Spike/rdmp-132 migrate to log file

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.4] - Unreleased
+
+## Changed
+
+- Add ability to log to file instead of database
+
 ## [8.1.3] - 2024-01-15
 
 ### Changed

--- a/Rdmp.Core/Logging/DataLoadInfo.cs
+++ b/Rdmp.Core/Logging/DataLoadInfo.cs
@@ -10,6 +10,7 @@ using System.Collections.Generic;
 using System.Threading;
 using FAnsi;
 using FAnsi.Discovery;
+using Rdmp.Core.ReusableLibraryCode.Settings;
 
 namespace Rdmp.Core.Logging;
 
@@ -322,7 +323,7 @@ public sealed class DataLoadInfo : IDataLoadInfo
 
     public void LogProgress(ProgressEventType pevent, string Source, string Description)
     {
-        bool useLocalFileSystem = true;
+        bool useLocalFileSystem = UserSettings.LogToFileSystem && UserSettings.FileSystemLogLocation is not null;
         if (useLocalFileSystem)
         {
             var logger = FileSystemLogger.Instance;

--- a/Rdmp.Core/Logging/DataLoadInfo.cs
+++ b/Rdmp.Core/Logging/DataLoadInfo.cs
@@ -184,8 +184,8 @@ public sealed class DataLoadInfo : IDataLoadInfo
         DatabaseSettings.AddParameterWithValueToCommand("@startTime", cmd, _startTime);
         DatabaseSettings.AddParameterWithValueToCommand("@dataLoadTaskID", cmd, parentTaskID);
         DatabaseSettings.AddParameterWithValueToCommand("@isTest", cmd, _isTest);
-        DatabaseSettings.AddParameterWithValueToCommand("@packageName", cmd, _packageName);
-        DatabaseSettings.AddParameterWithValueToCommand("@userAccount", cmd, _userAccount);
+        DatabaseSettings.AddParameterWithValueToCommand("@packageName", cmd, _packageName.Substring(Math.Max(0, _packageName.Length - 750)));
+        DatabaseSettings.AddParameterWithValueToCommand("@userAccount", cmd, _userAccount.Substring(Math.Max(0, _packageName.Length - 500)));
         DatabaseSettings.AddParameterWithValueToCommand("@suggestedRollbackCommand", cmd,
             _suggestedRollbackCommand ?? string.Empty);
 

--- a/Rdmp.Core/Logging/FileSystemLogger.cs
+++ b/Rdmp.Core/Logging/FileSystemLogger.cs
@@ -1,0 +1,35 @@
+﻿using NLog;
+using System;
+
+namespace Rdmp.Core.Logging;
+
+public class FileSystemLogger
+{
+
+    private static readonly Lazy<FileSystemLogger> lazy =
+         new Lazy<FileSystemLogger>(() => new FileSystemLogger());
+
+    public static FileSystemLogger Instance { get { return lazy.Value; } }
+
+
+
+    private FileSystemLogger()
+    {
+        var location = "C:\\temp\\logs\\";
+        var config = new NLog.Config.LoggingConfiguration();
+        var logfile = new NLog.Targets.FileTarget("ProgressLog") { FileName = $"{location}ProgressLog.log" };
+        config.AddRule(LogLevel.Info, LogLevel.Info, logfile);
+        NLog.LogManager.Configuration = config;
+
+    }
+
+
+    public void LogEventToFile(string logType, object[] logItems)
+    {
+        var logMessage = $"{string.Join("|", Array.ConvertAll(logItems, item => item.ToString()))}";
+        var Logger = NLog.LogManager.GetLogger(logType);
+        Logger.Info(logMessage);
+    }
+
+
+}

--- a/Rdmp.Core/Logging/FileSystemLogger.cs
+++ b/Rdmp.Core/Logging/FileSystemLogger.cs
@@ -1,5 +1,7 @@
 ﻿using NLog;
+using Rdmp.Core.ReusableLibraryCode.Settings;
 using System;
+using System.IO;
 
 namespace Rdmp.Core.Logging;
 
@@ -15,9 +17,9 @@ public class FileSystemLogger
 
     private FileSystemLogger()
     {
-        var location = "C:\\temp\\logs\\";
+        var location = UserSettings.FileSystemLogLocation;
         var config = new NLog.Config.LoggingConfiguration();
-        var logfile = new NLog.Targets.FileTarget("ProgressLog") { FileName = $"{location}ProgressLog.log" };
+        var logfile = new NLog.Targets.FileTarget("ProgressLog") { FileName = Path.Combine(location,"ProgressLog.log"), ArchiveAboveSize= UserSettings.LogFileSizeLimit };
         config.AddRule(LogLevel.Info, LogLevel.Info, logfile);
         NLog.LogManager.Configuration = config;
 

--- a/Rdmp.Core/Logging/LogManager.cs
+++ b/Rdmp.Core/Logging/LogManager.cs
@@ -13,6 +13,7 @@ using System.Text;
 using System.Threading;
 using FAnsi.Discovery;
 using FAnsi.Discovery.QuerySyntax;
+using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Logging.PastEvents;
 using Rdmp.Core.ReusableLibraryCode;
 using Rdmp.Core.ReusableLibraryCode.DataAccess;
@@ -242,8 +243,8 @@ public class LogManager : ILogManager
 
         using var cmd = Server.GetCommand(sql, conn);
         Server.AddParameterWithValueToCommand("@date", cmd, DateTime.Now);
-        Server.AddParameterWithValueToCommand("@dataSetID", cmd, dataSetID);
-        Server.AddParameterWithValueToCommand("@username", cmd, Environment.UserName);
+        Server.AddParameterWithValueToCommand("@dataSetID", cmd, dataSetID.Substring(Math.Max(0, dataSetID.Length - 1000)));
+        Server.AddParameterWithValueToCommand("@username", cmd, Environment.UserName.Substring(Math.Max(0, Environment.UserName.Length - 500)));
 
         cmd.ExecuteNonQuery();
     }
@@ -256,7 +257,7 @@ public class LogManager : ILogManager
             const string sql = "INSERT INTO DataSet (dataSetID,name) VALUES (@datasetName,@datasetName)";
 
             using var cmd = Server.GetCommand(sql, conn);
-            Server.AddParameterWithValueToCommand("@datasetName", cmd, datasetName);
+            Server.AddParameterWithValueToCommand("@datasetName", cmd, datasetName.Substring(Math.Max(0, datasetName.Length - 150)));
             cmd.ExecuteNonQuery();
         }
     }

--- a/Rdmp.Core/Logging/TableLoadInfo.cs
+++ b/Rdmp.Core/Logging/TableLoadInfo.cs
@@ -87,7 +87,7 @@ public class TableLoadInfo : ITableLoadInfo
 
         DatabaseSettings.AddParameterWithValueToCommand("@startTime", cmd, DateTime.Now);
         DatabaseSettings.AddParameterWithValueToCommand("@dataLoadRunID", cmd, parent.ID);
-        DatabaseSettings.AddParameterWithValueToCommand("@targetTable", cmd, destinationTable);
+        DatabaseSettings.AddParameterWithValueToCommand("@targetTable", cmd, destinationTable.Substring(Math.Max(0,destinationTable.Length - 200))); //200 char limit on this table, just pull the rightmost 200 chars
         DatabaseSettings.AddParameterWithValueToCommand("@expectedInserts", cmd, expectedInserts);
         DatabaseSettings.AddParameterWithValueToCommand("@suggestedRollbackCommand", cmd, _suggestedRollbackCommand);
 

--- a/Rdmp.Core/Logging/TableLoadInfo.cs
+++ b/Rdmp.Core/Logging/TableLoadInfo.cs
@@ -7,6 +7,8 @@
 using System;
 using System.Data;
 using System.Threading;
+using Amazon.Auth.AccessControlPolicy;
+using BadMedicine;
 using FAnsi.Connections;
 using FAnsi.Discovery;
 
@@ -76,6 +78,7 @@ public class TableLoadInfo : ITableLoadInfo
     private void RecordNewTableLoadInDatabase(DataLoadInfo parent, string destinationTable, DataSource[] sources,
         int expectedInserts)
     {
+        bool useLocalFileSystem = true;
         using var con = DatabaseSettings.GetConnection();
         using var cmd = DatabaseSettings.GetCommand(
             "INSERT INTO TableLoadRun (startTime,dataLoadRunID,targetTable,expectedInserts,suggestedRollbackCommand) " +
@@ -92,6 +95,7 @@ public class TableLoadInfo : ITableLoadInfo
 
         //get the ID, can come back as a decimal or an Int32 or an Int64 so whatever, just turn it into a string and then parse it
         _id = int.Parse(cmd.ExecuteScalar().ToString());
+
 
         //keep a record of all data sources
         DataSources = sources;
@@ -125,6 +129,7 @@ public class TableLoadInfo : ITableLoadInfo
             }
 
             s.ID = int.Parse(cmdInsertDs.ExecuteScalar().ToString());
+
         }
     }
 

--- a/Rdmp.Core/Logging/TableLoadInfo.cs
+++ b/Rdmp.Core/Logging/TableLoadInfo.cs
@@ -78,7 +78,6 @@ public class TableLoadInfo : ITableLoadInfo
     private void RecordNewTableLoadInDatabase(DataLoadInfo parent, string destinationTable, DataSource[] sources,
         int expectedInserts)
     {
-        bool useLocalFileSystem = true;
         using var con = DatabaseSettings.GetConnection();
         using var cmd = DatabaseSettings.GetCommand(
             "INSERT INTO TableLoadRun (startTime,dataLoadRunID,targetTable,expectedInserts,suggestedRollbackCommand) " +

--- a/Rdmp.Core/ReusableLibraryCode/Settings/UserSettings.cs
+++ b/Rdmp.Core/ReusableLibraryCode/Settings/UserSettings.cs
@@ -34,6 +34,24 @@ public static class UserSettings
         set => AppSettings.AddOrUpdateValue("UseLocalFileSystem", value);
     }
 
+    public static bool LogToFileSystem
+    {
+        get => AppSettings.GetValueOrDefault("LogToFileSystem", false);
+        set => AppSettings.AddOrUpdateValue("LogToFileSystem", value);
+    }
+
+    public static long LogFileSizeLimit
+    {
+        get => AppSettings.GetValueOrDefault("LogFileSizeLimit", 1073741824);
+        set => AppSettings.AddOrUpdateValue("LogFileSizeLimit", value);
+    }
+
+    public static string FileSystemLogLocation
+    {
+        get => AppSettings.GetValueOrDefault("FileSystemLogLocation", null);
+        set => AppSettings.AddOrUpdateValue("FileSystemLogLocation", value);
+    }
+
     public static string LocalFileSystemLocation 
     {
         get => AppSettings.GetValueOrDefault("LocalFileSystemLocation", Path.Combine(Environment.GetFolderPath(Environment.SpecialFolder.ApplicationData), "rdmp")); 

--- a/Rdmp.UI/SimpleDialogs/UserSettingsUI.Designer.cs
+++ b/Rdmp.UI/SimpleDialogs/UserSettingsUI.Designer.cs
@@ -75,6 +75,7 @@
             groupBox6 = new System.Windows.Forms.GroupBox();
             cbSkipCohortBuilderValidationOnCommit = new System.Windows.Forms.CheckBox();
             groupBox7 = new System.Windows.Forms.GroupBox();
+            cbUseLogFiles = new System.Windows.Forms.CheckBox();
             label15 = new System.Windows.Forms.Label();
             tbLocalFileSystemLocation = new System.Windows.Forms.TextBox();
             cbUseLocalFileSystem = new System.Windows.Forms.CheckBox();
@@ -91,6 +92,8 @@
             userSettingsToolTips = new System.Windows.Forms.ToolTip(components);
             tbFind = new System.Windows.Forms.TextBox();
             label14 = new System.Windows.Forms.Label();
+            tbLogLocation = new System.Windows.Forms.TextBox();
+            label16 = new System.Windows.Forms.Label();
             groupBox1.SuspendLayout();
             ((System.ComponentModel.ISupportInitialize)olvErrorCodes).BeginInit();
             groupBox2.SuspendLayout();
@@ -331,7 +334,7 @@
             // 
             groupBox1.Anchor = System.Windows.Forms.AnchorStyles.None;
             groupBox1.Controls.Add(olvErrorCodes);
-            groupBox1.Location = new System.Drawing.Point(3, 445);
+            groupBox1.Location = new System.Drawing.Point(3, 478);
             groupBox1.Name = "groupBox1";
             groupBox1.Size = new System.Drawing.Size(978, 249);
             groupBox1.TabIndex = 16;
@@ -514,7 +517,7 @@
             flowLayoutPanel1.Controls.Add(groupBox1);
             flowLayoutPanel1.Location = new System.Drawing.Point(13, 69);
             flowLayoutPanel1.Name = "flowLayoutPanel1";
-            flowLayoutPanel1.Size = new System.Drawing.Size(987, 671);
+            flowLayoutPanel1.Size = new System.Drawing.Size(1012, 671);
             flowLayoutPanel1.TabIndex = 24;
             // 
             // groupBox8
@@ -573,6 +576,9 @@
             // 
             // groupBox7
             // 
+            groupBox7.Controls.Add(label16);
+            groupBox7.Controls.Add(tbLogLocation);
+            groupBox7.Controls.Add(cbUseLogFiles);
             groupBox7.Controls.Add(label15);
             groupBox7.Controls.Add(tbLocalFileSystemLocation);
             groupBox7.Controls.Add(cbUseLocalFileSystem);
@@ -593,10 +599,20 @@
             groupBox7.Controls.Add(cbAlwaysJoinEverything);
             groupBox7.Location = new System.Drawing.Point(615, 174);
             groupBox7.Name = "groupBox7";
-            groupBox7.Size = new System.Drawing.Size(360, 265);
+            groupBox7.Size = new System.Drawing.Size(360, 298);
             groupBox7.TabIndex = 25;
             groupBox7.TabStop = false;
             groupBox7.Text = "Miscellaneous";
+            // 
+            // cbUseLogFiles
+            // 
+            cbUseLogFiles.AutoSize = true;
+            cbUseLogFiles.Location = new System.Drawing.Point(7, 257);
+            cbUseLogFiles.Name = "cbUseLogFiles";
+            cbUseLogFiles.Size = new System.Drawing.Size(94, 19);
+            cbUseLogFiles.TabIndex = 29;
+            cbUseLogFiles.Text = "Use Log Files";
+            cbUseLogFiles.UseVisualStyleBackColor = true;
             // 
             // label15
             // 
@@ -732,7 +748,7 @@
             // tbFind
             // 
             tbFind.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
-            tbFind.Location = new System.Drawing.Point(900, 13);
+            tbFind.Location = new System.Drawing.Point(925, 13);
             tbFind.Name = "tbFind";
             tbFind.Size = new System.Drawing.Size(100, 23);
             tbFind.TabIndex = 25;
@@ -742,17 +758,35 @@
             // 
             label14.Anchor = System.Windows.Forms.AnchorStyles.Top | System.Windows.Forms.AnchorStyles.Right;
             label14.AutoSize = true;
-            label14.Location = new System.Drawing.Point(821, 16);
+            label14.Location = new System.Drawing.Point(846, 16);
             label14.Name = "label14";
             label14.Size = new System.Drawing.Size(73, 15);
             label14.TabIndex = 26;
             label14.Text = "Find Setting:";
             // 
+            // tbLogLocation
+            // 
+            tbLogLocation.Location = new System.Drawing.Point(156, 257);
+            tbLogLocation.Name = "tbLogLocation";
+            tbLogLocation.Size = new System.Drawing.Size(110, 23);
+            tbLogLocation.TabIndex = 30;
+            tbLogLocation.TextChanged += tbLogLocation_TextChanged;
+            // 
+            // label16
+            // 
+            label16.AutoSize = true;
+            label16.Location = new System.Drawing.Point(273, 261);
+            label16.Name = "label16";
+            label16.Size = new System.Drawing.Size(53, 15);
+            label16.TabIndex = 31;
+            label16.Text = "Location";
+            label16.Click += label16_Click;
+            // 
             // UserSettingsFileUI
             // 
             AutoScaleDimensions = new System.Drawing.SizeF(7F, 15F);
             AutoScaleMode = System.Windows.Forms.AutoScaleMode.Font;
-            ClientSize = new System.Drawing.Size(1012, 758);
+            ClientSize = new System.Drawing.Size(1037, 758);
             Controls.Add(label14);
             Controls.Add(btnClearUserSettings);
             Controls.Add(tbFind);
@@ -850,5 +884,8 @@
         private System.Windows.Forms.Label label15;
         private System.Windows.Forms.TextBox tbLocalFileSystemLocation;
         private System.Windows.Forms.CheckBox cbUseLocalFileSystem;
+        private System.Windows.Forms.CheckBox cbUseLogFiles;
+        private System.Windows.Forms.Label label16;
+        private System.Windows.Forms.TextBox tbLogLocation;
     }
 }

--- a/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
+++ b/Rdmp.UI/SimpleDialogs/UserSettingsUI.cs
@@ -106,6 +106,7 @@ public partial class UserSettingsFileUI : Form
         RegisterCheckbox(cbUseAliasInsteadOfTransformInGroupByAggregateGraphs,
             nameof(UserSettings.UseAliasInsteadOfTransformInGroupByAggregateGraphs));
         RegisterCheckbox(cbUseLocalFileSystem, nameof(UserSettings.UseLocalFileSystem));
+        RegisterCheckbox(cbUseLogFiles, nameof(UserSettings.LogToFileSystem));
         AddTooltip(label7, nameof(UserSettings.CreateDatabaseTimeout));
         AddTooltip(tbCreateDatabaseTimeout, nameof(UserSettings.CreateDatabaseTimeout));
         AddTooltip(label13, nameof(UserSettings.ArchiveTriggerTimeout));
@@ -139,6 +140,8 @@ public partial class UserSettingsFileUI : Form
         ddWordWrap.SelectedItem = (WrapMode)UserSettings.WrapMode;
 
         tbHeatmapColours.Text = UserSettings.HeatMapColours;
+        tbLocalFileSystemLocation.Text = UserSettings.LocalFileSystemLocation;
+        tbLogLocation.Text = UserSettings.FileSystemLogLocation;
 
         _bLoaded = true;
 
@@ -250,6 +253,11 @@ public partial class UserSettingsFileUI : Form
         UserSettings.LocalFileSystemLocation = tbLocalFileSystemLocation.Text;
     }
 
+    private void tbLogLocation_TextChanged(object sender, EventArgs e)
+    {
+        UserSettings.FileSystemLogLocation = tbLogLocation.Text;    
+    }
+
     private void tbTooltipAppearDelay_TextChanged(object sender, EventArgs e)
     {
         if (int.TryParse(tbTooltipAppearDelay.Text, out var result)) UserSettings.TooltipAppearDelay = result;
@@ -266,5 +274,10 @@ public partial class UserSettingsFileUI : Form
             cb.Key.Visible = string.IsNullOrWhiteSpace(text) ||
                              cb.Key.Text.Contains(text, StringComparison.CurrentCultureIgnoreCase) ||
                              cb.Value.Name.Contains(text, StringComparison.CurrentCultureIgnoreCase);
+    }
+
+    private void label16_Click(object sender, EventArgs e)
+    {
+
     }
 }

--- a/Rdmp.UI/SimpleDialogs/UserSettingsUI.resx
+++ b/Rdmp.UI/SimpleDialogs/UserSettingsUI.resx
@@ -120,4 +120,7 @@
   <metadata name="userSettingsToolTips.TrayLocation" type="System.Drawing.Point, System.Drawing, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b03f5f7f11d50a3a">
     <value>17, 17</value>
   </metadata>
+  <metadata name="$this.TrayHeight" type="System.Int32, mscorlib, Version=4.0.0.0, Culture=neutral, PublicKeyToken=b77a5c561934e089">
+    <value>25</value>
+  </metadata>
 </root>

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -10,6 +10,6 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("8.1.3")]
-[assembly: AssemblyFileVersion("8.1.3")]
-[assembly: AssemblyInformationalVersion("8.1.3")]
+[assembly: AssemblyVersion("8.1.4")]
+[assembly: AssemblyFileVersion("8.1.4")]
+[assembly: AssemblyInformationalVersion("8.1.4-rc1")]


### PR DESCRIPTION
Experimental feature that user settings option to log to file rather than database.

There is a suspicion that long extractions are slowed by the progress log getting stuck waiting for write access.
The current thinking is that bypassing this and writing directly to file should speed this up
