### PR TITLE
Task/RDMP-164 Fix Plugin Dependency Issue

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.6] = Unreleased
+
+## Changed
+
+- Add Microsoft.Bcl.AsyncInterfaces 6.0.0 for plugin dependancy tree
+
 ## [8.1.5] - 2024-04-03
 
 ## Changed

--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,5 +38,6 @@
 		<PackageVersion Include="NSubstitute" Version="5.1.0"/>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.2"/>
+		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 	</ItemGroup>
 </Project>

--- a/Documentation/CodeTutorials/Packages.md
+++ b/Documentation/CodeTutorials/Packages.md
@@ -40,4 +40,5 @@
 | Autoupdater.NET.Official | [GitHub](https://github.com/ravibpatel/AutoUpdater.NET) | MIT | Manages updating of the RDMP windows client directly from the RDMP GitHub Releases|
 | ConsoleControl | [GitHub](https://github.com/dwmkerr/consolecontrol)  | MIT | Runs RDMP cli subprocesses|
 | Terminal.Gui                            | [GitHub](https://github.com/gui-cs/Terminal.Gui)                           | [MIT](https://opensource.org/licenses/MIT)                                                     | Console user-interface|
+| Microsoft.Bcl.AsyncInterfaces | [GitHub](https://github.com/dotnet/runtime) |[MIT](https://opensource.org/licenses/MIT)  | |
 [DBMS]: ./Glossary.md#DBMS

--- a/Rdmp.Core/Rdmp.Core.csproj
+++ b/Rdmp.Core/Rdmp.Core.csproj
@@ -321,6 +321,7 @@
 		<PackageReference Include="SSH.NET" />
 		<PackageReference Include="Terminal.Gui" />
 		<PackageReference Include="YamlDotNet" />
+		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Curation\KeywordHelp.txt">


### PR DESCRIPTION
There is an issue with the RDMPDicom plugin where it is expecting Microsoft.Bcl.AsyncInterfaces to exist upstream within RDMP.
This stems from the fo-dicom dependency, and is suspected to be because of some .net8 compatibility issue.

Adding the package here resolves this issue, and can be revisited once fo-dicom fully support .net8 without this issue