### PR TITLE
Build using .Net 9 SDK rather than 8

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -17,3 +17,7 @@ updates:
     aws-sdk:
       patterns:
         - "AWSSDK.*"
+- package-ecosystem: "dotnet-sdk"
+  directory: "/"
+  schedule:
+    interval: weekly

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -175,14 +175,14 @@ jobs:
       - name: Temporary Bundle of ddls for auto-updater
         shell: bash
         run: |
-          cp -r Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/runtimes ./PublishWinForms
-          cp -r Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/x64 ./PublishWinForms
-          cp Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/D3DCompiler_47_cor3.dll ./PublishWinForms
-          cp Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/PenImc_cor3.dll ./PublishWinForms
-          cp Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/PresentationNative_cor3.dll ./PublishWinForms
-          cp Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/vcruntime140_cor3.dll ./PublishWinForms
-          cp Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/WebView2Loader.dll ./PublishWinForms
-          cp Application/ResearchDataManagementPlatform/bin/Release/net8.0-windows/win-x64/wpfgfx_cor3.dll ./PublishWinForms
+          cp -r Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/runtimes ./PublishWinForms
+          cp -r Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/x64 ./PublishWinForms
+          cp Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/D3DCompiler_47_cor3.dll ./PublishWinForms
+          cp Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/PenImc_cor3.dll ./PublishWinForms
+          cp Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/PresentationNative_cor3.dll ./PublishWinForms
+          cp Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/vcruntime140_cor3.dll ./PublishWinForms
+          cp Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/WebView2Loader.dll ./PublishWinForms
+          cp Application/ResearchDataManagementPlatform/bin/Release/net9.0-windows/win-x64/wpfgfx_cor3.dll ./PublishWinForms
       - name: Install Plugins
         shell: bash
         run: |

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -18,6 +18,8 @@ jobs:
     steps:
       - name: Checkout code
         uses: actions/checkout@v4
+      - name: setup .NET
+        uses: actions/setup-dotnet@v4.1.0
       - name: Populate Databases.yaml
         shell: bash
         run: |

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -25,6 +25,8 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+      - name: setup .NET
+        uses: actions/setup-dotnet@v4.1.0
 
       - name: Initialize CodeQL
         uses: github/codeql-action/init@v3

--- a/Application/ResearchDataManagementPlatform/RDMPMainForm.cs
+++ b/Application/ResearchDataManagementPlatform/RDMPMainForm.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.IO;
 using System.Linq;
@@ -81,7 +82,7 @@ public partial class RDMPMainForm : RDMPForm
         WindowState = FormWindowState.Maximized;
         CloseOnEscape = false;
 
-        if (UserSettings.LicenseAccepted != new License("LIBRARYLICENSES").GetHashOfLicense())
+        if (UserSettings.LicenseAccepted != new WindowManagement.Licenses.License("LIBRARYLICENSES").GetHashOfLicense())
             new LicenseUI().ShowDialog();
     }
 
