### PR TITLE
RDMP-228 Reorder YAML Data Load

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue with whitespace confusing encryption key paths
 - Add ability to add description to new cohort versions
 - Add functionality to revert to historical cohort version
+- Fix issue with YAML mode object load ordering
 
 ## [8.2.1] - 2024-07-18
 

--- a/Rdmp.Core/Repositories/YamlRepository.cs
+++ b/Rdmp.Core/Repositories/YamlRepository.cs
@@ -47,9 +47,7 @@ public class YamlRepository : MemoryDataExportRepository
 
         // Build the serializer
         _serializer = CreateSerializer(GetCompatibleTypes());
-
-        LoadObjects();
-
+        
         if (File.Exists(GetEncryptionKeyPathFile()))
         {
             EncryptionKeyPath = File.ReadLines(GetEncryptionKeyPathFile()).First();
@@ -60,6 +58,8 @@ public class YamlRepository : MemoryDataExportRepository
                 if (File.Exists(trimmed)) EncryptionKeyPath = trimmed;
             }
         }
+        
+        LoadObjects();      
 
         // Don't create new objects with the ID of existing objects
         NextObjectId = Objects.IsEmpty ? 0 : Objects.Max(o => o.Key.ID);


### PR DESCRIPTION
## Proposed Change

Issue raised :https://github.com/HicServices/RDMP/issues/1907
YAML repo was not population the encryption key before trying to decrypt the passwords.
Reordering the object load resolves this issue
## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Created or updated any tests if relevant
-   [x] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [x] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [x] Have added an entry into the changelog
