### PR TITLE
Task/RDMP-161 Add ability to mark as not extractable

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,8 +1,14 @@
-# Changelog
+hared# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [8.1.6] - Unreleased
+
+## Changed
+
+- Add ability to set Extraction Categort as "Not Extractable"
 
 ## [8.1.5] - 2024-04-03
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,4 +1,4 @@
-hared# Changelog
+# Changelog
 All notable changes to this project will be documented in this file.
 
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandChangeExtractionCategory.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandChangeExtractionCategory.cs
@@ -69,17 +69,25 @@ public sealed class ExecuteCommandChangeExtractionCategory : BasicCommandExecuti
             Show("Cannot set the Extraction Category to 'Core' for a  Project Specific Catalogue item. It will be saved as 'Project Specific'.");
         }
 
-        if (ExecuteWithCommit(() => ExecuteImpl(c.Value), $"Set ExtractionCategory to '{c}'", _extractionInformations))
+        if (ExecuteWithCommit(() => ExecuteImpl(c.Value), c == ExtractionCategory.NotExtractable ? "Make Not Extractable" : $"Set ExtractionCategory to '{c}'", _extractionInformations))
             //publish the root Catalogue
             Publish(_extractionInformations.First());
     }
 
     private void ExecuteImpl(ExtractionCategory category)
     {
+
         foreach (var ei in _extractionInformations)
         {
-            ei.ExtractionCategory = category;
-            ei.SaveToDatabase();
+            if (category == ExtractionCategory.NotExtractable)
+            {
+                ei.DeleteInDatabase();
+            }
+            else
+            {
+                ei.ExtractionCategory = category;
+                ei.SaveToDatabase();
+            }
         }
     }
 }

--- a/Rdmp.Core/Curation/Data/ExtractionCategory.cs
+++ b/Rdmp.Core/Curation/Data/ExtractionCategory.cs
@@ -47,5 +47,8 @@ public enum ExtractionCategory
     /// </summary>
     Any,
 
+    /// <summary>
+    /// Value used for improved UI experience, will be set to null when executed
+    /// </summary>
     NotExtractable
 }

--- a/Rdmp.Core/Curation/Data/ExtractionCategory.cs
+++ b/Rdmp.Core/Curation/Data/ExtractionCategory.cs
@@ -45,5 +45,7 @@ public enum ExtractionCategory
     /// <summary>
     /// Value can only be used for fetching ExtractionInformations.  This means that all will be returned.  You cannot set a column to have an ExtractionCategory of Any
     /// </summary>
-    Any
+    Any,
+
+    NotExtractable
 }

--- a/Rdmp.Core/Icons/IconProvision/StateBasedIconProviders/ExtractionInformationStateBasedIconProvider.cs
+++ b/Rdmp.Core/Icons/IconProvision/StateBasedIconProviders/ExtractionInformationStateBasedIconProvider.cs
@@ -35,6 +35,8 @@ internal sealed class ExtractionInformationStateBasedIconProvider : IObjectState
 
     private static readonly Image<Rgba32> NoIconAvailable = Image.Load<Rgba32>(CatalogueIcons.NoIconAvailable);
 
+    private static readonly Image<Rgba32> ExtractionInformationNotExtractable = IconOverlayProvider.GetOverlayNoCache(ExtractionInformationCore, OverlayKind.Delete);
+
     public Image<Rgba32> GetImageIfSupportedObject(object o)
     {
         if (o is ExtractionCategory cat)
@@ -67,6 +69,7 @@ internal sealed class ExtractionInformationStateBasedIconProvider : IObjectState
             ExtractionCategory.Deprecated => ExtractionInformationDeprecated,
             ExtractionCategory.ProjectSpecific => ExtractionInformationProjectSpecific,
             ExtractionCategory.Any => NoIconAvailable,
+            ExtractionCategory.NotExtractable => ExtractionInformationNotExtractable,
             _ => throw new ArgumentOutOfRangeException(nameof(category))
         };
     }

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -10,6 +10,6 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("8.1.5")]
-[assembly: AssemblyFileVersion("8.1.5")]
-[assembly: AssemblyInformationalVersion("8.1.5")]
+[assembly: AssemblyVersion("8.1.6")]
+[assembly: AssemblyFileVersion("8.1.6")]
+[assembly: AssemblyInformationalVersion("8.1.6-rc1")]

--- a/directory.build.props
+++ b/directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>11.0</LangVersion>
-    <Version>8.1.5</Version>
+    <Version>8.1.6</Version>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
Adds ability to mark Catalogue column as not extractable.
Functionality already exists, but is a bit circuitous as it required deleting the ExtractionCategory within the Catalogue Column

This update adds the "Not Extractable" ExtractionCategory type, which under the hood just nullifies the ExtractionCategory . This provides the same functionality as the existing method, but with a nicer user experience

As we are actually deleting the ExtractionCategory under the hood, we don't need to worry about these items appearing in extraction configurations

To Test:
Set the extraction category of a catalogue column to "Not extractable"
It will appear in a "Non extractable" folder within the catalogue