@@ -163,6 +164,7 @@ public partial class RDMPMainForm : RDMPForm
         Loading = false;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override string Text
     {
         get => base.Text;

--- a/Application/ResearchDataManagementPlatform/ResearchDataManagementPlatform.csproj
+++ b/Application/ResearchDataManagementPlatform/ResearchDataManagementPlatform.csproj
@@ -2,7 +2,7 @@
   <PropertyGroup>
     <ProjectGuid>{550988FD-F1FA-41D8-BE0F-00B4DE47D320}</ProjectGuid>
     <OutputType>WinExe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>$(TargetFramework)-windows</TargetFramework>
     <GenerateDocumentationFile>true</GenerateDocumentationFile>
     <UseWindowsForms>true</UseWindowsForms>
     <EnableWindowsTargeting>true</EnableWindowsTargeting>

--- a/Application/ResearchDataManagementPlatform/Theme/Themes.cs
+++ b/Application/ResearchDataManagementPlatform/Theme/Themes.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System.ComponentModel;
 using System.Globalization;
 using System.Windows.Forms;
 using Rdmp.UI.Theme;
@@ -16,6 +17,8 @@ namespace ResearchDataManagementPlatform.Theme;
 public class MyVS2015BlueTheme : VS2015BlueTheme, ITheme
 {
     private ThemeExtender _extender;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool ApplyThemeToMenus { get; set; }
 
     public MyVS2015BlueTheme()
@@ -40,6 +43,8 @@ public class MyVS2015BlueTheme : VS2015BlueTheme, ITheme
 public class MyVS2015DarkTheme : VS2015DarkTheme, ITheme
 {
     private ThemeExtender _extender;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool ApplyThemeToMenus { get; set; }
 
     public MyVS2015DarkTheme()
@@ -64,6 +69,8 @@ public class MyVS2015DarkTheme : VS2015DarkTheme, ITheme
 public class MyVS2015LightTheme : VS2015LightTheme, ITheme
 {
     private ThemeExtender _extender;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool ApplyThemeToMenus { get; set; }
 
     public MyVS2015LightTheme()

--- a/Application/ResearchDataManagementPlatform/WindowManagement/ContentWindowTracking/Persistence/PersistableSingleDatabaseObjectDockContent.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/ContentWindowTracking/Persistence/PersistableSingleDatabaseObjectDockContent.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.Core.CommandExecution;
 using Rdmp.Core.Curation.Data;
@@ -28,6 +29,7 @@ namespace ResearchDataManagementPlatform.WindowManagement.ContentWindowTracking.
 [TechnicalUI]
 public class PersistableSingleDatabaseObjectDockContent : RDMPSingleControlTab
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IMapsDirectlyToDatabaseTable DatabaseObject { get; private set; }
 
     public const string Prefix = "RDMPSingleDatabaseObjectControl";

--- a/Application/ResearchDataManagementPlatform/WindowManagement/ContentWindowTracking/Persistence/RDMPSingleControlTab.cs
+++ b/Application/ResearchDataManagementPlatform/WindowManagement/ContentWindowTracking/Persistence/RDMPSingleControlTab.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Text;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data.Dashboarding;
@@ -26,6 +27,7 @@ public class RDMPSingleControlTab : DockContent, IRefreshBusSubscriber
     /// <summary>
     /// The control hosted on this tab
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Control Control { get; protected set; }
 
     public const string BasicPrefix = "BASIC";

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [Unreleased]
+
+- Build on and target .Net 9 rather than 8
+
 ## [8.4.0] - Unreleased
 
 - Add Ordering to Filters

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -1,7 +1,9 @@
 <Project>
-  <PropertyGroup>
-    <LangVersion>11.0</LangVersion>
-    <Version>8.3.0</Version>
+	<PropertyGroup>
+		<TargetFramework>net9.0</TargetFramework>
+		<LangVersion>latest</LangVersion>
+		<Version>8.3.0</Version>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
-  </PropertyGroup>
+		<NoWarn>NU1902;NU1903;NU1904;1701;1702;CS1591;NU1701;CA1416</NoWarn>
+	</PropertyGroup>
 </Project>

--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -2,10 +2,6 @@
 	<PropertyGroup>
 		<TargetFramework>net9.0</TargetFramework>
 		<LangVersion>latest</LangVersion>
-		<Version>8.3.0</Version>
-  <PropertyGroup>
-    <LangVersion>11.0</LangVersion>
-    <Version>8.4.1</Version>
 		<ManagePackageVersionsCentrally>true</ManagePackageVersionsCentrally>
 		<NoWarn>NU1902;NU1903;NU1904;1701;1702;CS1591;NU1701;CA1416</NoWarn>
 	</PropertyGroup>

--- a/Rdmp.Core.Tests/Rdmp.Core.Tests.csproj
+++ b/Rdmp.Core.Tests/Rdmp.Core.Tests.csproj
@@ -5,7 +5,6 @@
         <Product>Rdmp.Core.Tests</Product>
         <Copyright>Copyright © 2019</Copyright>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
-        <TargetFramework>net8.0</TargetFramework>
         <DebugType>embedded</DebugType>
         <DebugSymbols>true</DebugSymbols>
     </PropertyGroup>

--- a/Rdmp.Core/Rdmp.Core.csproj
+++ b/Rdmp.Core/Rdmp.Core.csproj
@@ -14,7 +14,6 @@
 		<PackageLicenseExpression>GPL-3.0-or-later</PackageLicenseExpression>
 		<description>Core package for plugin development</description>
 		<copyright>Copyright 2018-2019</copyright>
-		<TargetFramework>net8.0</TargetFramework>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>

--- a/Rdmp.UI.Tests/Rdmp.UI.Tests.csproj
+++ b/Rdmp.UI.Tests/Rdmp.UI.Tests.csproj
@@ -1,14 +1,13 @@
 ﻿<Project Sdk="Microsoft.NET.Sdk">
     <PropertyGroup>
-        <TargetFramework>net8.0-windows</TargetFramework>
+        <TargetFramework>$(TargetFramework)-windows</TargetFramework>
         <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
         <EnableWindowsTargeting>true</EnableWindowsTargeting>
         <DebugType>embedded</DebugType>
         <DebugSymbols>true</DebugSymbols>
-        <NoWarn>NU1701</NoWarn>
 		<SuppressNETCoreSdkPreviewMessage>true</SuppressNETCoreSdkPreviewMessage>
 		<EnableUnsafeBinaryFormatterSerialization>true</EnableUnsafeBinaryFormatterSerialization>
-		<NoWarn>$(NoWarn);SYSLIB0011</NoWarn>
+		<NoWarn>$(NoWarn);NU1701;SYSLIB0011</NoWarn>
 		<GenerateResourceWarnOnBinaryFormatterUse>false</GenerateResourceWarnOnBinaryFormatterUse>
         <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
     </PropertyGroup>

--- a/Rdmp.UI/AggregationUIs/AggregateGraphUI.cs
+++ b/Rdmp.UI/AggregationUIs/AggregateGraphUI.cs
@@ -64,10 +64,13 @@ public partial class AggregateGraphUI : AggregateGraph_Design
     /// the sensible decision is taken e.g. to not try to render.
     /// 
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool Silent { get; set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Scintilla QueryEditor { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public int Timeout
     {
         get => _timeoutControls.Timeout;
@@ -166,8 +169,13 @@ public partial class AggregateGraphUI : AggregateGraph_Design
         llCancel.Visible = false;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Exception Exception { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool Crashed { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool Done { get; private set; }
 
     private Task _loadTask;

--- a/Rdmp.UI/CatalogueSummary/DataQualityReporting/SubComponents/ConsequenceBar.cs
+++ b/Rdmp.UI/CatalogueSummary/DataQualityReporting/SubComponents/ConsequenceBar.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 
@@ -30,12 +31,22 @@ public partial class ConsequenceBar : UserControl
     public static Color HasValuesColor = Color.Black;
     public static Color IsNullColor = Color.LightGray;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public double Correct { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public double Invalid { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public double Missing { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public double Wrong { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public double DBNull { get; set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Label { get; set; }
 
     protected override void OnPaintBackground(PaintEventArgs e)

--- a/Rdmp.UI/CatalogueSummary/DataQualityReporting/SubComponents/DQEPivotCategorySelector.cs
+++ b/Rdmp.UI/CatalogueSummary/DataQualityReporting/SubComponents/DQEPivotCategorySelector.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.Core.DataQualityEngine.Data;
 
@@ -19,6 +20,8 @@ namespace Rdmp.UI.CatalogueSummary.DataQualityReporting.SubComponents;
 public partial class DQEPivotCategorySelector : UserControl
 {
     public event Action PivotCategorySelectionChanged;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string SelectedPivotCategory { get; private set; }
 
     public DQEPivotCategorySelector()

--- a/Rdmp.UI/CatalogueSummary/DataQualityReporting/SubComponents/EvaluationTrackBar.cs
+++ b/Rdmp.UI/CatalogueSummary/DataQualityReporting/SubComponents/EvaluationTrackBar.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -31,6 +32,7 @@ public partial class EvaluationTrackBar : UserControl
     }
 
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Evaluation[] Evaluations
     {
         get => _evaluations;

--- a/Rdmp.UI/CatalogueSummary/LoadEvents/LoadEventsTreeView.cs
+++ b/Rdmp.UI/CatalogueSummary/LoadEvents/LoadEventsTreeView.cs
@@ -38,6 +38,7 @@ namespace Rdmp.UI.CatalogueSummary.LoadEvents;
 /// </summary>
 public partial class LoadEventsTreeView : RDMPUserControl, IObjectCollectionControl
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public LoadEventsTreeViewObjectCollection Collection { get; set; }
 
     private BackgroundWorker _populateLoadHistory = new();

--- a/Rdmp.UI/CatalogueSummary/LoadEvents/ResolveFatalErrors.cs
+++ b/Rdmp.UI/CatalogueSummary/LoadEvents/ResolveFatalErrors.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using Rdmp.Core.Logging;
 using Rdmp.Core.Logging.PastEvents;
@@ -28,6 +29,8 @@ public partial class ResolveFatalErrors : RDMPForm
 {
     private readonly LogManager _logManager;
     private readonly ArchivalFatalError[] _toResolve;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Scintilla Explanation { get; set; }
 
     public ResolveFatalErrors(IActivateItems activator, LogManager logManager, ArchivalFatalError[] toResolve) :

--- a/Rdmp.UI/ChecksUI/ChecksUI.cs
+++ b/Rdmp.UI/ChecksUI/ChecksUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Concurrent;
+using System.ComponentModel;
 using System.Drawing;
 using System.Threading;
 using System.Windows.Forms;
@@ -123,7 +124,10 @@ public partial class ChecksUI : UserControl, ICheckNotifier
             };
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool CheckingInProgress { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowsYesNoToAll { get; set; }
 
     private Timer _timer;

--- a/Rdmp.UI/ChecksUI/RAGSmiley.cs
+++ b/Rdmp.UI/ChecksUI/RAGSmiley.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Threading.Tasks;
@@ -19,6 +20,7 @@ public partial class RAGSmiley : UserControl, IRAGSmiley
 {
     private bool _alwaysShowHandCursor;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AlwaysShowHandCursor
     {
         get => _alwaysShowHandCursor;

--- a/Rdmp.UI/CohortUI/CohortSourceManagement/CreateNewCohortDatabaseWizardUI.cs
+++ b/Rdmp.UI/CohortUI/CohortSourceManagement/CreateNewCohortDatabaseWizardUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.Core.CohortCommitting;
 using Rdmp.Core.DataExport.Data;
@@ -53,9 +54,13 @@ internal partial class CreateNewCohortDatabaseWizardUI : RDMPUserControl
             Activator.RepositoryLocator.DataExportRepository, false);
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public CreateNewCohortDatabaseWizard Wizard { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public PrivateIdentifierPrototype PrivateIdentifierPrototype { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ExternalCohortTable ExternalCohortTableCreatedIfAny { get; private set; }
 
     private void btnDiscoverExtractionIdentifiers_Click(object sender, EventArgs e)

--- a/Rdmp.UI/CohortUI/CreateHoldoutLookup/CreateHoldoutLookupUI.cs
+++ b/Rdmp.UI/CohortUI/CreateHoldoutLookup/CreateHoldoutLookupUI.cs
@@ -6,6 +6,7 @@
 
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.Core.CohortCommitting.Pipeline;
 using Rdmp.Core.CommandExecution;
@@ -26,6 +27,7 @@ public partial class CreateHoldoutLookupUI : RDMPForm
     private readonly CohortIdentificationConfiguration _cic;
 
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string CohortDescription
     {
         get => tbDescription.Text;
@@ -53,6 +55,7 @@ public partial class CreateHoldoutLookupUI : RDMPForm
         });
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public CohortHoldoutLookupRequest Result { get; set; }
 
     private void btnOk_Click(object sender, EventArgs e)

--- a/Rdmp.UI/CohortUI/ImportCustomData/CohortCreationRequestUI.cs
+++ b/Rdmp.UI/CohortUI/ImportCustomData/CohortCreationRequestUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -36,6 +37,8 @@ public partial class CohortCreationRequestUI : RDMPForm
     private readonly IExternalCohortTable _target;
     private IDataExportRepository _repository;
 
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string CohortDescription
     {
         get => tbDescription.Text;
@@ -68,7 +71,10 @@ public partial class CohortCreationRequestUI : RDMPForm
     }
 
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public CohortCreationRequest Result { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IProject Project { get; set; }
 
     private void btnOk_Click(object sender, EventArgs e)

--- a/Rdmp.UI/Collections/RDMPCollectionUI.cs
+++ b/Rdmp.UI/Collections/RDMPCollectionUI.cs
@@ -19,6 +19,7 @@ namespace Rdmp.UI.Collections;
 [TypeDescriptionProvider(typeof(AbstractControlDescriptionProvider<RDMPCollectionUI, UserControl>))]
 public abstract class RDMPCollectionUI : RDMPCollectionUI_Design, IConsultableBeforeClosing
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public RDMPCollectionCommonFunctionality CommonTreeFunctionality { get; private set; }
 
     protected RDMPCollectionUI()

--- a/Rdmp.UI/Collections/SessionCollectionUI.cs
+++ b/Rdmp.UI/Collections/SessionCollectionUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using Rdmp.Core;
@@ -31,7 +32,9 @@ public class SessionCollectionUI : RDMPUserControl, IObjectCollectionControl, IC
     private BrightIdeasSoftware.OLVColumn olvName;
     private bool _firstTime = true;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public SessionCollection Collection { get; private set; }
+
     public RDMPCollectionCommonFunctionality CommonTreeFunctionality { get; } = new();
 
     public SessionCollectionUI()

--- a/Rdmp.UI/DashboardTabs/DashboardableControlHostPanel.cs
+++ b/Rdmp.UI/DashboardTabs/DashboardableControlHostPanel.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data.Dashboarding;
@@ -25,6 +26,8 @@ public partial class DashboardableControlHostPanel : RDMPUserControl
 {
     private readonly DashboardControl _databaseRecord;
     private bool _editMode;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IDashboardableControl HostedControl { get; private set; }
 
     private const float BorderWidth = 5;

--- a/Rdmp.UI/DataLoadUIs/ANOUIs/ANOTableManagement/ColumnInfoToANOTableConverterUI.cs
+++ b/Rdmp.UI/DataLoadUIs/ANOUIs/ANOTableManagement/ColumnInfoToANOTableConverterUI.cs
@@ -63,6 +63,7 @@ public partial class ColumnInfoToANOTableConverterUI : ColumnInfoToANOTableConve
     private ColumnInfo _columnInfo;
     private bool _yesToAll;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ColumnInfo ColumnInfo
     {
         get => _columnInfo;

--- a/Rdmp.UI/DataLoadUIs/CreateNewLoadMetadataUI.cs
+++ b/Rdmp.UI/DataLoadUIs/CreateNewLoadMetadataUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.Curation.Data.DataLoad;
@@ -24,6 +25,8 @@ namespace Rdmp.UI.DataLoadUIs;
 public partial class CreateNewLoadMetadataUI : RDMPForm
 {
     private readonly Catalogue _catalogue;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public LoadMetadata LoadMetadataCreatedIfAny { get; set; }
 
     public CreateNewLoadMetadataUI(Catalogue catalogue, IActivateItems activator) : base(activator)

--- a/Rdmp.UI/DataLoadUIs/LoadMetadataUIs/ChooseLoadFolderUI.cs
+++ b/Rdmp.UI/DataLoadUIs/LoadMetadataUIs/ChooseLoadFolderUI.cs
@@ -13,6 +13,7 @@ using Rdmp.Core.Curation.Data.DataLoad;
 using Rdmp.UI.ItemActivation;
 using Rdmp.UI.SimpleDialogs;
 using Rdmp.UI.TestsAndSetup.ServicePropogation;
+using System.ComponentModel;
 
 namespace Rdmp.UI.DataLoadUIs.LoadMetadataUIs;
 
@@ -34,6 +35,8 @@ public partial class ChooseLoadDirectoryUI : RDMPForm
     /// The users final choice of project directory, also check DialogResult for Ok / Cancel
     /// </summary>
     //public string Result { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public LoadDirectory ResultDirectory { get; private set; }
 
     private Regex _endsWithDataFolder = new(@"[/\\]Data[/\\ ]*$", RegexOptions.IgnoreCase);

--- a/Rdmp.UI/DataLoadUIs/LoadMetadataUIs/LoadDiagram/StateDiscovery/LoadStateUI.cs
+++ b/Rdmp.UI/DataLoadUIs/LoadMetadataUIs/LoadDiagram/StateDiscovery/LoadStateUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using Rdmp.Core.Icons.IconProvision;
@@ -22,6 +23,8 @@ public partial class LoadStateUI : UserControl
     private Bitmap _unknown;
     private Bitmap _noLoadUnderway;
     private Bitmap _executingOrCrashed;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public LoadState State { get; private set; }
 
     public LoadStateUI()

--- a/Rdmp.UI/DataLoadUIs/ModuleUIs/DataFlowSources/ExplicitTypingCollectionUI.cs
+++ b/Rdmp.UI/DataLoadUIs/ModuleUIs/DataFlowSources/ExplicitTypingCollectionUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data.DataLoad;
 using Rdmp.Core.DataLoad.Modules.DataFlowSources;
@@ -25,6 +26,7 @@ namespace Rdmp.UI.DataLoadUIs.ModuleUIs.DataFlowSources;
 /// </summary>
 public partial class ExplicitTypingCollectionUI : Form, ICustomUI<ExplicitTypingCollection>
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ICatalogueRepository CatalogueRepository { get; set; }
 
     public ExplicitTypingCollectionUI()

--- a/Rdmp.UI/DataLoadUIs/ModuleUIs/DataProvider/WebServiceConfigurationUI.cs
+++ b/Rdmp.UI/DataLoadUIs/ModuleUIs/DataProvider/WebServiceConfigurationUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data.DataLoad;
 using Rdmp.Core.DataLoad.Modules.DataProvider;
@@ -19,6 +20,7 @@ namespace Rdmp.UI.DataLoadUIs.ModuleUIs.DataProvider;
 ///</summary>
 public partial class WebServiceConfigurationUI : Form, ICustomUI<WebServiceConfiguration>
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ICatalogueRepository CatalogueRepository { get; set; }
 
     public WebServiceConfigurationUI()

--- a/Rdmp.UI/DataLoadUIs/ModuleUIs/LoadProgressUpdating/DataLoadProgressUpdateInfoUI.cs
+++ b/Rdmp.UI/DataLoadUIs/ModuleUIs/LoadProgressUpdating/DataLoadProgressUpdateInfoUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data.DataLoad;
@@ -35,6 +36,7 @@ public partial class DataLoadProgressUpdateInfoUI : Form, ICustomUI<DataLoadProg
     private const string WarningRAW =
         "(Must return a single date value.  IMPORTANT: Since you are targetting RAW, you MUST only specify table names, do not add a database qualifier e.g. [MyTable] NOT [MyLIVEDb]..[MyTable])";
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Scintilla QueryEditor { get; set; }
 
     public DataLoadProgressUpdateInfoUI()
@@ -46,9 +48,10 @@ public partial class DataLoadProgressUpdateInfoUI : Form, ICustomUI<DataLoadProg
         pSQL.Controls.Add(QueryEditor);
         QueryEditor.TextChanged += QueryEditor_TextChanged;
 
-        ddStrategy.DataSource = Enum.GetValues(typeof(DataLoadProgressUpdateStrategy));
+        ddStrategy.DataSource = Enum.GetValues<DataLoadProgressUpdateStrategy>();
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ICatalogueRepository CatalogueRepository { get; set; }
 
     public void SetGenericUnderlyingObjectTo(ICustomUIDrivenClass value)

--- a/Rdmp.UI/ExtractionUIs/ExtractionInformationUI.cs
+++ b/Rdmp.UI/ExtractionUIs/ExtractionInformationUI.cs
@@ -53,6 +53,7 @@ namespace Rdmp.UI.ExtractionUIs;
 /// </summary>
 public partial class ExtractionInformationUI : ExtractionInformationUI_Design, ISaveableUI
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ExtractionInformation ExtractionInformation { get; private set; }
 
     //Editor that user can type into

--- a/Rdmp.UI/ExtractionUIs/FilterUIs/ExtractionFilterUI.cs
+++ b/Rdmp.UI/ExtractionUIs/FilterUIs/ExtractionFilterUI.cs
@@ -50,6 +50,7 @@ public partial class ExtractionFilterUI : ExtractionFilterUI_Design, ILifetimeSu
 
     private AutoCompleteProviderWin _autoCompleteProvider;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ISqlParameter[] GlobalFilterParameters { get; private set; }
 
     private Scintilla QueryEditor;
@@ -212,6 +213,7 @@ public partial class ExtractionFilterUI : ExtractionFilterUI_Design, ILifetimeSu
     /// <summary>
     /// Used for publishing IFilters created here back to the main Catalogue
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Catalogue Catalogue { get; set; }
 
     public void RefreshBus_RefreshObject(object sender, RefreshObjectEventArgs e)

--- a/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/ExtractionFilterParameterSetUI.cs
+++ b/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/ExtractionFilterParameterSetUI.cs
@@ -27,6 +27,7 @@ public partial class ExtractionFilterParameterSetUI : ExtractionFilterParameterS
 {
     private ExtractionFilterParameterSet _extractionFilterParameterSet;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ExtractionFilterParameterSet ExtractionFilterParameterSet
     {
         get => _extractionFilterParameterSet;

--- a/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/ParameterCollectionUI.cs
+++ b/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/ParameterCollectionUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using BrightIdeasSoftware;
@@ -46,6 +47,7 @@ namespace Rdmp.UI.ExtractionUIs.FilterUIs.ParameterUIs;
 /// </summary>
 public partial class ParameterCollectionUI : RDMPUserControl
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ParameterCollectionUIOptions Options { get; private set; }
 
     private ToolStripMenuItem miAddNewParameter = new("New Parameter...");

--- a/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/ParameterEditorScintillaControlUI.cs
+++ b/Rdmp.UI/ExtractionUIs/FilterUIs/ParameterUIs/ParameterEditorScintillaControlUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.Linq;
@@ -37,10 +38,13 @@ public partial class ParameterEditorScintillaControlUI : RDMPUserControl
     public event ParameterEventHandler ParameterChanged = delegate { };
     public event Action ProblemObjectsFound = delegate { };
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ParameterCollectionUIOptions Options { get; set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Dictionary<ISqlParameter, Exception> ProblemObjects { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool IsBroken { get; private set; }
 
     public ParameterEditorScintillaControlUI()

--- a/Rdmp.UI/ExtractionUIs/JoinsAndLookups/KeyDropLocationUI.cs
+++ b/Rdmp.UI/ExtractionUIs/JoinsAndLookups/KeyDropLocationUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using BrightIdeasSoftware;
 using Rdmp.Core.Curation.Data;
@@ -19,8 +20,11 @@ namespace Rdmp.UI.ExtractionUIs.JoinsAndLookups;
 public partial class KeyDropLocationUI : UserControl
 {
     private JoinKeyType _keyType;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ColumnInfo SelectedColumn { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public JoinKeyType KeyType
     {
         get => _keyType;
@@ -39,6 +43,7 @@ public partial class KeyDropLocationUI : UserControl
     /// <summary>
     /// Set this to allow dragging only certain items onto the control.  Return true to allow drop and false to prevent it.
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Func<ColumnInfo, bool> IsValidGetter { get; set; }
 
     public event Action SelectedColumnChanged;

--- a/Rdmp.UI/LocationsMenu/Ticketing/TicketingControlUI.cs
+++ b/Rdmp.UI/LocationsMenu/Ticketing/TicketingControlUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using Rdmp.Core.Ticketing;
 using Rdmp.UI.ItemActivation;
 using Rdmp.UI.SimpleDialogs;
@@ -25,14 +26,18 @@ public partial class TicketingControlUI : RDMPUserControl
 {
     private ITicketingSystem _ticketingSystemConfiguration;
     public event EventHandler TicketTextChanged;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool IsValidTicketName { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string TicketText
     {
         get => tbTicket.Text;
         set => tbTicket.Text = value;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Title
     {
         set => gbTicketing.Text = value;

--- a/Rdmp.UI/MainFormUITabs/ExtractionProgressUI.cs
+++ b/Rdmp.UI/MainFormUITabs/ExtractionProgressUI.cs
@@ -24,6 +24,8 @@ namespace Rdmp.UI.MainFormUITabs;
 public partial class ExtractionProgressUI : ExtractionProgressUI_Design, ISaveableUI
 {
     public ExtractionProgress ExtractionProgress => (ExtractionProgress)DatabaseObject;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IDetermineDatasetTimespan TimespanCalculator { get; set; } = new DatasetTimespanCalculator();
 
     private Tuple<DateTime?, DateTime?> dqeResult;

--- a/Rdmp.UI/MainFormUITabs/SubComponents/ImportSQLTableUI.cs
+++ b/Rdmp.UI/MainFormUITabs/SubComponents/ImportSQLTableUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using FAnsi.Discovery;
@@ -36,8 +37,14 @@ namespace Rdmp.UI.MainFormUITabs.SubComponents;
 public partial class ImportSQLTableUI : RDMPForm
 {
     private readonly bool _allowImportAsCatalogue;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ITableInfoImporter Importer { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ITableInfo TableInfoCreatedIfAny { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string TargetFolder { get; set; }
 
     private Project _projectSpecific;

--- a/Rdmp.UI/Menus/DocumentationNodeMenu.cs
+++ b/Rdmp.UI/Menus/DocumentationNodeMenu.cs
@@ -6,11 +6,13 @@
 
 using Rdmp.Core.CommandExecution.AtomicCommands;
 using Rdmp.Core.Providers.Nodes;
+using System.ComponentModel;
 
 namespace Rdmp.UI.Menus;
 
 internal class DocumentationNodeMenu : RDMPContextMenuStrip
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DocumentationNode DocumentationNode { get; set; }
 
     public DocumentationNodeMenu(RDMPContextMenuStripArgs args, DocumentationNode documentationNode) : base(args,

--- a/Rdmp.UI/Menus/MenuItems/SaveMenuItem.cs
+++ b/Rdmp.UI/Menus/MenuItems/SaveMenuItem.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.UI.SimpleControls;
 
@@ -19,6 +20,7 @@ public class SaveMenuItem : ToolStripMenuItem
 {
     private ISaveableUI _saveable;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ISaveableUI Saveable
     {
         get => _saveable;

--- a/Rdmp.UI/Menus/RDMPContextMenuStrip.cs
+++ b/Rdmp.UI/Menus/RDMPContextMenuStrip.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -35,7 +36,10 @@ namespace Rdmp.UI.Menus;
 public class RDMPContextMenuStrip : ContextMenuStrip
 {
     private readonly object _o;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IRDMPPlatformRepositoryServiceLocator RepositoryLocator { get; private set; }
+
     protected IActivateItems _activator;
 
     protected readonly AtomicCommandUIFactory AtomicCommandUIFactory;

--- a/Rdmp.UI/PipelineUIs/DataObjects/DataFlowComponentVisualisation.cs
+++ b/Rdmp.UI/PipelineUIs/DataObjects/DataFlowComponentVisualisation.cs
@@ -24,12 +24,15 @@ namespace Rdmp.UI.PipelineUIs.DataObjects;
 [TechnicalUI]
 public partial class DataFlowComponentVisualisation : UserControl
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public object Value { get; set; }
+
     private readonly PipelineComponentRole _role;
 
     private ICheckable _checkable;
     private MandatoryPropertyChecker _mandatoryChecker;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool IsLocked
     {
         get => pbPadlock.Visible;

--- a/Rdmp.UI/PipelineUIs/DataObjects/PipelineComponentVisualisation.cs
+++ b/Rdmp.UI/PipelineUIs/DataObjects/PipelineComponentVisualisation.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data.Pipelines;
@@ -30,10 +31,16 @@ internal class PipelineComponentVisualisation : DataFlowComponentVisualisation
     private Pen _origFullPen;
     private Exception _exInitialization;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowDrag { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowSelection { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IPipelineComponent PipelineComponent { get; set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool IsSelected
     {
         get => _isSelected;
@@ -45,6 +52,7 @@ internal class PipelineComponentVisualisation : DataFlowComponentVisualisation
         }
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Exception ExInitialization
     {
         get => _exInitialization;

--- a/Rdmp.UI/PipelineUIs/Pipelines/ConfigureAndExecutePipelineUI.cs
+++ b/Rdmp.UI/PipelineUIs/Pipelines/ConfigureAndExecutePipelineUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Data;
 using System.Threading;
 using System.Threading.Tasks;
@@ -103,6 +104,7 @@ public partial class ConfigureAndExecutePipelineUI : RDMPUserControl, IPipelineR
     private bool _pipelineOptionsSet;
 
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DataFlowPipelineEngineFactory PipelineFactory { get; private set; }
 
     private void SetPipelineOptions(ICatalogueRepository repository)

--- a/Rdmp.UI/PipelineUIs/Pipelines/PipelineDiagramUI.cs
+++ b/Rdmp.UI/PipelineUIs/Pipelines/PipelineDiagramUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using BrightIdeasSoftware;
@@ -34,7 +35,10 @@ public partial class PipelineDiagramUI : UserControl
 {
     private IPipeline _pipeline;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowSelection { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowReOrdering { get; set; }
 
     private RAGSmiley pipelineSmiley = new();

--- a/Rdmp.UI/PipelineUIs/Pipelines/PipelineSelectionUI.cs
+++ b/Rdmp.UI/PipelineUIs/Pipelines/PipelineSelectionUI.cs
@@ -37,25 +37,26 @@ public partial class PipelineSelectionUI : UserControl, IPipelineSelectionUI
     private const string ShowAll = "Show All/Incompatible Pipelines";
     public bool showAll = false;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IPipeline Pipeline
     {
         get => _pipeline;
         set
         {
             _pipeline = value;
+            if (ddPipelines == null) return;
 
-            if (ddPipelines != null)
+            if (_extractionConfiguration is not null && value is not null)
             {
-                if (_extractionConfiguration is not null && value is not null)
-                {
-                    _extractionConfiguration.DefaultPipeline_ID = value.ID;
-                    _extractionConfiguration.SaveToDatabase();
-                }
-                ddPipelines.SelectedItem = value;
+                _extractionConfiguration.DefaultPipeline_ID = value.ID;
+                _extractionConfiguration.SaveToDatabase();
             }
+
+            ddPipelines.SelectedItem = value;
         }
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public override string Text
     {
         get => gbPrompt.Text;

--- a/Rdmp.UI/ProjectUI/Datasets/ConfigureDatasetUI.cs
+++ b/Rdmp.UI/ProjectUI/Datasets/ConfigureDatasetUI.cs
@@ -46,7 +46,9 @@ namespace Rdmp.UI.ProjectUI.Datasets;
 /// </summary>
 public partial class ConfigureDatasetUI : ConfigureDatasetUI_Design, ILifetimeSubscriber
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public SelectedDataSets SelectedDataSet { get; private set; }
+
     private IExtractableDataSet _dataSet;
     private ExtractionConfiguration _config;
 

--- a/Rdmp.UI/ProjectUI/Graphs/ExtractionAggregateGraph.cs
+++ b/Rdmp.UI/ProjectUI/Graphs/ExtractionAggregateGraph.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using FAnsi.Discovery.QuerySyntax;
 using Rdmp.Core.Curation.Data;
@@ -35,7 +36,9 @@ namespace Rdmp.UI.ProjectUI.Graphs;
 /// </summary>
 public sealed class ExtractionAggregateGraphUI : AggregateGraphUI, IObjectCollectionControl
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ExtractDatasetCommand Request { get; private set; }
+
     private ExtractionAggregateGraphObjectCollection _collection;
 
     protected override AggregateBuilder GetQueryBuilder(AggregateConfiguration aggregateConfiguration)

--- a/Rdmp.UI/Rdmp.UI.csproj
+++ b/Rdmp.UI/Rdmp.UI.csproj
@@ -14,12 +14,12 @@
 		<description>UI package for plugin development</description>
 		<copyright>Copyright 2018-2019</copyright>
 		<ProjectGuid>60721bce-e328-45cf-b6d2-b627364fbbfa</ProjectGuid>
-		<TargetFramework>net8.0-windows</TargetFramework>
+		<TargetFramework>$(TargetFramework)-windows</TargetFramework>
 		<Copyright>Copyright ©  2019</Copyright>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<GenerateDocumentationFile>true</GenerateDocumentationFile>
 		<EnableWindowsTargeting>true</EnableWindowsTargeting>
-		<NoWarn>1701;1702;CS1591;NU1701;CA1416</NoWarn>
+		<NoWarn>$(NoWarn)</NoWarn>
 
 		<GenerateResourceUsePreserializedResources>true</GenerateResourceUsePreserializedResources>
 		<DebugType>embedded</DebugType>

--- a/Rdmp.UI/ScintillaHelper/ScintillaMenu.cs
+++ b/Rdmp.UI/ScintillaHelper/ScintillaMenu.cs
@@ -31,6 +31,7 @@ internal class ScintillaMenu : ContextMenuStrip
     /// Spell checker for the hosted control.  If set then right clicks will spell check the word
     /// under the caret and show suggestions
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public WordList Hunspell { get; set; }
 
     public ScintillaMenu(Scintilla scintilla, bool spellCheck) : base()

--- a/Rdmp.UI/SimpleControls/CheckAndExecuteUI.cs
+++ b/Rdmp.UI/SimpleControls/CheckAndExecuteUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using Rdmp.Core.CommandExecution.AtomicCommands.Automation;
@@ -33,7 +34,9 @@ public partial class CheckAndExecuteUI : RDMPUserControl, IConsultableBeforeClos
 
     public CommandGetterHandler CommandGetter;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool ChecksPassed { get; private set; }
+
     public bool IsExecuting => _runningTask is { IsCompleted: false };
 
     /// <summary>
@@ -44,8 +47,10 @@ public partial class CheckAndExecuteUI : RDMPUserControl, IConsultableBeforeClos
 
     private RunnerFactory _factory;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IRunner CurrentRunner { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowsYesNoToAll
     {
         get => checksUI1.AllowsYesNoToAll;
@@ -66,6 +71,7 @@ public partial class CheckAndExecuteUI : RDMPUserControl, IConsultableBeforeClos
 
     private RDMPCommandLineOptions Detatch_CommandGetter() => CommandGetter(CommandLineActivity.run);
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public List<HelpStage> HelpStages { get; private set; }
 
     //constructor

--- a/Rdmp.UI/SimpleControls/ConnectionStringTextBox.cs
+++ b/Rdmp.UI/SimpleControls/ConnectionStringTextBox.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -24,6 +25,8 @@ public class ConnectionStringTextBox : TextBox
     private List<string> supportedKeywords = new();
     private bool suppressAutocomplete;
 
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DatabaseType DatabaseType
     {
         get => _databaseType;

--- a/Rdmp.UI/SimpleControls/DatabaseTypeUI.cs
+++ b/Rdmp.UI/SimpleControls/DatabaseTypeUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using FAnsi;
 using Rdmp.Core.ReusableLibraryCode.Icons.IconProvision;
@@ -17,6 +18,7 @@ public partial class DatabaseTypeUI : UserControl
     private DatabaseType _databaseType;
     public event EventHandler DatabaseTypeChanged;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DatabaseType DatabaseType
     {
         get => _databaseType;

--- a/Rdmp.UI/SimpleControls/HelpIcon.cs
+++ b/Rdmp.UI/SimpleControls/HelpIcon.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System.ComponentModel;
 using System.Windows.Forms;
 using Rdmp.UI.SimpleDialogs;
 using Rdmp.UI.TransparentHelpSystem;
@@ -20,12 +21,15 @@ public partial class HelpIcon : UserControl
     /// <summary>
     /// Returns the text that will be displayed when the user hovers over the control (this may be truncated if the text provided to <see cref="SetHelpText"/> was very long)
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string HoverText { get; private set; }
 
     private string _title;
     private HelpWorkflow _workFlow;
     private string _originalHoverText;
     private ToolTip _tt;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool SuppressClick { get; set; }
 
     public HelpIcon()

--- a/Rdmp.UI/SimpleControls/SelectIMapsDirectlyToDatabaseTableComboBox.cs
+++ b/Rdmp.UI/SimpleControls/SelectIMapsDirectlyToDatabaseTableComboBox.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using Rdmp.Core.CommandExecution;
@@ -21,6 +22,7 @@ public partial class SelectIMapsDirectlyToDatabaseTableComboBox : UserControl
     public event EventHandler<EventArgs> SelectedItemChanged;
     private IActivateItems _activator;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IMapsDirectlyToDatabaseTable SelectedItem
     {
         get => suggestComboBox1.SelectedItem as IMapsDirectlyToDatabaseTable;

--- a/Rdmp.UI/SimpleControls/ServerDatabaseTableSelector.cs
+++ b/Rdmp.UI/SimpleControls/ServerDatabaseTableSelector.cs
@@ -31,36 +31,42 @@ public partial class ServerDatabaseTableSelector : UserControl
 {
     private bool _allowTableValuedFunctionSelection;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Server
     {
         get => cbxServer.Text;
         set => cbxServer.Text = value;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Database
     {
         get => cbxDatabase.Text;
         set => cbxDatabase.Text = value;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Table
     {
         private get => cbxTable.Text;
         set => cbxTable.Text = value;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Username
     {
         get => tbUsername.Text;
         set => tbUsername.Text = value;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Password
     {
         get => tbPassword.Text;
         set => tbPassword.Text = value;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string Timeout
     {
         get => tbTimeout.Text;
@@ -268,6 +274,7 @@ public partial class ServerDatabaseTableSelector : UserControl
         cbxServer.Items.AddRange(defaultServers);
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowTableValuedFunctionSelection
     {
         get => _allowTableValuedFunctionSelection;
@@ -281,6 +288,7 @@ public partial class ServerDatabaseTableSelector : UserControl
         }
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DatabaseType DatabaseType
     {
         get => databaseTypeUI1.DatabaseType;
@@ -289,6 +297,7 @@ public partial class ServerDatabaseTableSelector : UserControl
 
     public DiscoveredServer Result => new(GetBuilder());
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool TableShouldBeNovel
     {
         set

--- a/Rdmp.UI/SimpleCounterButton.cs
+++ b/Rdmp.UI/SimpleCounterButton.cs
@@ -4,6 +4,7 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
+using System.ComponentModel;
 using System.Drawing;
 using System.Drawing.Drawing2D;
 using System.Windows.Forms;
@@ -19,6 +20,7 @@ public class SimpleCounterButton : ToolStripButton
 {
     private int? _count;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public int? Count
     {
         get => _count;

--- a/Rdmp.UI/SimpleDialogs/ChooseLoggingTaskUI.cs
+++ b/Rdmp.UI/SimpleDialogs/ChooseLoggingTaskUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Windows.Forms;
 using Rdmp.Core.Curation.Data;
@@ -36,6 +37,7 @@ public partial class ChooseLoggingTaskUI : RDMPUserControl, ICheckNotifier
     private Catalogue _catalogue;
     private string expectedDatabaseTypeString = "HIC.Logging.Database";
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Catalogue Catalogue
     {
         get => _catalogue;

--- a/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
+++ b/Rdmp.UI/SimpleDialogs/ForwardEngineering/ConfigureCatalogueExtractabilityUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Diagnostics;
 using System.Drawing;
 using System.Linq;
@@ -72,7 +73,11 @@ public partial class ConfigureCatalogueExtractabilityUI : RDMPForm, ISaveableUI
 
     public ICatalogue CatalogueCreatedIfAny => _catalogue;
     public ITableInfo TableInfoCreated => _tableInfo;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DiscoveredTable TableCreated { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string TargetFolder { get; set; }
 
     private BinderWithErrorProviderFactory _binder;

--- a/Rdmp.UI/SimpleDialogs/Reports/DataGeneratorUI.cs
+++ b/Rdmp.UI/SimpleDialogs/Reports/DataGeneratorUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Threading;
 using System.Windows.Forms;
@@ -27,6 +28,7 @@ public partial class DataGeneratorUI : UserControl
         cbGenerate.Checked = true;
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IDataGenerator Generator
     {
         get => _generator;
@@ -82,6 +84,7 @@ public partial class DataGeneratorUI : UserControl
         TrackBarMouseUp?.Invoke();
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool Generate
     {
         get => cbGenerate.Checked;

--- a/Rdmp.UI/SimpleDialogs/Reports/GenerateTestDataUI.cs
+++ b/Rdmp.UI/SimpleDialogs/Reports/GenerateTestDataUI.cs
@@ -17,6 +17,7 @@ using Rdmp.UI.ItemActivation;
 using Rdmp.UI.TestsAndSetup.ServicePropogation;
 using Rdmp.UI.TransparentHelpSystem;
 using Rdmp.UI.Tutorials;
+using System.ComponentModel;
 
 namespace Rdmp.UI.SimpleDialogs.Reports;
 
@@ -35,7 +36,9 @@ namespace Rdmp.UI.SimpleDialogs.Reports;
 /// </summary>
 public partial class GenerateTestDataUI : RDMPForm
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public HelpWorkflow HelpWorkflow { get; private set; }
+
     private int? _seed;
 
     public GenerateTestDataUI(IActivateItems activator, ICommandExecution command) : base(activator)

--- a/Rdmp.UI/SimpleDialogs/SelectDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/SelectDialog.cs
@@ -7,6 +7,7 @@
 using System;
 using System.Collections;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Text.RegularExpressions;
@@ -73,11 +74,13 @@ public partial class SelectDialog<T> : Form, IVirtualListDataSource where T : cl
     /// </summary>
     public T Selected;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public HashSet<T> MultiSelected { get; private set; }
 
     /// <summary>
     /// Hides the Type selection toggle buttons and forces results to only appear matching the given Type
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Type AlwaysFilterOn
     {
         get => _alwaysFilterOn;
@@ -93,6 +96,7 @@ public partial class SelectDialog<T> : Form, IVirtualListDataSource where T : cl
         }
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowMultiSelect
     {
         get => olv.MultiSelect;

--- a/Rdmp.UI/SimpleDialogs/ServerDatabaseTableSelectorDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/ServerDatabaseTableSelectorDialog.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Windows.Forms;
 using FAnsi;
 using FAnsi.Discovery;
@@ -38,6 +39,7 @@ public partial class ServerDatabaseTableSelectorDialog : Form
     public DiscoveredDatabase SelectedDatabase => serverDatabaseTableSelector1.GetDiscoveredDatabase();
     public DiscoveredTable SelectedTable => serverDatabaseTableSelector1.GetDiscoveredTable();
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool AllowTableValuedFunctionSelection
     {
         get => serverDatabaseTableSelector1.AllowTableValuedFunctionSelection;

--- a/Rdmp.UI/SimpleDialogs/SimpleFileImporting/CreateNewCatalogueByImportingFileUI.cs
+++ b/Rdmp.UI/SimpleDialogs/SimpleFileImporting/CreateNewCatalogueByImportingFileUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Data;
 using System.Drawing;
 using System.IO;
@@ -47,7 +48,10 @@ public partial class CreateNewCatalogueByImportingFileUI : RDMPForm
     private FileInfo _selectedFile;
     private DataFlowPipelineContext<DataTable> _context;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public HelpWorkflow HelpWorkflow { get; set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public string TargetFolder { get; set; }
 
     public CreateNewCatalogueByImportingFileUI(IActivateItems activator,

--- a/Rdmp.UI/SimpleDialogs/SimpleFileImporting/CreateNewCatalogueByImportingFileUI_Advanced.cs
+++ b/Rdmp.UI/SimpleDialogs/SimpleFileImporting/CreateNewCatalogueByImportingFileUI_Advanced.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Windows.Forms;
 using FAnsi.Discovery;
@@ -41,6 +42,7 @@ public partial class CreateNewCatalogueByImportingFileUI_Advanced : UserControl
     private FileInfo _file;
     private Project _projectSpecific;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ICatalogue CatalogueCreatedIfAny { get; private set; }
 
     public CreateNewCatalogueByImportingFileUI_Advanced(IActivateItems activator, DiscoveredDatabase database,

--- a/Rdmp.UI/SimpleDialogs/SqlDialogs/SQLPreviewWindow.cs
+++ b/Rdmp.UI/SimpleDialogs/SqlDialogs/SQLPreviewWindow.cs
@@ -38,6 +38,7 @@ public partial class SQLPreviewWindow : Form
         btnOk.Select();
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool YesToAll { get; set; }
 
     private void btnOk_Click(object sender, EventArgs e)

--- a/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.cs
+++ b/Rdmp.UI/SimpleDialogs/TypeTextOrCancelDialog.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using FAnsi.Discovery;
@@ -29,6 +30,7 @@ public partial class TypeTextOrCancelDialog : Form
     /// <summary>
     /// True to require that text typed be sane for usage as a column name, table name etc e.g. "bob" but not "bob::bbbbb".
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool RequireSaneHeaderText { get; set; }
 
     //"Column Name","Enter name for column (this should NOT include any qualifiers e.g. database name)", 300);

--- a/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
+++ b/Rdmp.UI/SimpleDialogs/WideMessageBox.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Text;
@@ -40,6 +41,7 @@ public partial class WideMessageBox : Form
     /// <summary>
     /// The currently displayed message
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public WideMessageBoxArgs Args { get; set; }
 
     private readonly Stack<WideMessageBoxArgs> _navigationStack = new();

--- a/Rdmp.UI/SuggestComboBox.cs
+++ b/Rdmp.UI/SuggestComboBox.cs
@@ -30,6 +30,8 @@ public class SuggestComboBox : ComboBox
     private Expression<Func<string, string>> _suggestListOrderRule;
     private Func<string, string> _suggestListOrderRuleCompiled;
 
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public int SuggestBoxHeight
     {
         get => _suggLb.Height;
@@ -43,6 +45,7 @@ public class SuggestComboBox : ComboBox
     /// If the item-type of the ComboBox is not string,
     /// you can set here which property should be used
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Expression<Func<ObjectCollection, IEnumerable<string>>> PropertySelector
     {
         get => _propertySelector;
@@ -61,12 +64,14 @@ public class SuggestComboBox : ComboBox
     /// <para>1st string: list item</para>
     /// <para>2nd string: typed text</para>
     ///</summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Expression<Func<string, string, bool>> FilterRule
     {
         get => _filterRule;
         set
         {
             if (value == null) return;
+
             _filterRule = value;
             _filterRuleCompiled = item => value.Compile()(item, Text);
         }
@@ -77,12 +82,14 @@ public class SuggestComboBox : ComboBox
     /// (as Expression here because simple lamda (func) is not serializable)
     /// <para>default: alphabetic ordering</para>
     ///</summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Expression<Func<string, string>> SuggestListOrderRule
     {
         get => _suggestListOrderRule;
         set
         {
             if (value == null) return;
+
             _suggestListOrderRule = value;
             _suggestListOrderRuleCompiled = value.Compile();
         }

--- a/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPForm.cs
+++ b/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPForm.cs
@@ -24,11 +24,15 @@ public class RDMPForm : Form, IRDMPControl
     /// <summary>
     /// Whether escape keystrokes should trigger form closing (defaults to true).
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool CloseOnEscape { get; set; }
 
     protected readonly bool VisualStudioDesignMode;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IActivateItems Activator { get; private set; }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public RDMPControlCommonFunctionality CommonFunctionality { get; private set; }
 
     /// <summary>

--- a/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPSingleDatabaseObjectControl.cs
+++ b/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPSingleDatabaseObjectControl.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -43,6 +44,7 @@ public abstract class RDMPSingleDatabaseObjectControl<T> : RDMPUserControl, IRDM
     /// and create <see cref="Commit"/> when changes are saved.  Using this field requires
     /// declaring yourself <see cref="ISaveableUI"/>
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool UseCommitSystem { get; set; } = false;
 
     /// <summary>
@@ -64,12 +66,15 @@ public abstract class RDMPSingleDatabaseObjectControl<T> : RDMPUserControl, IRDM
     private IActivateItems _activator;
 
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DatabaseEntity DatabaseObject { get; private set; }
+
     protected RDMPCollection AssociatedCollection = RDMPCollection.None;
 
     /// <summary>
     /// True if the hosted <see cref="DatabaseObject"/> <see cref="IMightBeReadOnly.ShouldBeReadOnly"/>.  This property is detected and update during SetDatabaseObject so use it only after this call has been made
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool ReadOnly { get; set; }
 
     protected RDMPSingleDatabaseObjectControl()

--- a/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPUserControl.cs
+++ b/Rdmp.UI/TestsAndSetup/ServicePropogation/RDMPUserControl.cs
@@ -22,7 +22,10 @@ namespace Rdmp.UI.TestsAndSetup.ServicePropogation;
 [TypeDescriptionProvider(typeof(AbstractControlDescriptionProvider<RDMPUserControl, UserControl>))]
 public abstract class RDMPUserControl : UserControl, IRDMPControl
 {
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public RDMPControlCommonFunctionality CommonFunctionality { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public IActivateItems Activator { get; private set; }
 
     protected readonly bool VisualStudioDesignMode;

--- a/Rdmp.UI/TestsAndSetup/StartupUI.cs
+++ b/Rdmp.UI/TestsAndSetup/StartupUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Linq;
 using System.Reflection;
 using System.Text.RegularExpressions;
@@ -33,6 +34,7 @@ public partial class StartupUI : Form, ICheckNotifier
     /// <summary>
     /// True if we failed to reach the catalogue database
     /// </summary>
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool CouldNotReachTier1Database { get; private set; }
 
 
@@ -74,6 +76,7 @@ public partial class StartupUI : Form, ICheckNotifier
     }
 
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool DoNotContinue { get; set; }
 
     private void StartupDatabaseFound(object sender, PlatformDatabaseFoundEventArgs eventArgs)

--- a/Rdmp.UI/Validation/ResolveMissingTargetPropertiesUI.cs
+++ b/Rdmp.UI/Validation/ResolveMissingTargetPropertiesUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -38,6 +39,7 @@ public partial class ResolveMissingTargetPropertiesUI : Form
         lbMissingReferences.Items.AddRange(GetMissingReferences(validator, availableColumns).ToArray());
     }
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Validator AdjustedValidator { get; set; }
 
     public static IEnumerable<string> GetUnReferencedColumns(Validator v, IEnumerable<string> columns)

--- a/Rdmp.UI/Validation/ValidationSetupUI.cs
+++ b/Rdmp.UI/Validation/ValidationSetupUI.cs
@@ -41,6 +41,7 @@ public partial class ValidationSetupUI : ValidationSetupForm_Design, ISaveableUI
 {
     private string _noPrimaryConstraintText = "No Primary Constraint Defined";
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Validator Validator { get; private set; }
 
     private bool bSuppressChangeEvents;

--- a/Rdmp.UI/Versioning/CreatePlatformDatabase.cs
+++ b/Rdmp.UI/Versioning/CreatePlatformDatabase.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Threading.Tasks;
 using System.Windows.Forms;
 using FAnsi;
@@ -37,6 +38,8 @@ public partial class CreatePlatformDatabase : Form
     private IPatcher _patcher;
 
     private Task _tCreateDatabase;
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public DiscoveredDatabase DatabaseCreatedIfAny { get; private set; }
 
     /// <summary>

--- a/Rdmp.UI/Wizard/CreateNewCohortIdentificationConfigurationUI.cs
+++ b/Rdmp.UI/Wizard/CreateNewCohortIdentificationConfigurationUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.Drawing;
 using System.Windows.Forms;
 using Rdmp.Core.CommandExecution.AtomicCommands;
@@ -28,6 +29,7 @@ public partial class CreateNewCohortIdentificationConfigurationUI : RDMPForm
     private Size _smallSize = new(755, 140);
     private Size _bigSize = new(1368, 876);
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public CohortIdentificationConfiguration CohortIdentificationCriteriaCreatedIfAny { get; private set; }
 
     public CreateNewCohortIdentificationConfigurationUI(IActivateItems activator) : base(activator)

--- a/Rdmp.UI/Wizard/CreateNewDataExtractionProjectUI.cs
+++ b/Rdmp.UI/Wizard/CreateNewDataExtractionProjectUI.cs
@@ -5,6 +5,7 @@
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
 using System;
+using System.ComponentModel;
 using System.IO;
 using System.Linq;
 using System.Windows.Forms;
@@ -50,7 +51,10 @@ public partial class CreateNewDataExtractionProjectUI : RDMPForm
 
     private bool _bLoading;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public ExtractionConfiguration ExtractionConfigurationCreatedIfAny { get; private set; }
+
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public Project ProjectCreatedIfAny { get; private set; }
 
     private void GetNextProjectNumber(IActivateItems activator)

--- a/Rdmp.UI/Wizard/SimpleFilterUI.cs
+++ b/Rdmp.UI/Wizard/SimpleFilterUI.cs
@@ -6,6 +6,7 @@
 
 using System;
 using System.Collections.Generic;
+using System.ComponentModel;
 using System.Drawing;
 using System.Linq;
 using System.Windows.Forms;
@@ -38,6 +39,7 @@ public partial class SimpleFilterUI : UserControl
 
     public IFilter Filter => _filter;
 
+    [DesignerSerializationVisibility(DesignerSerializationVisibility.Hidden)]
     public bool Mandatory
     {
         get => _mandatory;

--- a/Tests.Common/Tests.Common.csproj
+++ b/Tests.Common/Tests.Common.csproj
@@ -3,7 +3,6 @@
         <PackageId>HIC.RDMP.Plugin.Test</PackageId>
         <version>$(version)</version>
         <title>HIC.RDMP.Plugin.Test</title>
-        <TargetFramework>net8.0</TargetFramework>
         <authors>Health Informatics Centre, University of Dundee</authors>
         <owners>Health Informatics Centre, University of Dundee</owners>
         <licenseUrl>https://raw.githubusercontent.com/HicServices/RDMP/master/LICENSE</licenseUrl>

--- a/Tools/rdmp/rdmp.csproj
+++ b/Tools/rdmp/rdmp.csproj
@@ -2,7 +2,6 @@
 	<PropertyGroup>
 		<ProjectGuid>{A6107DDC-8268-4902-A994-233B00480113}</ProjectGuid>
 		<OutputType>Exe</OutputType>
-		<TargetFramework>net8.0</TargetFramework>
 		<AutoGenerateBindingRedirects>true</AutoGenerateBindingRedirects>
 		<GenerateAssemblyInfo>false</GenerateAssemblyInfo>
 		<AssemblyTitle>rdmp</AssemblyTitle>

--- a/global.json
+++ b/global.json
@@ -1,0 +1,6 @@
+{
+  "sdk": {
+    "version": "9.0.100",
+    "rollForward": "minor"
+  }
+}


### PR DESCRIPTION
## Proposed Change

- Update SDK used
- Make target .Net version centrally configured from `Directory.Build.props` instead of per-project
- Enable Dependabot auto-update PRs for the `global.json` file governing which SDK is used on Github
- Fix WFO1000 errors which are now flagged as serious by .Net - details: https://github.com/dotnet/docs/issues/42724
- Disambiguate reference to `License` object (used internally in RDMP, but .Net's System.ComponentModel now has a License object too)
 
## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Created or updated any tests if relevant
-   [ ] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [x] Requested a review by one of the repository maintainers
-   [x] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [x] Have added an entry into the changelog
