### PR TITLE
Fix vanishing menu

### DIFF
--- a/Tools/rdmp/CommandLine/Gui/ConsoleMainWindow.cs
+++ b/Tools/rdmp/CommandLine/Gui/ConsoleMainWindow.cs
@@ -157,12 +157,13 @@ internal class ConsoleMainWindow
 
         Application.RootMouseEvent = OnRootMouseEvent;
 
+
+
+
         _treeView.ObjectActivationButton = _rightClick;
-        _treeView.ObjectActivated += _treeView_ObjectActivated;
         _treeView.KeyPress += treeView_KeyPress;
         _treeView.SelectionChanged += _treeView_SelectionChanged;
         _treeView.AspectGetter = AspectGetter;
-
         var statusBar = new StatusBar(new StatusItem[]
         {
             new(Key.Q | Key.CtrlMask, "~^Q~ Quit", () => Quit()),
@@ -363,6 +364,10 @@ internal class ConsoleMainWindow
         {
             switch (obj.KeyEvent.Key)
             {
+                case Key.Enter:
+                    _treeView_ObjectActivated(null);
+                    obj.Handled = true;
+                    break;
                 case Key.DeleteChar:
                     var many = _treeView.GetAllSelectedObjects().ToArray();
                     obj.Handled = true;


### PR DESCRIPTION
Fixes #1745

Looks like Terminal.Gui object activation event does fire but possibly the Key.Enter is somehow not marked internal or theres something odd about the way the menu interacts with that bit of the code.

Anyway this workaround is just to switch to the key press event instead.