### PR TITLE
Task/RDMP-160 Fix Bad Logic Check

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Allow for custom .bak file physical locations during data loads
 - Add ability to have multiple data loads for a single catalogue
 - Allow for Project Specific Catalogues to have multiple extraction identifiers
+- Allow for Catalogues with Non-Core extraction categories to be made Project specific
 
 
 ## [8.1.4] - 2024-02-19

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMakeCatalogueProjectSpecific.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMakeCatalogueProjectSpecific.cs
@@ -59,7 +59,7 @@ public class ExecuteCommandMakeCatalogueProjectSpecific : BasicCommandExecution,
                 $"Cannot make {_catalogue} Project Specific because it is already a part of ExtractionConfiguration {alreadyInConfiguration} (Project={alreadyInConfiguration.Project}) and possibly others");
 
         eds.Project_ID = _project.ID;
-        foreach (var ei in _catalogue.GetAllExtractionInformation(ExtractionCategory.Any))
+        foreach (var ei in _catalogue.GetAllExtractionInformation(ExtractionCategory.Any).Where(ei => ei.ExtractionCategory is ExtractionCategory.Core))
         {
             ei.ExtractionCategory = ExtractionCategory.ProjectSpecific;
             ei.SaveToDatabase();

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMakeCatalogueProjectSpecific.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandMakeCatalogueProjectSpecific.cs
@@ -115,9 +115,5 @@ public class ExecuteCommandMakeCatalogueProjectSpecific : BasicCommandExecution,
         if (ei.Count(e => e.IsExtractionIdentifier) < 1)
             SetImpossible("Catalogue must have at least 1 IsExtractionIdentifier column");
 
-        if (ei.Any(e =>
-                e.ExtractionCategory != ExtractionCategory.Core &&
-                e.ExtractionCategory != ExtractionCategory.ProjectSpecific))
-            SetImpossible("All existing ExtractionInformations must be ExtractionCategory.Core");
     }
 }


### PR DESCRIPTION
When attempting to convert a catalogue to project specific, it would be denied if there was a non-core extraction column.
However, a project specific catalogue could have its column set to any extraction type.
This fix removes the restriction on converting catalogues -> project specific catalogues when they have non-core extraction columns

To Test:
* set a column type to supplementary
* attempt to convert the catalogue to project specific