### PR TITLE
Task/rdmp 250 remote table attacher no raw

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [8.4.1] - Unreleased
+
+- Add Remote Table Without DB Creation Attacher
+
 ## [8.4.0] - 2024-12-02
 
 - Add Ordering to Filters

--- a/Rdmp.Core/DataLoad/Modules/Attachers/RemoteAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/RemoteAttacher.cs
@@ -24,7 +24,7 @@ namespace Rdmp.Core.DataLoad.Modules.Attachers;
 public class RemoteAttacher : Attacher, IPluginAttacher
 {
 
-    public RemoteAttacher() : base(true) { }
+    public RemoteAttacher(bool requestsExternalDatabaseCreation=true) : base(requestsExternalDatabaseCreation) { }
     [DemandsInitialization("How far back to pull data from")]
     public AttacherHistoricalDurations HistoricalFetchDuration { get; set; }
 

--- a/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableAttacher.cs
@@ -37,7 +37,7 @@ public class RemoteTableAttacher : RemoteAttacher
 {
     private const string FutureLoadMessage = "Cannot load data from the future";
 
-    public RemoteTableAttacher() : base()
+    public RemoteTableAttacher(bool requestsExternalDatabaseCreation=true) : base(requestsExternalDatabaseCreation)
     {
     }
 

--- a/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableWithoutDBCreationAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableWithoutDBCreationAttacher.cs
@@ -7,12 +7,13 @@
 
 namespace Rdmp.Core.DataLoad.Modules.Attachers;
 
+/// <summary>
+/// Data load component for loading tables with records read from a remote database server.  Runs the specified query (which can include a date parameter)
+/// and inserts the results of the query into RAW.
+/// This attcher does not create RAW if it does not exist. Another attacher will be required to generate the initial RAW database
+/// </summary>
 public class RemoteTableWithoutDBCreationAttacher: RemoteTableAttacher
 {
-    /// <summary>
-    /// Data load component for loading tables with records read from a remote database server.  Runs the specified query (which can include a date parameter)
-    /// and inserts the results of the query into RAW.
-    /// This attcher does not create RAW if it does not exist. Another attacher will be required to generate the initial RAW database
-    /// </summary>
+
     public RemoteTableWithoutDBCreationAttacher() : base(false) { }
 }

--- a/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableWithoutDBCreationAttacher.cs
+++ b/Rdmp.Core/DataLoad/Modules/Attachers/RemoteTableWithoutDBCreationAttacher.cs
@@ -1,0 +1,18 @@
+﻿// Copyright (c) The University of Dundee 2024-2024
+// This file is part of the Research Data Management Platform (RDMP).
+// RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
+// RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
+// You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
+
+
+namespace Rdmp.Core.DataLoad.Modules.Attachers;
+
+public class RemoteTableWithoutDBCreationAttacher: RemoteTableAttacher
+{
+    /// <summary>
+    /// Data load component for loading tables with records read from a remote database server.  Runs the specified query (which can include a date parameter)
+    /// and inserts the results of the query into RAW.
+    /// This attcher does not create RAW if it does not exist. Another attacher will be required to generate the initial RAW database
+    /// </summary>
+    public RemoteTableWithoutDBCreationAttacher() : base(false) { }
+}


### PR DESCRIPTION
## Proposed Change

DLS issue where they are using an MDF attacher then wanting to import a table to strip out already imported records.
Can't currently use an MDF and remote table attacher in the same data load.
this PR adds a remote table attacher that does not request Raw DB creation.
This is so that it can be used in conjunction with the MDF attacher
## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Created or updated any tests if relevant
-   [x] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [x] Requested a review by one of the repository maintainers
-   [x] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [x] Have added an entry into the changelog
