### PR TITLE
Task/RDMP-136 Force Wide Form Focus

### DIFF
--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
@@ -202,6 +202,7 @@ public partial class WideMessageBox : Form
             wmb.ShowDialog();
         else
             wmb.Show();
+        wmb.Focus();
     }
 
     public static void Show(string title, string message, WideMessageBoxTheme theme)


### PR DESCRIPTION
There was an issue where the wide notification form would not be rendered if the user had an alternative focus when RDMP attempted to render the form. Calling focus on the form forces it to be become the focused item within RDMP and be rendered correctly