### PR TITLE
Task/RDMP-154 Cohort Importer respects remote server ID

### DIFF
--- a/Rdmp.Core/CommandExecution/AtomicCommands/CohortCreationCommands/ExecuteCommandImportAlreadyExistingCohort.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/CohortCreationCommands/ExecuteCommandImportAlreadyExistingCohort.cs
@@ -61,9 +61,10 @@ public class ExecuteCommandImportAlreadyExistingCohort : BasicCommandExecution, 
         // the cohorts in the database
         var available = ExtractableCohort.GetImportableCohortDefinitions(ect).Where(c => c.ID.HasValue).ToArray();
 
+
         // the ones we already know about
         var existing = new HashSet<int>(BasicActivator.RepositoryLocator.DataExportRepository
-            .GetAllObjects<ExtractableCohort>().Select(c => c.OriginID));
+            .GetAllObjects<ExtractableCohort>().Where(c => c.ExternalCohortTable_ID == ect.ID).Select(c => c.OriginID));
 
         // new ones we don't know about yet
         available = available.Where(c => !existing.Contains(c.ID.Value)).ToArray();

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewExternalDatabaseServer.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCreateNewExternalDatabaseServer.cs
@@ -93,7 +93,8 @@ public class ExecuteCommandCreateNewExternalDatabaseServer : BasicCommandExecuti
         {
             ServerCreatedIfAny = new ExternalDatabaseServer(BasicActivator.RepositoryLocator.CatalogueRepository,
                 $"New ExternalDatabaseServer {Guid.NewGuid()}", _patcher);
-            ServerCreatedIfAny.SetProperties(_database);
+            if(_database is not null)
+                ServerCreatedIfAny.SetProperties(_database);
         }
         else
             //create the new server


### PR DESCRIPTION
DLS ran into an issue when trying to import cohort:ID=1 from a remote cohort database when internal cohort:ID=1 already exists.
This fix allows for new cohorts from remote databases to be imported despite the ID clash with internal cohorts by updating the filter to match on ID and source database