### PR TITLE
Fix bcl.AsyncInterfaces issue in plugins

### DIFF
--- a/Directory.Packages.props
+++ b/Directory.Packages.props
@@ -38,6 +38,5 @@
 		<PackageVersion Include="NSubstitute" Version="5.1.0"/>
 		<PackageVersion Include="Microsoft.NET.Test.Sdk" Version="17.9.0"/>
 		<PackageVersion Include="coverlet.collector" Version="6.0.2"/>
-		<PackageVersion Include="Microsoft.Bcl.AsyncInterfaces" Version="6.0.0" />
 	</ItemGroup>
 </Project>

--- a/Rdmp.Core/Curation/Data/SafeDirectoryCatalog.cs
+++ b/Rdmp.Core/Curation/Data/SafeDirectoryCatalog.cs
@@ -98,7 +98,6 @@ public static class SafeDirectoryCatalog
         "libarchive.net.dll",
         "mapsdirectlytodatabasetable.dll",
         "mathnet.numerics.dll",
-        "microsoft.bcl.asyncinterfaces.dll",
         "microsoft.csharp.dll",
         "microsoft.data.sqlclient.dll",
         "microsoft.data.sqlclient.sni.dll",

--- a/Rdmp.Core/Rdmp.Core.csproj
+++ b/Rdmp.Core/Rdmp.Core.csproj
@@ -321,7 +321,6 @@
 		<PackageReference Include="SSH.NET" />
 		<PackageReference Include="Terminal.Gui" />
 		<PackageReference Include="YamlDotNet" />
-		<PackageReference Include="Microsoft.Bcl.AsyncInterfaces"/>
 	</ItemGroup>
 	<ItemGroup>
 		<EmbeddedResource Include="Curation\KeywordHelp.txt">


### PR DESCRIPTION
## Proposed Change

The file Microsoft.Bcl.AsyncInterfaces used to be bundled with RDMP itself due to a different dependency, so was being stripped out of plugin packages. It's no longer included, so shouldn't be stripped out of plugins any more.

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [ ] Created or updated any tests if relevant
-   [ ] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [ ] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [ ] Have added an entry into the changelog
