### PR TITLE
Make Cohort Version Dropdown Options Longer

### DIFF
--- a/Rdmp.UI/LocationsMenu/Versioning/VersioningControlUI.Designer.cs
+++ b/Rdmp.UI/LocationsMenu/Versioning/VersioningControlUI.Designer.cs
@@ -1,12 +1,15 @@
-﻿using Rdmp.Core.CommandExecution.AtomicCommands;
+﻿using NPOI.OpenXmlFormats.Spreadsheet;
+using Rdmp.Core.CommandExecution.AtomicCommands;
 using Rdmp.Core.Curation.Data.Cohort;
 using Rdmp.UI.ChecksUI;
 using Rdmp.UI.ItemActivation;
 using Rdmp.UI.SimpleDialogs;
 using Rdmp.UI.SubComponents;
 using System;
+using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
+using Terminal.Gui;
 using static Azure.Core.HttpHeader;
 
 namespace Rdmp.UI.LocationsMenu.Versioning
@@ -80,7 +83,7 @@ namespace Rdmp.UI.LocationsMenu.Versioning
             tbTicket.Size = new System.Drawing.Size(187, 23);
             tbTicket.TabIndex = 30;
             tbTicket.SelectionChangeCommitted += VersionChange;
-            //tbTicket.TextChanged += tbTicket_TextChanged;
+            tbTicket.MouseHover += tbTicket_MouseOver;
             // 
             // label6
             // 
@@ -115,6 +118,21 @@ namespace Rdmp.UI.LocationsMenu.Versioning
             }
         }
 
+        private void tbTicket_MouseOver(object sender, EventArgs e)
+        {
+            ToolTip buttonToolTip = new ToolTip();
+            buttonToolTip.ToolTipTitle = "Value";
+            buttonToolTip.UseFading = true;
+            buttonToolTip.UseAnimation = true;
+            buttonToolTip.IsBalloon = true;
+            buttonToolTip.ShowAlways = true;
+            buttonToolTip.AutoPopDelay = 5000;
+            buttonToolTip.InitialDelay = 1000;
+            buttonToolTip.ReshowDelay = 0;
+
+            buttonToolTip.SetToolTip(tbTicket, tbTicket.Text);
+        }
+
         private void CommitNewVersion(object sender, EventArgs e)
         {
             var versions = _cic.GetVersions();
@@ -132,6 +150,7 @@ namespace Rdmp.UI.LocationsMenu.Versioning
             _cic = databaseObject;
             _activator = activator;
             tbTicket.DropDownStyle = ComboBoxStyle.DropDownList;
+            int cbWidth = (int)tbTicket.DropDownWidth;
             var versions = databaseObject.GetVersions();
             if (!versions.Any() || databaseObject.Version is not null)
             {
@@ -144,6 +163,17 @@ namespace Rdmp.UI.LocationsMenu.Versioning
             }
             versions.Insert(0, databaseObject);
             tbTicket.DataSource = versions;
+            foreach (var version in versions)
+            {
+                var longestItem = CreateGraphics().MeasureString(version.Name, SystemFonts.MessageBoxFont).Width;
+                if (longestItem > cbWidth)
+                {
+                    cbWidth = (int)longestItem + 1;
+                }
+
+            }
+            tbTicket.DropDownWidth = cbWidth;
+
         }
         #endregion
 


### PR DESCRIPTION
## Proposed Change

Make Cohort version dropdown options long enough to fit the option names
Dynamically figures out the correct length required to display the full text

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Created or updated any tests if relevant
-   [x] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [x] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [ ] Have added an entry into the changelog
