### PR TITLE
Allow for multiple identifiers in an project catalogue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Extractions now remember the last used pipeline
 - Allow for custom .bak file physical locations during data loads
 - Add ability to have multiple data loads for a single catalogue
+- Allow for Project Specific Catalogues to have multiple extraction identifiers
 
 
 ## [8.1.4] - 2024-02-19

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMakeCatalogueProjectSpecific.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMakeCatalogueProjectSpecific.cs
@@ -112,8 +112,8 @@ public class ExecuteCommandMakeCatalogueProjectSpecific : BasicCommandExecution,
         if (!ei.Any())
             SetImpossible("Catalogue has no extractable columns");
 
-        if (ei.Count(e => e.IsExtractionIdentifier) != 1)
-            SetImpossible("Catalogue must have exactly 1 IsExtractionIdentifier column");
+        if (ei.Count(e => e.IsExtractionIdentifier) < 1)
+            SetImpossible("Catalogue must have at least 1 IsExtractionIdentifier column");
 
         if (ei.Any(e =>
                 e.ExtractionCategory != ExtractionCategory.Core &&


### PR DESCRIPTION
When attempting to convert a catalogue to a project specific catalogue, it is not possible if there are multiple extraction identifiers.
Currently, If you have a project specific catalogue, you can add any number of identifiers.
This is clearly an oversight in the logic check.

Fix allows for catalogue -> project specific conversion as long as there are more than zero identifiers