### PR TITLE
Remove credentials for Postgres test server we do not have

### DIFF
--- a/Tests.Common/TestDatabases.txt
+++ b/Tests.Common/TestDatabases.txt
@@ -11,7 +11,7 @@ ServerName:	(localdb)\MSSQLLocalDB
 #Uncomment to run tests with a YamlRepository
 #UseFileSystemRepo: true
 MySql:	server=127.0.0.1;Uid=root;Pwd=YourStrong!Passw0rd;AllowPublicKeyRetrieval=True
-PostgreSql:	User ID=postgres;Password=;Host=127.0.0.1;Port=5432
+#PostgreSql:	User ID=postgres;Password=;Host=127.0.0.1;Port=5432
 Oracle: 
 #User accounts you can create with limited access rights (e.g. connect list databases etc).  These users will be used in low privilege tests
 #The account will be granted limited read/write access to databases on a per test basis (See DatabaseTests.SetupLowPrivilegeUserRightsFor)


### PR DESCRIPTION
## Proposed Change

Currently CI wastes c 2s per unit test trying to connect to a PostgreSQL server we don't have in CI - commenting out that line cuts about 90s off each test run or 3m of Github hosted runner usage.

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [ ] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [ ] Created or updated any tests if relevant
-   [ ] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [ ] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [ ] Have added an entry into the changelog
