### PR TITLE
Remove trivial Equ usage

### DIFF
--- a/Application/ResearchDataManagementPlatform/WindowManagement/CollectionNavigation.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/CollectionNavigation.cs
@@ -4,6 +4,8 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+#nullable enable
+using System;
 using FAnsi.Discovery;
 using Rdmp.Core.CommandExecution;
 using Equ;
@@ -14,25 +16,36 @@ namespace ResearchDataManagementPlatform.WindowManagement;
 /// <summary>
 /// Records the fact that the user visited a specific object in a tree collection
 /// </summary>
-public sealed class CollectionNavigation : PropertywiseEquatable<CollectionNavigation>, INavigation
+public sealed class CollectionNavigation : IEquatable<CollectionNavigation>, INavigation
 {
-    public IMapsDirectlyToDatabaseTable Object { get; }
+    private readonly IMapsDirectlyToDatabaseTable _object;
 
-    [MemberwiseEqualityIgnore] public bool IsAlive => Object is not IMightNotExist o || o.Exists();
+    public bool IsAlive => _object is not IMightNotExist o || o.Exists();
 
     public CollectionNavigation(IMapsDirectlyToDatabaseTable @object)
     {
-        Object = @object;
+        _object = @object;
     }
 
     public void Activate(ActivateItems activateItems)
     {
-        activateItems.RequestItemEmphasis(this, new EmphasiseRequest(Object, 0));
+        activateItems.RequestItemEmphasis(this, new EmphasiseRequest(_object, 0));
     }
 
     public void Close()
     {
     }
 
-    public override string ToString() => Object.ToString();
+    public override string? ToString() => _object.ToString();
+
+    public bool Equals(CollectionNavigation? other)
+    {
+        if (other is null) return false;
+
+        return ReferenceEquals(this, other) || Equals(_object, other._object);
+    }
+
+    public override bool Equals(object? obj) => ReferenceEquals(this, obj) || (obj is CollectionNavigation other && Equals(other));
+
+    public override int GetHashCode() => HashCode.Combine(_object);
 }

--- a/Application/ResearchDataManagementPlatform/WindowManagement/CollectionNavigation.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/CollectionNavigation.cs
@@ -8,7 +8,6 @@
 using System;
 using FAnsi.Discovery;
 using Rdmp.Core.CommandExecution;
-using Equ;
 using Rdmp.Core.MapsDirectlyToDatabaseTable;
 
 namespace ResearchDataManagementPlatform.WindowManagement;

--- a/Documentation/CodeTutorials/Packages.md
+++ b/Documentation/CodeTutorials/Packages.md
@@ -7,7 +7,6 @@
 
 | Package | Source Code | License | Purpose | Additional Risk Assessment |
 | ------- | ------------| ------- | ------- | -------------------------- |
-| Equ | [GitHub](https://github.com/thedmi/Equ) | [MIT](https://opensource.org/licenses/MIT) | Simplifies object equality implementation | |
 | FluentFTP | [Github](https://github.com/robinrodricks/FluentFTP/) | [MIT](https://opensource.org/licenses/MIT) | FTP(S) client | |
 | MongoDB.Driver | [GitHub](https://github.com/mongodb/mongo-csharp-driver) | [Apache 2.0](https://opensource.org/licenses/Apache-2.0) | Database driver for MongoDB | |
 | Microsoft.SourceLink.GitHub | [GitHub](https://github.com/dotnet/sourcelink) | [MIT](https://opensource.org/licenses/MIT) | Enable source linkage from nupkg | Official MS project |

--- a/Rdmp.Core/Rdmp.Core.csproj
+++ b/Rdmp.Core/Rdmp.Core.csproj
@@ -314,7 +314,6 @@
 		<PackageReference Include="AWSSDK.SSO" />
 		<PackageReference Include="AWSSDK.SSOOIDC" />
 		<PackageReference Include="CommandLineParser" />
-		<PackageReference Include="Equ" />
 		<PackageReference Include="ExcelNumberFormat" />
 		<PackageReference Include="FluentFTP" />
 		<PackageReference Include="HIC.SynthEHR" />


### PR DESCRIPTION
## Proposed Change

We were importing the entire `Equ` Nuget package just to implement the `.Equals()` method for a single class, which seems a little inefficient...

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Created or updated any tests if relevant
-   [ ] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [x] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [ ] Have added an entry into the changelog
