### PR TITLE
RDMP-149: External Database Command Settings Saved

### DIFF
--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewExternalDatabaseServer.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewExternalDatabaseServer.cs
@@ -90,8 +90,11 @@ public class ExecuteCommandCreateNewExternalDatabaseServer : BasicCommandExecuti
 
         //user wants to create a new server e.g. a new Logging server
         if (_patcher == null)
+        {
             ServerCreatedIfAny = new ExternalDatabaseServer(BasicActivator.RepositoryLocator.CatalogueRepository,
                 $"New ExternalDatabaseServer {Guid.NewGuid()}", _patcher);
+            ServerCreatedIfAny.SetProperties(_database);
+        }
         else
             //create the new server
             ServerCreatedIfAny = BasicActivator.CreateNewPlatformDatabase(


### PR DESCRIPTION
Issue: running the command 
```
/imaging/bin/rdmp/rdmp createnewexternaldatabaseserver None "DatabaseType:MySQL:Server=127.0.0.1;Uid=smi;Pwd=SmiSqlPassword;Database=smi_isolation" --dir /imaging/conf/rdmp
```
Results in the YAML is:
```
Name: New ExternalDatabaseServer 0156c15a-4621-4452-bcbb-1ba87f17c2a9
CreatedByAssembly:
MappedDataPath:
Server:
Database:
Username:
Password:
DatabaseType: MicrosoftSQLServer
ID: 2
```
Running the same command with this updates results in 
```
Name: New ExternalDatabaseServer 208e0a74-93cd-418c-bc81-1a51af53c0cc
CreatedByAssembly: 
MappedDataPath: 
Server: 127.0.0.1
Database: smi_isolation
Username: smi
Password: <Redacted>
DatabaseType: MySql
ID: 3

```