### PR TITLE
Bugfix/rdmp 185 table import check fail

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.1.7] - Unreleased
+
+## Changed
+
+- Fix issue with non-default named PostgreSQL Table Info not being checkable
+
 ## [8.1.6] - Unreleased
 
 ## Changed

--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -499,7 +499,7 @@ public class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<C
     /// <inheritdoc/>
     public LoadMetadata[] LoadMetadatas()
     {
-        var loadMetadataLinkIDs = Repository.GetAllObjectsWhere<LoadMetadataCatalogueLinkage>("CatalogueID",ID).Select(l => l.LoadMetadataID);
+        var loadMetadataLinkIDs = Repository.GetAllObjectsWhere<LoadMetadataCatalogueLinkage>("CatalogueID", ID).Select(l => l.LoadMetadataID);
 
         return Repository.GetAllObjects<LoadMetadata>().Where(cat => loadMetadataLinkIDs.Contains(cat.ID)).ToArray();
     }
@@ -511,7 +511,7 @@ public class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<C
 
     /// <inheritdoc/>
     [NoMappingToDatabase]
-     public ExternalDatabaseServer LiveLoggingServer =>
+    public ExternalDatabaseServer LiveLoggingServer =>
        LiveLoggingServer_ID == null
                    ? null
                    : Repository.GetObjectByID<ExternalDatabaseServer>((int)LiveLoggingServer_ID);
@@ -893,8 +893,8 @@ public class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<C
 
             try
             {
-                var server = DataAccessPortal.ExpectDistinctServer(tables, accessContext, true);//can just set this to true....has been like this for 7 years
-                //server.Builder.Add("Database", "smi"); //the issue is that we don't provide a database, so fansisql assumes the default
+                var setInitialDatabase = tables.Where(t => t.Database != null).Any();
+                var server = DataAccessPortal.ExpectDistinctServer(tables, accessContext, setInitialDatabase);
                 using var con = server.GetConnection();
                 con.Open();
 

--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -893,8 +893,8 @@ public class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<C
 
             try
             {
-                var server = DataAccessPortal.ExpectDistinctServer(tables, accessContext, false);
-
+                var server = DataAccessPortal.ExpectDistinctServer(tables, accessContext, true);//can just set this to true....has been like this for 7 years
+                //server.Builder.Add("Database", "smi"); //the issue is that we don't provide a database, so fansisql assumes the default
                 using var con = server.GetConnection();
                 con.Open();
 

--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -893,7 +893,7 @@ public class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<C
 
             try
             {
-                var setInitialDatabase = tables.Where(t => t.Database != null).Any();
+                var setInitialDatabase = tables.Any(static t => t.Database != null);
                 var server = DataAccessPortal.ExpectDistinctServer(tables, accessContext, setInitialDatabase);
                 using var con = server.GetConnection();
                 con.Open();

--- a/SharedAssemblyInfo.cs
+++ b/SharedAssemblyInfo.cs
@@ -10,6 +10,6 @@ using System.Reflection;
 [assembly: AssemblyTrademark("")]
 [assembly: AssemblyCulture("")]
 
-[assembly: AssemblyVersion("8.1.6")]
-[assembly: AssemblyFileVersion("8.1.6")]
-[assembly: AssemblyInformationalVersion("8.1.6-rc1")]
+[assembly: AssemblyVersion("8.1.7")]
+[assembly: AssemblyFileVersion("8.1.7")]
+[assembly: AssemblyInformationalVersion("8.1.7")]

--- a/directory.build.props
+++ b/directory.build.props
@@ -1,7 +1,7 @@
 <Project>
   <PropertyGroup>
     <LangVersion>11.0</LangVersion>
-    <Version>8.1.6</Version>
+    <Version>8.1.7</Version>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
   </PropertyGroup>
 </Project>


### PR DESCRIPTION
## Proposed Change

Fixes the issue raised in https://github.com/HicServices/RDMP/issues/1834
When checking a catalogue, we don't specify the tableInfo database name when creating the connection to the database.
This change checks if the tableInfo had a known database, if true it will use the known database, otherwise will use the db servers default database

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Created or updated any tests if relevant
-   [x] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [x] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [x] Have added an entry into the changelog
