### PR TITLE
Fix up some codeql/inspection code issues

### DIFF
--- a/Rdmp.Core.Tests/DataExport/DataExtraction/ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest.cs
+++ b/Rdmp.Core.Tests/DataExport/DataExtraction/ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest.cs
@@ -82,19 +82,19 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             null, db, pipe, null);
 
         cmd.Execute();
-        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().Where(c => c.Name == "bob").FirstOrDefault();
-        var chiColumnInfo = catalogue.CatalogueItems.Where(ci => ci.Name == "chi").First();
+        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().FirstOrDefault(static c => c.Name == "bob");
+        var chiColumnInfo = catalogue.CatalogueItems.First(static ci => ci.Name == "chi");
         var ei = chiColumnInfo.ExtractionInformation;
         ei.IsExtractionIdentifier = true;
         ei.IsPrimaryKey = true;
         ei.SaveToDatabase();
         var project = new Project(DataExportRepository, "MyProject")
         {
-            ProjectNumber = 500
+            ProjectNumber = 500,
+            ExtractionDirectory = Path.GetTempPath()
         };
-        project.ExtractionDirectory = Path.GetTempPath();
         project.SaveToDatabase();
-        CohortIdentificationConfiguration cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic.CreateRootContainerIfNotExists();
         var agg1 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         var conf = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -106,13 +106,13 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         dim.SaveToDatabase();
         agg1.SaveToDatabase();
 
-        string CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
-        string cohortTableName = "Cohort";
-        string definitionTableName = "CohortDefinition";
-        string ExternalCohortTableNameInCatalogue = "CohortTests";
+        var CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
+        var cohortTableName = "Cohort";
+        var definitionTableName = "CohortDefinition";
+        var ExternalCohortTableNameInCatalogue = "CohortTests";
         const string ReleaseIdentifierFieldName = "ReleaseId";
         const string DefinitionTableForeignKeyField = "cohortDefinition_id";
-        DiscoveredDatabase _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
+        var _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
         if (_cohortDatabase.Exists())
             DeleteTables(_cohortDatabase);
         else
@@ -166,7 +166,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
                     };
 
         newExternal.SaveToDatabase();
-        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().Where(p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration").First();
+        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().First(static p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration");
         var newCohortCmd = new ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration(
             new ThrowImmediatelyActivator(RepositoryLocator),
             cic,
@@ -174,14 +174,14 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             "MyCohort",
             project,
             cohortPipeline
-            );
+        );
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
+        var extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
 
         var ec = new ExtractionConfiguration(DataExportRepository, project)
         {
             Name = "ext1",
-            Cohort_ID = _extractableCohort.ID
+            Cohort_ID = extractableCohort.ID
         };
         ec.AddDatasetToConfiguration(new ExtractableDataSet(DataExportRepository, catalogue));
 
@@ -197,7 +197,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         var argumentTblNamePattern = destinationArguments.Single(a => a.Name == "TableNamingPattern");
         var reExtract = destinationArguments.Single(a => a.Name == "AppendDataIfTableExists");
         Assert.That(argumentServer.Name, Is.EqualTo("TargetDatabaseServer"));
-        ExternalDatabaseServer _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
+        var _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
         {
             Server = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.Name,
             Username = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExplicitUsernameIfAny,
@@ -309,19 +309,19 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             null, db, pipe, null);
 
         cmd.Execute();
-        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().Where(c => c.Name == "bob").FirstOrDefault();
-        var chiColumnInfo = catalogue.CatalogueItems.Where(ci => ci.Name == "chi").First();
+        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().FirstOrDefault(static c => c.Name == "bob");
+        var chiColumnInfo = catalogue.CatalogueItems.First(static ci => ci.Name == "chi");
         var ei = chiColumnInfo.ExtractionInformation;
         ei.IsExtractionIdentifier = true;
         ei.IsPrimaryKey = true;
         ei.SaveToDatabase();
         var project = new Project(DataExportRepository, "MyProject")
         {
-            ProjectNumber = 500
+            ProjectNumber = 500,
+            ExtractionDirectory = Path.GetTempPath()
         };
-        project.ExtractionDirectory = Path.GetTempPath();
         project.SaveToDatabase();
-        CohortIdentificationConfiguration cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic.CreateRootContainerIfNotExists();
         var agg1 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         var conf = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -333,13 +333,13 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         dim.SaveToDatabase();
         agg1.SaveToDatabase();
 
-        string CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
-        string cohortTableName = "Cohort";
-        string definitionTableName = "CohortDefinition";
-        string ExternalCohortTableNameInCatalogue = "CohortTests";
+        var CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
+        var cohortTableName = "Cohort";
+        var definitionTableName = "CohortDefinition";
+        var ExternalCohortTableNameInCatalogue = "CohortTests";
         const string ReleaseIdentifierFieldName = "ReleaseId";
         const string DefinitionTableForeignKeyField = "cohortDefinition_id";
-        DiscoveredDatabase _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
+        var _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
         if (_cohortDatabase.Exists())
             DeleteTables(_cohortDatabase);
         else
@@ -392,7 +392,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
                     };
 
         newExternal.SaveToDatabase();
-        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().Where(p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration").First();
+        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().First(static p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration");
         var newCohortCmd = new ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration(
             new ThrowImmediatelyActivator(RepositoryLocator),
             cic,
@@ -400,14 +400,14 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             "MyCohort",
             project,
             cohortPipeline
-            );
+        );
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
+        var extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
 
         var ec = new ExtractionConfiguration(DataExportRepository, project)
         {
             Name = "ext1",
-            Cohort_ID = _extractableCohort.ID
+            Cohort_ID = extractableCohort.ID
         };
         ec.AddDatasetToConfiguration(new ExtractableDataSet(DataExportRepository, catalogue));
 
@@ -423,7 +423,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         var argumentTblNamePattern = destinationArguments.Single(a => a.Name == "TableNamingPattern");
         var reExtract = destinationArguments.Single(a => a.Name == "AppendDataIfTableExists");
         Assert.That(argumentServer.Name, Is.EqualTo("TargetDatabaseServer"));
-        ExternalDatabaseServer _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
+        var _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
         {
             Server = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.Name,
             Username = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExplicitUsernameIfAny,
@@ -486,17 +486,17 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         //add new entry here
         var tbl = db.DiscoverTables(false).First();
         tbl.Insert(new Dictionary<string, object>
-            {
-                { "chi","1111111111"},
-                {"notes","T"},
-                {"dtCreated", new DateTime(2001, 1, 2) },
-                {"century",19},
-                {"surname","1234"},
-                {"forename","yes"},
-                {"sex","M"},
-            });
+        {
+            { "chi","1111111111"},
+            {"notes","T"},
+            {"dtCreated", new DateTime(2001, 1, 2) },
+            {"century",19},
+            {"surname","1234"},
+            {"forename","yes"},
+            {"sex","M"},
+        });
 
-        CohortIdentificationConfiguration cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic2.CreateRootContainerIfNotExists();
         var agg12 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         _ = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -509,7 +509,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         agg12.SaveToDatabase();
 
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
+        var _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
         ec.Cohort_ID = _extractableCohort2.ID;
         ec.SaveToDatabase();
 
@@ -566,24 +566,24 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             null, db, pipe, null);
 
         cmd.Execute();
-        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().Where(c => c.Name == "bob").FirstOrDefault();
-        var chiColumnInfo = catalogue.CatalogueItems.Where(ci => ci.Name == "chi").First();
+        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().FirstOrDefault(static c => c.Name == "bob");
+        var chiColumnInfo = catalogue.CatalogueItems.First(static ci => ci.Name == "chi");
         var ei = chiColumnInfo.ExtractionInformation;
         ei.IsExtractionIdentifier = true;
         ei.IsPrimaryKey = true;
         ei.SaveToDatabase();
 
-        var surnameInfo = catalogue.CatalogueItems.Where(ci => ci.Name == "surname").First();
+        var surnameInfo = catalogue.CatalogueItems.First(static ci => ci.Name == "surname");
         surnameInfo.ExtractionInformation.IsPrimaryKey = true;
         surnameInfo.ExtractionInformation.SaveToDatabase();
 
         var project = new Project(DataExportRepository, "MyProject")
         {
-            ProjectNumber = 500
+            ProjectNumber = 500,
+            ExtractionDirectory = Path.GetTempPath()
         };
-        project.ExtractionDirectory = Path.GetTempPath();
         project.SaveToDatabase();
-        CohortIdentificationConfiguration cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic.CreateRootContainerIfNotExists();
         var agg1 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         var conf = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -595,13 +595,13 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         dim.SaveToDatabase();
         agg1.SaveToDatabase();
 
-        string CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
-        string cohortTableName = "Cohort";
-        string definitionTableName = "CohortDefinition";
-        string ExternalCohortTableNameInCatalogue = "CohortTests";
+        var CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
+        var cohortTableName = "Cohort";
+        var definitionTableName = "CohortDefinition";
+        var ExternalCohortTableNameInCatalogue = "CohortTests";
         const string ReleaseIdentifierFieldName = "ReleaseId";
         const string DefinitionTableForeignKeyField = "cohortDefinition_id";
-        DiscoveredDatabase _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
+        var _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
         if (_cohortDatabase.Exists())
             DeleteTables(_cohortDatabase);
         else
@@ -654,7 +654,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
                     };
 
         newExternal.SaveToDatabase();
-        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().Where(p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration").First();
+        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().First(static p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration");
         var newCohortCmd = new ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration(
             new ThrowImmediatelyActivator(RepositoryLocator),
             cic,
@@ -662,14 +662,14 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             "MyCohort",
             project,
             cohortPipeline
-            );
+        );
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
+        var extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
 
         var ec = new ExtractionConfiguration(DataExportRepository, project)
         {
             Name = "ext1",
-            Cohort_ID = _extractableCohort.ID
+            Cohort_ID = extractableCohort.ID
         };
         ec.AddDatasetToConfiguration(new ExtractableDataSet(DataExportRepository, catalogue));
 
@@ -685,7 +685,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         var argumentTblNamePattern = destinationArguments.Single(a => a.Name == "TableNamingPattern");
         var reExtract = destinationArguments.Single(a => a.Name == "AppendDataIfTableExists");
         Assert.That(argumentServer.Name, Is.EqualTo("TargetDatabaseServer"));
-        ExternalDatabaseServer _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
+        var _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
         {
             Server = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.Name,
             Username = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExplicitUsernameIfAny,
@@ -748,17 +748,17 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         //add new entry here
         var tbl = db.DiscoverTables(false).First();
         tbl.Insert(new Dictionary<string, object>
-            {
-                { "chi","1111111111"},
-                {"notes","T"},
-                {"dtCreated", new DateTime(2001, 1, 2) },
-                {"century",19},
-                {"surname","1234"},
-                {"forename","yes"},
-                {"sex","M"},
-            });
+        {
+            { "chi","1111111111"},
+            {"notes","T"},
+            {"dtCreated", new DateTime(2001, 1, 2) },
+            {"century",19},
+            {"surname","1234"},
+            {"forename","yes"},
+            {"sex","M"},
+        });
 
-        CohortIdentificationConfiguration cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic2.CreateRootContainerIfNotExists();
         var agg12 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         _ = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -770,15 +770,15 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         dim2.SaveToDatabase();
         agg12.SaveToDatabase();
         newCohortCmd = new ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration(
-           new ThrowImmediatelyActivator(RepositoryLocator),
-           cic2,
-           newExternal,
-           "MyCohort",
-           project,
-           cohortPipeline
-           );
+            new ThrowImmediatelyActivator(RepositoryLocator),
+            cic2,
+            newExternal,
+            "MyCohort",
+            project,
+            cohortPipeline
+        );
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
+        var _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
         ec.Cohort_ID = _extractableCohort2.ID;
         ec.SaveToDatabase();
 
@@ -835,8 +835,8 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             null, db, pipe, null);
 
         cmd.Execute();
-        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().Where(c => c.Name == "bob").FirstOrDefault();
-        var chiColumnInfo = catalogue.CatalogueItems.Where(ci => ci.Name == "chi").First();
+        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().FirstOrDefault(static c => c.Name == "bob");
+        var chiColumnInfo = catalogue.CatalogueItems.First(static ci => ci.Name == "chi");
         var ei = chiColumnInfo.ExtractionInformation;
         ei.IsPrimaryKey = true;
         ei.IsExtractionIdentifier = true;
@@ -844,11 +844,11 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
 
         var project = new Project(DataExportRepository, "MyProject")
         {
-            ProjectNumber = 500
+            ProjectNumber = 500,
+            ExtractionDirectory = Path.GetTempPath()
         };
-        project.ExtractionDirectory = Path.GetTempPath();
         project.SaveToDatabase();
-        CohortIdentificationConfiguration cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic.CreateRootContainerIfNotExists();
         var agg1 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         var conf = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -860,13 +860,13 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         dim.SaveToDatabase();
         agg1.SaveToDatabase();
 
-        string CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
-        string cohortTableName = "Cohort";
-        string definitionTableName = "CohortDefinition";
-        string ExternalCohortTableNameInCatalogue = "CohortTests";
+        var CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
+        const string cohortTableName = "Cohort";
+        const string definitionTableName = "CohortDefinition";
+        var ExternalCohortTableNameInCatalogue = "CohortTests";
         const string ReleaseIdentifierFieldName = "ReleaseId";
         const string DefinitionTableForeignKeyField = "cohortDefinition_id";
-        DiscoveredDatabase _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
+        var _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
         if (_cohortDatabase.Exists())
             DeleteTables(_cohortDatabase);
         else
@@ -920,7 +920,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
                     };
 
         newExternal.SaveToDatabase();
-        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().Where(p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration").First();
+        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().First(static p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration");
         var newCohortCmd = new ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration(
             new ThrowImmediatelyActivator(RepositoryLocator),
             cic,
@@ -928,14 +928,14 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             "MyCohort",
             project,
             cohortPipeline
-            );
+        );
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
+        var extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
 
         var ec = new ExtractionConfiguration(DataExportRepository, project)
         {
             Name = "ext1",
-            Cohort_ID = _extractableCohort.ID
+            Cohort_ID = extractableCohort.ID
         };
         ec.AddDatasetToConfiguration(new ExtractableDataSet(DataExportRepository, catalogue));
 
@@ -951,7 +951,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         var argumentTblNamePattern = destinationArguments.Single(a => a.Name == "TableNamingPattern");
         var reExtract = destinationArguments.Single(a => a.Name == "AppendDataIfTableExists");
         Assert.That(argumentServer.Name, Is.EqualTo("TargetDatabaseServer"));
-        ExternalDatabaseServer _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
+        var _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
         {
             Server = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.Name,
             Username = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExplicitUsernameIfAny,
@@ -1014,17 +1014,17 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         //add new entry here
         var tbl = db.DiscoverTables(false).First();
         tbl.Insert(new Dictionary<string, object>
-            {
-                { "chi","1111111111"},
-                {"notes","T"},
-                {"dtCreated", new DateTime(2001, 1, 2) },
-                {"century",19},
-                {"surname","1234"},
-                {"forename","yes"},
-                {"sex","M"},
-            });
+        {
+            { "chi","1111111111"},
+            {"notes","T"},
+            {"dtCreated", new DateTime(2001, 1, 2) },
+            {"century",19},
+            {"surname","1234"},
+            {"forename","yes"},
+            {"sex","M"},
+        });
 
-        CohortIdentificationConfiguration cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic2.CreateRootContainerIfNotExists();
         var agg12 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         _ = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -1037,7 +1037,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         agg12.SaveToDatabase();
 
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
+        var _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
         ec.Cohort_ID = _extractableCohort2.ID;
         ec.SaveToDatabase();
 
@@ -1094,8 +1094,8 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             null, db, pipe, null);
 
         cmd.Execute();
-        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().Where(c => c.Name == "bob").FirstOrDefault();
-        var chiColumnInfo = catalogue.CatalogueItems.Where(ci => ci.Name == "chi").First();
+        var catalogue = CatalogueRepository.GetAllObjects<Catalogue>().FirstOrDefault(static c => c.Name == "bob");
+        var chiColumnInfo = catalogue.CatalogueItems.First(static ci => ci.Name == "chi");
         var ei = chiColumnInfo.ExtractionInformation;
         ei.IsPrimaryKey = true;
         ei.IsExtractionIdentifier = true;
@@ -1103,11 +1103,11 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
 
         var project = new Project(DataExportRepository, "MyProject")
         {
-            ProjectNumber = 500
+            ProjectNumber = 500,
+            ExtractionDirectory = Path.GetTempPath()
         };
-        project.ExtractionDirectory = Path.GetTempPath();
         project.SaveToDatabase();
-        CohortIdentificationConfiguration cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic.CreateRootContainerIfNotExists();
         var agg1 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         var conf = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -1119,13 +1119,13 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         dim.SaveToDatabase();
         agg1.SaveToDatabase();
 
-        string CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
-        string cohortTableName = "Cohort";
-        string definitionTableName = "CohortDefinition";
-        string ExternalCohortTableNameInCatalogue = "CohortTests";
+        var CohortDatabaseName = TestDatabaseNames.GetConsistentName("CohortDatabase");
+        var cohortTableName = "Cohort";
+        var definitionTableName = "CohortDefinition";
+        var ExternalCohortTableNameInCatalogue = "CohortTests";
         const string ReleaseIdentifierFieldName = "ReleaseId";
         const string DefinitionTableForeignKeyField = "cohortDefinition_id";
-        DiscoveredDatabase _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
+        var _cohortDatabase = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExpectDatabase(CohortDatabaseName);
         if (_cohortDatabase.Exists())
             DeleteTables(_cohortDatabase);
         else
@@ -1179,7 +1179,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
                     };
 
         newExternal.SaveToDatabase();
-        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().Where(p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration").First();
+        var cohortPipeline = CatalogueRepository.GetAllObjects<Pipeline>().First(static p => p.Name == "CREATE COHORT:By Executing Cohort Identification Configuration");
         var newCohortCmd = new ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration(
             new ThrowImmediatelyActivator(RepositoryLocator),
             cic,
@@ -1187,14 +1187,14 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             "MyCohort",
             project,
             cohortPipeline
-            );
+        );
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
+        var extractableCohort = new ExtractableCohort(DataExportRepository, newExternal, 1);
 
         var ec = new ExtractionConfiguration(DataExportRepository, project)
         {
             Name = "ext1",
-            Cohort_ID = _extractableCohort.ID
+            Cohort_ID = extractableCohort.ID
         };
         ec.AddDatasetToConfiguration(new ExtractableDataSet(DataExportRepository, catalogue));
 
@@ -1205,20 +1205,20 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             typeof(ExecuteFullExtractionToDatabaseMSSql), 0, "MS SQL Destination");
         var destinationArguments = component.CreateArgumentsForClassIfNotExists<ExecuteFullExtractionToDatabaseMSSql>()
             .ToList();
-        var argumentServer = destinationArguments.Single(a => a.Name == "TargetDatabaseServer");
-        var argumentDbNamePattern = destinationArguments.Single(a => a.Name == "DatabaseNamingPattern");
-        var argumentTblNamePattern = destinationArguments.Single(a => a.Name == "TableNamingPattern");
-        var reExtract = destinationArguments.Single(a => a.Name == "AppendDataIfTableExists");
+        var argumentServer = destinationArguments.Single(static a => a.Name == "TargetDatabaseServer");
+        var argumentDbNamePattern = destinationArguments.Single(static a => a.Name == "DatabaseNamingPattern");
+        var argumentTblNamePattern = destinationArguments.Single(static a => a.Name == "TableNamingPattern");
+        var reExtract = destinationArguments.Single(static a => a.Name == "AppendDataIfTableExists");
         Assert.That(argumentServer.Name, Is.EqualTo("TargetDatabaseServer"));
-        ExternalDatabaseServer _extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
+        var extractionServer = new ExternalDatabaseServer(CatalogueRepository, "myserver", null)
         {
             Server = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.Name,
             Username = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExplicitUsernameIfAny,
             Password = DiscoveredServerICanCreateRandomDatabasesAndTablesOn.ExplicitPasswordIfAny
         };
-        _extractionServer.SaveToDatabase();
+        extractionServer.SaveToDatabase();
 
-        argumentServer.SetValue(_extractionServer);
+        argumentServer.SetValue(extractionServer);
         argumentServer.SaveToDatabase();
         argumentDbNamePattern.SetValue($"{TestDatabaseNames.Prefix}$p_$n");
         argumentDbNamePattern.SaveToDatabase();
@@ -1231,8 +1231,9 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
             typeof(ExecuteCrossServerDatasetExtractionSource), -1, "Source");
         var arguments2 = component2.CreateArgumentsForClassIfNotExists<ExecuteCrossServerDatasetExtractionSource>()
             .ToArray();
-        arguments2.Single(a => a.Name.Equals("AllowEmptyExtractions")).SetValue(false);
-        arguments2.Single(a => a.Name.Equals("AllowEmptyExtractions")).SaveToDatabase();
+        var allowEmpty = arguments2.Single(static a => a.Name.Equals("AllowEmptyExtractions"));
+        allowEmpty.SetValue(false);
+        allowEmpty.SaveToDatabase();
 
         //configure the component as the destination
         extractionPipeline.DestinationPipelineComponent_ID = component.ID;
@@ -1275,17 +1276,17 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         ////add new entry here
         var tbl = db.DiscoverTables(false).First();
         tbl.Insert(new Dictionary<string, object>
-            {
-                { "chi","1111111111"},
-                {"notes","T"},
-                {"dtCreated", new DateTime(2001, 1, 2) },
-                {"century",19},
-                {"surname","1234"},
-                {"forename","yes"},
-                {"sex","M"},
-            });
+        {
+            { "chi","1111111111"},
+            {"notes","T"},
+            {"dtCreated", new DateTime(2001, 1, 2) },
+            {"century",19},
+            {"surname","1234"},
+            {"forename","yes"},
+            {"sex","M"},
+        });
 
-        CohortIdentificationConfiguration cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
+        var cic2 = new CohortIdentificationConfiguration(CatalogueRepository, "Cohort1");
         cic2.CreateRootContainerIfNotExists();
         var agg12 = new AggregateConfiguration(CatalogueRepository, catalogue, "agg1");
         _ = new AggregateConfiguration(CatalogueRepository, catalogue, "UnitTestShortcutAggregate");
@@ -1298,7 +1299,7 @@ public class ExecuteFullExtractionToDatabaseMSSqlDestinationReExtractionTest : D
         agg12.SaveToDatabase();
 
         newCohortCmd.Execute();
-        ExtractableCohort _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
+        var _extractableCohort2 = new ExtractableCohort(DataExportRepository, newExternal, 2);
         ec.Cohort_ID = _extractableCohort2.ID;
         ec.SaveToDatabase();
 

--- a/Rdmp.Core.Tests/DataLoad/Engine/Integration/DataTableUploadDestinationTests.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Integration/DataTableUploadDestinationTests.cs
@@ -1551,10 +1551,11 @@ ALTER TABLE DroppedColumnsTable add color varchar(1)
             destination.Dispose(ThrowImmediatelyDataLoadEventListener.Quiet, ex);
             throw;
         }
-        var t = db.DiscoverTables(false).Select(t => t.GetRuntimeName()).ToList();
+
+        var t = db.DiscoverTables(false).Select(static t => t.GetRuntimeName()).ToList();
         Assert.That(t.Contains("DataTableUploadDestinationTests_Archive"), Is.EqualTo(false));
-        var destinationTable = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests").First();
-        var columns = destinationTable.DiscoverColumns().Select(c => c.GetRuntimeName());
+        var destinationTable = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests");
+        var columns = destinationTable.DiscoverColumns().Select(static c => c.GetRuntimeName());
         Assert.That(columns.Contains(SpecialFieldNames.DataLoadRunID), Is.EqualTo(false));
     }
 
@@ -1586,10 +1587,11 @@ ALTER TABLE DroppedColumnsTable add color varchar(1)
             destination.Dispose(ThrowImmediatelyDataLoadEventListener.Quiet, ex);
             throw;
         }
-        var t = db.DiscoverTables(false).Select(t => t.GetRuntimeName()).ToList();
+
+        var t = db.DiscoverTables(false).Select(static t => t.GetRuntimeName()).ToList();
         Assert.That(t.Contains("DataTableUploadDestinationTests_Archive"), Is.EqualTo(true));
-        var destinationTable = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests").First();
-        var columns = destinationTable.DiscoverColumns().Select(c => c.GetRuntimeName());
+        var destinationTable = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests");
+        var columns = destinationTable.DiscoverColumns().Select(static c => c.GetRuntimeName());
         Assert.That(columns.Contains(SpecialFieldNames.DataLoadRunID), Is.EqualTo(true));
     }
 
@@ -1633,10 +1635,12 @@ ALTER TABLE DroppedColumnsTable add color varchar(1)
             destination.Dispose(ThrowImmediatelyDataLoadEventListener.Quiet, ex);
             throw;
         }
-        var table = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests").First();
-        var resultDT = table.GetDataTable();
-        Assert.That(resultDT.Rows.Count, Is.EqualTo(1));
+
+        var table = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests");
+        using var resultDt = table.GetDataTable();
+        Assert.That(resultDt.Rows, Has.Count.EqualTo(1));
     }
+
     [Test]
     public void DataTableUploadClashSameRowWithTrigger()
     {
@@ -1678,10 +1682,12 @@ ALTER TABLE DroppedColumnsTable add color varchar(1)
             destination.Dispose(ThrowImmediatelyDataLoadEventListener.Quiet, ex);
             throw;
         }
-        var table = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests").First();
-        var resultDT = table.GetDataTable();
-        Assert.That(resultDT.Rows.Count, Is.EqualTo(1));
+
+        var table = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests");
+        using var resultDt = table.GetDataTable();
+        Assert.That(resultDt.Rows, Has.Count.EqualTo(1));
     }
+
     [Test]
     public void DataTableUploadClashUpdateNoTrigger()
     {
@@ -1730,12 +1736,13 @@ ALTER TABLE DroppedColumnsTable add color varchar(1)
         destination.PreInitialize(db, toConsole);
         Assert.Throws<Exception>(() => destination.ProcessPipelineData(dt1, toConsole, token));
         destination.Dispose(ThrowImmediatelyDataLoadEventListener.Quiet, null);
-        var table = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests").First();
-        var resultDT = table.GetDataTable();
-        Assert.That(resultDT.Rows.Count, Is.EqualTo(1));
-        Assert.That(resultDT.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
-        Assert.That(resultDT.Rows[0].ItemArray[1], Is.EqualTo("Friend"));
+        var table = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests");
+        var resultDt = table.GetDataTable();
+        Assert.That(resultDt.Rows, Has.Count.EqualTo(1));
+        Assert.That(resultDt.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
+        Assert.That(resultDt.Rows[0].ItemArray[1], Is.EqualTo("Friend"));
     }
+
     [Test]
     public void DataTableUploadClashUpdateWithTrigger()
     {
@@ -1777,16 +1784,18 @@ ALTER TABLE DroppedColumnsTable add color varchar(1)
             destination.Dispose(ThrowImmediatelyDataLoadEventListener.Quiet, ex);
             throw;
         }
-        var table = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests").First();
-        var resultDT = table.GetDataTable();
-        Assert.That(resultDT.Rows.Count, Is.EqualTo(1));
-        Assert.That(resultDT.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
-        Assert.That(resultDT.Rows[0].ItemArray[1], Is.EqualTo("Enemy"));
-        table = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests_Archive").First();
-        resultDT = table.GetDataTable();
-        Assert.That(resultDT.Rows.Count, Is.EqualTo(1));
-        Assert.That(resultDT.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
+
+        var table = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests");
+        using var resultDt = table.GetDataTable();
+        Assert.That(resultDt.Rows, Has.Count.EqualTo(1));
+        Assert.That(resultDt.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
+        Assert.That(resultDt.Rows[0].ItemArray[1], Is.EqualTo("Enemy"));
+        table = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests_Archive");
+        using var resultDt2 = table.GetDataTable();
+        Assert.That(resultDt2.Rows, Has.Count.EqualTo(1));
+        Assert.That(resultDt2.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
     }
+
     //need to test rows to modify ln 354
     //test when we drop a column
     [Test]
@@ -1830,15 +1839,16 @@ ALTER TABLE DroppedColumnsTable add color varchar(1)
             destination.Dispose(ThrowImmediatelyDataLoadEventListener.Quiet, ex);
             throw;
         }
-        var table = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests").First();
-        var resultDT = table.GetDataTable();
-        Assert.That(resultDT.Rows.Count, Is.EqualTo(1));
-        Assert.That(resultDT.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
-        Assert.That(resultDT.Rows[0].ItemArray[1], Is.EqualTo(string.Empty));
-        table = db.DiscoverTables(false).Where(t => t.GetRuntimeName() == "DataTableUploadDestinationTests_Archive").First();
-        resultDT = table.GetDataTable();
-        Assert.That(resultDT.Rows.Count, Is.EqualTo(1));
-        Assert.That(resultDT.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
+
+        var table = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests");
+        using var resultDt = table.GetDataTable();
+        Assert.That(resultDt.Rows, Has.Count.EqualTo(1));
+        Assert.That(resultDt.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
+        Assert.That(resultDt.Rows[0].ItemArray[1], Is.EqualTo(string.Empty));
+        table = db.DiscoverTables(false).First(static t => t.GetRuntimeName() == "DataTableUploadDestinationTests_Archive");
+        using var resultDt2 = table.GetDataTable();
+        Assert.That(resultDt2.Rows, Has.Count.EqualTo(1));
+        Assert.That(resultDt2.Rows[0].ItemArray[0], Is.EqualTo("Fish"));
     }
 
 

--- a/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Sources/DelimitedFileSourceTests_ResolvedAccordingToStrategy.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Sources/DelimitedFileSourceTests_ResolvedAccordingToStrategy.cs
@@ -189,13 +189,6 @@ public class DelimitedFileSourceTests_ResolvedAccordingToStrategy : DelimitedFil
             "Other People To Investigate",
             "Dennis,Hes ok,35");
 
-        void Adjust(DelimitedFlatFileDataFlowSource a)
-        {
-            a.BadDataHandlingStrategy = strategy;
-            a.AttemptToResolveNewLinesInRecords = tryToResolve;
-            a.ThrowOnEmptyFiles = true;
-        }
-
         switch (strategy)
         {
             case BadDataHandlingStrategy.ThrowException:
@@ -216,6 +209,15 @@ public class DelimitedFileSourceTests_ResolvedAccordingToStrategy : DelimitedFil
             default:
                 throw new ArgumentOutOfRangeException(nameof(strategy));
         }
+
+        return;
+
+        void Adjust(DelimitedFlatFileDataFlowSource a)
+        {
+            a.BadDataHandlingStrategy = strategy;
+            a.AttemptToResolveNewLinesInRecords = tryToResolve;
+            a.ThrowOnEmptyFiles = true;
+        }
     }
 
     [TestCase(BadDataHandlingStrategy.DivertRows, true)]
@@ -228,13 +230,6 @@ public class DelimitedFileSourceTests_ResolvedAccordingToStrategy : DelimitedFil
             "Name,Description,Age",
             "Frank,Is the greatest,100",
             "Bob");
-
-        void Adjust(DelimitedFlatFileDataFlowSource a)
-        {
-            a.BadDataHandlingStrategy = strategy;
-            a.AttemptToResolveNewLinesInRecords = tryToResolve;
-            a.ThrowOnEmptyFiles = true;
-        }
 
         switch (strategy)
         {
@@ -255,6 +250,15 @@ public class DelimitedFileSourceTests_ResolvedAccordingToStrategy : DelimitedFil
                 break;
             default:
                 throw new ArgumentOutOfRangeException(nameof(strategy));
+        }
+
+        return;
+
+        void Adjust(DelimitedFlatFileDataFlowSource a)
+        {
+            a.BadDataHandlingStrategy = strategy;
+            a.AttemptToResolveNewLinesInRecords = tryToResolve;
+            a.ThrowOnEmptyFiles = true;
         }
     }
 

--- a/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Sources/DelimitedFileSourceTests_Unresolveable.cs
+++ b/Rdmp.Core.Tests/DataLoad/Engine/Integration/PipelineTests/Sources/DelimitedFileSourceTests_Unresolveable.cs
@@ -28,13 +28,6 @@ internal class DelimitedFileSourceTests_Unresolveable : DelimitedFileSourceTests
             "Frank,Is the greatest,100",
             "Frank,Is the greatest,100");
 
-        void Adjust(DelimitedFlatFileDataFlowSource a)
-        {
-            a.BadDataHandlingStrategy = strategy;
-            a.ThrowOnEmptyFiles = true;
-            a.IgnoreQuotes = false;
-        }
-
         switch (strategy)
         {
             case BadDataHandlingStrategy.ThrowException:
@@ -57,6 +50,15 @@ internal class DelimitedFileSourceTests_Unresolveable : DelimitedFileSourceTests
             default:
                 throw new ArgumentOutOfRangeException(nameof(strategy));
         }
+
+        return;
+
+        void Adjust(DelimitedFlatFileDataFlowSource a)
+        {
+            a.BadDataHandlingStrategy = strategy;
+            a.ThrowOnEmptyFiles = true;
+            a.IgnoreQuotes = false;
+        }
     }
 
     [Test]
@@ -70,15 +72,16 @@ internal class DelimitedFileSourceTests_Unresolveable : DelimitedFileSourceTests
             "Frank,Is the greatest,100",
             "Frank,Is the greatest,100");
 
+        var dt2 = RunGetChunk(file, Adjust);
+        Assert.That(dt2.Rows, Has.Count.EqualTo(5));
+        Assert.That(dt2.Rows[1]["Description"], Is.EqualTo("\"Is the greatest"));
+        return;
+
         static void Adjust(DelimitedFlatFileDataFlowSource a)
         {
             a.BadDataHandlingStrategy = BadDataHandlingStrategy.ThrowException;
             a.ThrowOnEmptyFiles = true;
             a.IgnoreQuotes = true;
         }
-
-        var dt2 = RunGetChunk(file, Adjust);
-        Assert.That(dt2.Rows, Has.Count.EqualTo(5));
-        Assert.That(dt2.Rows[1]["Description"], Is.EqualTo("\"Is the greatest"));
     }
 }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/CohortCreationCommands/ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/CohortCreationCommands/ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfiguration.cs
@@ -70,19 +70,20 @@ public class ExecuteCommandCreateNewCohortByExecutingACohortIdentificationConfig
         if (cic == null)
             return;
 
-        if (BasicActivator.IsInteractive) {
-            var PromptForVersionOnCohortCommit = false;
-            var PromptForVersionOnCohortCommitSetting = BasicActivator.RepositoryLocator.CatalogueRepository.GetAllObjects<Setting.Setting>().Where(s => s.Key == "PromptForVersionOnCohortCommit").FirstOrDefault();
-            if (PromptForVersionOnCohortCommitSetting is not null) PromptForVersionOnCohortCommit = Convert.ToBoolean(PromptForVersionOnCohortCommitSetting.Value);
-            if (PromptForVersionOnCohortCommit && BasicActivator.YesNo("It is recommended to save your cohort as a new version before committing. Would you like to do this?", "Save cohort as new version before committing?"))
+        if (BasicActivator.IsInteractive)
+        {
+            var promptForVersionOnCohortCommit = false;
+            var promptForVersionOnCohortCommitSetting = BasicActivator.RepositoryLocator.CatalogueRepository.GetAllObjects<Setting.Setting>().FirstOrDefault(static s => s.Key == "PromptForVersionOnCohortCommit");
+            if (promptForVersionOnCohortCommitSetting is not null) promptForVersionOnCohortCommit = Convert.ToBoolean(promptForVersionOnCohortCommitSetting.Value);
+            if (promptForVersionOnCohortCommit && BasicActivator.YesNo("It is recommended to save your cohort as a new version before committing. Would you like to do this?", "Save cohort as new version before committing?"))
             {
                 var newVersion = new ExecuteCommandCreateVersionOfCohortConfiguration(BasicActivator, cic);
                 newVersion.Execute();
                 var versions = cic.GetVersions();
                 cic = versions.Last();
             }
-
         }
+
         if (Project == null && BasicActivator.CoreChildProvider is DataExportChildProvider dx)
         {
             var projAssociations = dx.AllProjectAssociatedCics

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCloneExtractionConfiguration.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandCloneExtractionConfiguration.cs
@@ -4,7 +4,6 @@
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
 // You should have received a copy of the GNU General Public License along with RDMP. If not, see <https://www.gnu.org/licenses/>.
 
-using System;
 using System.Collections.Generic;
 using System.Linq;
 using Rdmp.Core.Curation.Data;
@@ -16,48 +15,47 @@ using SixLabors.ImageSharp.PixelFormats;
 
 namespace Rdmp.Core.CommandExecution.AtomicCommands;
 
-public class ExecuteCommandCloneExtractionConfiguration : BasicCommandExecution, IAtomicCommand
+public class ExecuteCommandCloneExtractionConfiguration : BasicCommandExecution
 {
     private readonly ExtractionConfiguration _extractionConfiguration;
     private readonly IBasicActivateItems _activeItems;
-    private readonly List<IExtractableDataSet> toRemove = [];
-    private readonly List<Catalogue> toAdd = [];
+    private readonly List<IExtractableDataSet> _toRemove = [];
+    private readonly List<Catalogue> _toAdd = [];
+
     private void CheckForDeprecatedCatalogues()
     {
-        if (_extractionConfiguration.SelectedDataSets.Any(sd => sd.GetCatalogue().IsDeprecated) && _activeItems.IsInteractive)
+        if (!_extractionConfiguration.SelectedDataSets.Any(static sd => sd.GetCatalogue().IsDeprecated) ||
+            !_activeItems.IsInteractive) return;
+        if (!YesNo(
+                "There are Deprecated catalogues in this Extraction Configuration. Would you like to replace them with their replacement (where available)?",
+                "Replace Deprecated Catalogues")) return;
+
+        var repo = _activeItems.RepositoryLocator.CatalogueRepository;
+        var deprecatedDatasets = _extractionConfiguration.SelectedDataSets.Where(static sd => sd.GetCatalogue().IsDeprecated).ToList();
+        var replacedBy = repo.GetExtendedProperties(ExtendedProperty.ReplacedBy).ToArray();
+        foreach (var ds in deprecatedDatasets)
         {
-            if (YesNo("There are Deprecated catalogues in this Extraction Configuration. Would you like to replace them with their replacement (where available)?", "Replace Deprecated Catalogues"))
+            var replacement = replacedBy.FirstOrDefault(rb => rb.ReferencedObjectID == ds.GetCatalogue().ID);
+            if (replacement is null) continue;
+
+            var replacementCatalogue = repo.GetObjectByID<Catalogue>(int.Parse(replacement.Value));
+            while (replacementCatalogue.IsDeprecated)
             {
-                var repo = _activeItems.RepositoryLocator.CatalogueRepository;
-                var DeprecatedDatasets = _extractionConfiguration.SelectedDataSets.Where(sd => sd.GetCatalogue().IsDeprecated).ToList();
-                var replacedBy = repo.GetExtendedProperties(ExtendedProperty.ReplacedBy);
-                foreach (ISelectedDataSets ds in DeprecatedDatasets)
+                var replacementCatalogueIsReplacedBy = replacedBy.FirstOrDefault(rb => rb.ReferencedObjectID == replacementCatalogue.ID);
+                if (replacementCatalogueIsReplacedBy is not null)
                 {
-                    var replacement = replacedBy.Where(rb => rb.ReferencedObjectID == ds.GetCatalogue().ID).FirstOrDefault();
-                    if (replacement is not null)
-                    {
-                        var replacementCatalogue = repo.GetObjectByID<Catalogue>(Int32.Parse(replacement.Value));
-                        while (replacementCatalogue.IsDeprecated)
-                        {
-                            var replacementCatalogueIsReplacedBy = replacedBy.Where(rb => rb.ReferencedObjectID == replacementCatalogue.ID).FirstOrDefault();
-                            if(replacementCatalogueIsReplacedBy is not null)
-                            {
-                                //have found further down the tree
-                                replacementCatalogue = repo.GetObjectByID<Catalogue>(Int32.Parse(replacementCatalogueIsReplacedBy.Value));
-                            }
-                            else
-                            {
-                                //there is no replacement
-                                break;
-                            }
-                        }
-                        toRemove.Add(ds.ExtractableDataSet);
-                        toAdd.Add(replacementCatalogue);
-                    }
+                    //have found further down the tree
+                    replacementCatalogue = repo.GetObjectByID<Catalogue>(int.Parse(replacementCatalogueIsReplacedBy.Value));
                 }
-
-
+                else
+                {
+                    //there is no replacement
+                    break;
+                }
             }
+
+            _toRemove.Add(ds.ExtractableDataSet);
+            _toAdd.Add(replacementCatalogue);
         }
     }
 
@@ -82,11 +80,12 @@ public class ExecuteCommandCloneExtractionConfiguration : BasicCommandExecution,
         CheckForDeprecatedCatalogues();
 
         var clone = _extractionConfiguration.DeepCloneWithNewIDs();
-        foreach (ExtractableDataSet ds in toRemove)
+        foreach (var ds in _toRemove.Cast<ExtractableDataSet>())
         {
             clone.RemoveDatasetFromConfiguration(ds);
         }
-        foreach (Catalogue c in toAdd)
+
+        foreach (var c in _toAdd)
         {
             //check if the eds already exis
             var eds = _activeItems.RepositoryLocator.DataExportRepository.GetAllObjectsWhere<ExtractableDataSet>("Catalogue_ID", c.ID).FirstOrDefault();
@@ -95,8 +94,10 @@ public class ExecuteCommandCloneExtractionConfiguration : BasicCommandExecution,
                 eds = new ExtractableDataSet(_activeItems.RepositoryLocator.DataExportRepository, c);
                 eds.SaveToDatabase();
             }
+
             clone.AddDatasetToConfiguration(eds);
         }
+
         Publish((DatabaseEntity)clone.Project);
         Emphasise(clone);
     }

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDeprecate.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandDeprecate.cs
@@ -49,20 +49,18 @@ public class ExecuteCommandDeprecate : BasicCommandExecution
         {
             o.IsDeprecated = _desiredState;
             o.SaveToDatabase();
-            if (!_desiredState && o.GetType() == typeof(Catalogue))//false is not-depricated
+            if (!_desiredState && o is Catalogue catalogue) //false is not-deprecated
             {
-                var c = (Catalogue) o;
                 var replacedBy = _activeItems.RepositoryLocator.CatalogueRepository.GetExtendedProperties(ExtendedProperty.ReplacedBy);
-                var replacement = replacedBy.Where(rb => rb.ReferencedObjectID == c.ID).FirstOrDefault();
-                if(replacedBy != null)
-                    replacement.DeleteInDatabase();
+                var replacement = replacedBy.FirstOrDefault(rb => rb.ReferencedObjectID == catalogue.ID);
+                replacement?.DeleteInDatabase();
             }
         }
 
-       
 
         if (!BasicActivator.IsInteractive || _o.Length != 1 || _o[0] is not Catalogue || !_desiredState ||
             !BasicActivator.YesNo("Do you have a replacement Catalogue you want to link?", "Replacement")) return;
+
         var cmd = new ExecuteCommandReplacedBy(BasicActivator, _o[0], null)
         {
             PromptToPickReplacement = true

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandRevertToHistoricalCohortVersion.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandRevertToHistoricalCohortVersion.cs
@@ -35,10 +35,11 @@ public class ExecuteCommandRevertToHistoricalCohortVersion : BasicCommandExecuti
 
     public override void Execute()
     {
-        if (!_activator.RepositoryLocator.CatalogueRepository.GetAllObjectsWhere<CohortIdentificationConfiguration>("ClonedFrom_ID", _configuration.ID).Where(cic => cic.Version != null && cic.ID == _historicalConfiguration.ID).Any())
+        if (!_activator.RepositoryLocator.CatalogueRepository.GetAllObjectsWhere<CohortIdentificationConfiguration>("ClonedFrom_ID", _configuration.ID).Any(cic => cic.Version != null && cic.ID == _historicalConfiguration.ID))
         {
             throw new System.Exception("Historical configuration is not derived from this cohort configuration");
         }
+
         base.Execute();
         var clone = _historicalConfiguration.CloneIntoExistingConfiguration(ThrowImmediatelyCheckNotifier.Quiet, _configuration,false);
         Publish(clone);

--- a/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandUpdateCatalogueDataLocation.cs
+++ b/Rdmp.Core/CommandExecution/AtomicCommands/ExecuteCommandUpdateCatalogueDataLocation.cs
@@ -56,10 +56,10 @@ public class ExecuteCommandUpdateCatalogueDataLocation : BasicCommandExecution, 
 
             var discoveredColumns = _table.DiscoverColumns();
 
-            var foundColumn = discoveredColumns.AsEnumerable()
-                .Where(dc => dc.GetFullyQualifiedName().Contains(newColumn)).FirstOrDefault();
+            var foundColumn = discoveredColumns
+                .AsEnumerable().FirstOrDefault(dc => dc.GetFullyQualifiedName().Contains(newColumn));
             if (foundColumn is null) return $"Unable to find column '{newColumn}' in selected table";
-            if (foundColumn.DataType.ToString() != item.ColumnInfo.Data_type)
+            if (foundColumn.DataType?.ToString() != item.ColumnInfo.Data_type)
                 return
                     $"The data type of column '{newColumn}' is of type '{foundColumn.DataType}'. This does not match the current type of '{item.ColumnInfo.Data_type}'";
         }

--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -844,8 +844,10 @@ public sealed class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInject
             return -string.Compare(obj.ToString(), ToString(),
                 StringComparison.CurrentCulture); //sort alphabetically (reverse)
 
-        throw new Exception($"Cannot compare {GetType().Name} to {obj.GetType().Name}");
+        throw new Exception($"Cannot compare {GetType().Name} to {obj?.GetType().Name}");
     }
+
+    public new bool Equals(object obj) => obj is Catalogue c && (ReferenceEquals(this, c) || base.Equals(c));
 
     /// <summary>
     /// Checks that the Catalogue has a sensible Name (See <see cref="IsAcceptableName(string)"/>).  Then checks that there are no missing ColumnInfos

--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -35,7 +35,7 @@ using Rdmp.Core.Ticketing;
 namespace Rdmp.Core.Curation.Data;
 
 /// <inheritdoc cref="ICatalogue"/>
-public class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<CatalogueItem[]>,
+public sealed class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<CatalogueItem[]>,
     IInjectKnown<CatalogueExtractabilityStatus>
 {
     #region Database Properties

--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -36,7 +36,7 @@ namespace Rdmp.Core.Curation.Data;
 
 /// <inheritdoc cref="ICatalogue"/>
 public sealed class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInjectKnown<CatalogueItem[]>,
-    IInjectKnown<CatalogueExtractabilityStatus>
+    IInjectKnown<CatalogueExtractabilityStatus>, IEquatable<Catalogue>
 {
     #region Database Properties
 
@@ -847,7 +847,20 @@ public sealed class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInject
         throw new Exception($"Cannot compare {GetType().Name} to {obj?.GetType().Name}");
     }
 
-    public new bool Equals(object obj) => obj is Catalogue c && (ReferenceEquals(this, c) || base.Equals(c));
+    public override bool Equals(object obj) => obj is Catalogue c && (ReferenceEquals(this, c) || Equals(c));
+
+    public bool Equals(Catalogue other)
+    {
+        if (other is null) return false;
+        if (ReferenceEquals(this, other)) return true;
+        return _acronym == other._acronym && _name == other._name && _folder == other._folder && _description == other._description && Equals(_detailPageUrl, other._detailPageUrl) && _type == other._type && _periodicity == other._periodicity && _granularity == other._granularity && _geographicalCoverage == other._geographicalCoverage && _backgroundSummary == other._backgroundSummary && _searchKeywords == other._searchKeywords && _updateFreq == other._updateFreq && _updateSched == other._updateSched && _timeCoverage == other._timeCoverage && Nullable.Equals(_lastRevisionDate, other._lastRevisionDate) && _contactDetails == other._contactDetails && _resourceOwner == other._resourceOwner && _attributionCitation == other._attributionCitation && _accessOptions == other._accessOptions && _subjectNumbers == other._subjectNumbers && Equals(_apiAccessUrl, other._apiAccessUrl) && Equals(_browseUrl, other._browseUrl) && Equals(_bulkDownloadUrl, other._bulkDownloadUrl) && Equals(_queryToolUrl, other._queryToolUrl) && Equals(_sourceUrl, other._sourceUrl) && _countryOfOrigin == other._countryOfOrigin && _dataStandards == other._dataStandards && _administrativeContactName == other._administrativeContactName && _administrativeContactEmail == other._administrativeContactEmail && _administrativeContactTelephone == other._administrativeContactTelephone && _administrativeContactAddress == other._administrativeContactAddress && _explicitConsent == other._explicitConsent && _ethicsApprover == other._ethicsApprover && _sourceOfDataCollection == other._sourceOfDataCollection && _ticket == other._ticket && Nullable.Equals(_datasetStartDate, other._datasetStartDate) && _loggingDataTask == other._loggingDataTask && _validatorXml == other._validatorXml && _timeCoverageExtractionInformationID == other._timeCoverageExtractionInformationID && _pivotCategoryExtractionInformationID == other._pivotCategoryExtractionInformationID && _isDeprecated == other._isDeprecated && _isInternalDataset == other._isInternalDataset && _isColdStorageDataset == other._isColdStorageDataset && _liveLoggingServerID == other._liveLoggingServerID && Equals(_knownCatalogueItems, other._knownCatalogueItems) && Equals(_extractabilityStatus, other._extractabilityStatus) && base.Equals(other);
+    }
+
+    public override int GetHashCode() => HashCode.Combine(typeof(Catalogue), ID);
+
+    public static bool operator ==(Catalogue left, Catalogue right) => Equals(left, right);
+
+    public static bool operator !=(Catalogue left, Catalogue right) => !Equals(left, right);
 
     /// <summary>
     /// Checks that the Catalogue has a sensible Name (See <see cref="IsAcceptableName(string)"/>).  Then checks that there are no missing ColumnInfos

--- a/Rdmp.Core/Curation/Data/Catalogue.cs
+++ b/Rdmp.Core/Curation/Data/Catalogue.cs
@@ -849,14 +849,9 @@ public sealed class Catalogue : DatabaseEntity, IComparable, ICatalogue, IInject
 
     public override bool Equals(object obj) => obj is Catalogue c && (ReferenceEquals(this, c) || Equals(c));
 
-    public bool Equals(Catalogue other)
-    {
-        if (other is null) return false;
-        if (ReferenceEquals(this, other)) return true;
-        return _acronym == other._acronym && _name == other._name && _folder == other._folder && _description == other._description && Equals(_detailPageUrl, other._detailPageUrl) && _type == other._type && _periodicity == other._periodicity && _granularity == other._granularity && _geographicalCoverage == other._geographicalCoverage && _backgroundSummary == other._backgroundSummary && _searchKeywords == other._searchKeywords && _updateFreq == other._updateFreq && _updateSched == other._updateSched && _timeCoverage == other._timeCoverage && Nullable.Equals(_lastRevisionDate, other._lastRevisionDate) && _contactDetails == other._contactDetails && _resourceOwner == other._resourceOwner && _attributionCitation == other._attributionCitation && _accessOptions == other._accessOptions && _subjectNumbers == other._subjectNumbers && Equals(_apiAccessUrl, other._apiAccessUrl) && Equals(_browseUrl, other._browseUrl) && Equals(_bulkDownloadUrl, other._bulkDownloadUrl) && Equals(_queryToolUrl, other._queryToolUrl) && Equals(_sourceUrl, other._sourceUrl) && _countryOfOrigin == other._countryOfOrigin && _dataStandards == other._dataStandards && _administrativeContactName == other._administrativeContactName && _administrativeContactEmail == other._administrativeContactEmail && _administrativeContactTelephone == other._administrativeContactTelephone && _administrativeContactAddress == other._administrativeContactAddress && _explicitConsent == other._explicitConsent && _ethicsApprover == other._ethicsApprover && _sourceOfDataCollection == other._sourceOfDataCollection && _ticket == other._ticket && Nullable.Equals(_datasetStartDate, other._datasetStartDate) && _loggingDataTask == other._loggingDataTask && _validatorXml == other._validatorXml && _timeCoverageExtractionInformationID == other._timeCoverageExtractionInformationID && _pivotCategoryExtractionInformationID == other._pivotCategoryExtractionInformationID && _isDeprecated == other._isDeprecated && _isInternalDataset == other._isInternalDataset && _isColdStorageDataset == other._isColdStorageDataset && _liveLoggingServerID == other._liveLoggingServerID && Equals(_knownCatalogueItems, other._knownCatalogueItems) && Equals(_extractabilityStatus, other._extractabilityStatus) && base.Equals(other);
-    }
+    public bool Equals(Catalogue other) => base.Equals(other);
 
-    public override int GetHashCode() => HashCode.Combine(typeof(Catalogue), ID);
+    public override int GetHashCode() => base.GetHashCode();
 
     public static bool operator ==(Catalogue left, Catalogue right) => Equals(left, right);
 

--- a/Rdmp.Core/Curation/Data/Overview/OverviewModel.cs
+++ b/Rdmp.Core/Curation/Data/Overview/OverviewModel.cs
@@ -13,7 +13,6 @@ using Rdmp.Core.QueryBuilding;
 using Rdmp.Core.Repositories;
 using Rdmp.Core.ReusableLibraryCode.DataAccess;
 using System;
-using System.Collections;
 using System.Collections.Generic;
 using System.Data;
 using System.Linq;
@@ -25,7 +24,6 @@ namespace Rdmp.Core.Curation.Data.Overview;
 /// </summary>
 public class OverviewModel
 {
-
     private readonly ICatalogue _catalogue;
     private readonly IBasicActivateItems _activator;
 
@@ -46,20 +44,22 @@ public class OverviewModel
 
     public void Regen(string whereClause)
     {
-        DataTable dt = new();
-        bool hasExtractionIdentifier = true;
-        var column = _catalogue.CatalogueItems.Where(ci => ci.ExtractionInformation.IsExtractionIdentifier).FirstOrDefault();
+        using var dt = new DataTable();
+        var hasExtractionIdentifier = true;
+        var column = _catalogue.CatalogueItems.FirstOrDefault(static ci => ci.ExtractionInformation.IsExtractionIdentifier);
         if (column is null)
         {
             column = _catalogue.CatalogueItems.FirstOrDefault();
             hasExtractionIdentifier = false;
         }
+
         if (column is null) return;
+
         var discoveredColumn = column.ColumnInfo.Discover(DataAccessContext.InternalDataProcessing);
         var server = discoveredColumn.Table.Database.Server;
         using var con = server.GetConnection();
         con.Open();
-        string populatedWhere = !string.IsNullOrWhiteSpace(whereClause) ? $"WHERE {whereClause}" : "";
+        var populatedWhere = !string.IsNullOrWhiteSpace(whereClause) ? $"WHERE {whereClause}" : "";
         var sql = $"SELECT {column.ColumnInfo.GetRuntimeName()} FROM {discoveredColumn.Table.GetRuntimeName()} {populatedWhere}";
         using var cmd = server.GetCommand(sql, con);
         cmd.CommandTimeout = 30000;
@@ -67,11 +67,11 @@ public class OverviewModel
         dt.BeginLoadData();
         da.Fill(dt);
         dt.EndLoadData();
-        con.Dispose();
         _numberOfRecords = dt.Rows.Count;
-        _numberOfPeople = hasExtractionIdentifier?dt.AsEnumerable().Select(r => r[column.ColumnInfo.GetRuntimeName()]).ToList().Distinct().Count():0;
+        _numberOfPeople = hasExtractionIdentifier
+            ? dt.AsEnumerable().Select(r => r[column.ColumnInfo.GetRuntimeName()]).Distinct().Count()
+            : 0;
         GetDataLoads();
-        dt.Dispose();
     }
 
     public int GetNumberOfRecords()
@@ -86,7 +86,7 @@ public class OverviewModel
 
     public Tuple<DateTime, DateTime> GetStartEndDates(ColumnInfo dateColumn, string whereClause)
     {
-        DataTable dt = new();
+        using var dt = new DataTable();
 
         var discoveredColumn = _catalogue.CatalogueItems.First().ColumnInfo.Discover(DataAccessContext.InternalDataProcessing);
         var server = discoveredColumn.Table.Database.Server;
@@ -122,41 +122,37 @@ public class OverviewModel
             dt.BeginLoadData();
             da.Fill(dt);
             var latest = dt.AsEnumerable()
-               .Max(r => r.Field<DateTime>(dateColumn.Name));
+                .Max(r => r.Field<DateTime>(dateColumn.Name));
             var earliest = dt.AsEnumerable()
-              .Min(r => r.Field<DateTime>(dateColumn.Name));
-            dt = new();
-            dt.Rows.Add([earliest, latest]);
+                .Min(r => r.Field<DateTime>(dateColumn.Name));
+            dt.Rows.Clear();
+            dt.Rows.Add(earliest, latest);
         }
-        con.Dispose();
+
         return new Tuple<DateTime, DateTime>(DateTime.Parse(dt.Rows[0].ItemArray[0].ToString()), DateTime.Parse(dt.Rows[0].ItemArray[1].ToString()));
     }
 
 
     public static DataTable GetCountsByDatePeriod(ColumnInfo dateColumn, string datePeriod, string optionalWhere = "")
     {
-        DataTable dt = new();
+        var dt = new DataTable();
         if (!(new[] { "Day", "Month", "Year" }).Contains(datePeriod))
         {
             throw new Exception("Invalid Date period");
         }
+
         var discoveredColumn = dateColumn.Discover(DataAccessContext.InternalDataProcessing);
         var server = discoveredColumn.Table.Database.Server;
         using var con = server.GetConnection();
         con.Open();
-        var dateString = "yyyy-MM";
-        switch (datePeriod)
+        var dateString = datePeriod switch
         {
-            case "Day":
-                dateString = "yyyy-MM-dd";
-                break;
-            case "Month":
-                dateString = "yyyy-MM";
-                break;
-            case "Year":
-                dateString = "yyyy";
-                break;
-        }
+            "Day" => "yyyy-MM-dd",
+            "Month" => "yyyy-MM",
+            "Year" => "yyyy",
+            _ => "yyyy-MM"
+        };
+
         if (server.DatabaseType == FAnsi.DatabaseType.MicrosoftSQLServer)
         {
             var sql = @$"
@@ -190,51 +186,51 @@ public class OverviewModel
             {
                 counts[key]++;
             }
+
             dt = new DataTable();
             foreach (var item in counts)
             {
-                DataRow dr = dt.NewRow();
+                var dr = dt.NewRow();
                 dr["YearMonth"] = item.Key;
                 dr["# Records"] = item.Value;
                 dt.Rows.Add(dr);
             }
-            dt.EndLoadData();
 
+            dt.EndLoadData();
         }
-        con.Dispose();
+
         return dt;
     }
 
     private void GetDataLoads()
     {
-        _dataLoads = new();
+        _dataLoads = new DataTable();
         var repo = new MemoryCatalogueRepository();
         var qb = new QueryBuilder(null, null);
-        var columnInfo = _catalogue.CatalogueItems.Where(c => c.Name == SpecialFieldNames.DataLoadRunID).Select(c => c.ColumnInfo).FirstOrDefault();
-        if (columnInfo != null)
-        {
-            qb.AddColumn(new ColumnInfoToIColumn(repo, columnInfo));
-            qb.AddCustomLine($"{columnInfo.Name} IS NOT NULL", FAnsi.Discovery.QuerySyntax.QueryComponent.WHERE);
-            var sql = qb.SQL;
-            var server = columnInfo.Discover(DataAccessContext.InternalDataProcessing).Table.Database.Server;
-            using var con = server.GetConnection();
-            con.Open();
+        var columnInfo = _catalogue.CatalogueItems.Where(static c => c.Name == SpecialFieldNames.DataLoadRunID).Select(c => c.ColumnInfo).FirstOrDefault();
+        if (columnInfo == null) return;
 
-            using var cmd = server.GetCommand(sql, con);
-            cmd.CommandTimeout = 30000;
-            using var da = server.GetDataAdapter(cmd);
-            _dataLoads.BeginLoadData();
-            da.Fill(_dataLoads);
-            _dataLoads.EndLoadData();
-        }
+        qb.AddColumn(new ColumnInfoToIColumn(repo, columnInfo));
+        qb.AddCustomLine($"{columnInfo.Name} IS NOT NULL", FAnsi.Discovery.QuerySyntax.QueryComponent.WHERE);
+        var sql = qb.SQL;
+        var server = columnInfo.Discover(DataAccessContext.InternalDataProcessing).Table.Database.Server;
+        using var con = server.GetConnection();
+        con.Open();
 
+        using var cmd = server.GetCommand(sql, con);
+        cmd.CommandTimeout = 30000;
+        using var da = server.GetDataAdapter(cmd);
+        _dataLoads.BeginLoadData();
+        da.Fill(_dataLoads);
+        _dataLoads.EndLoadData();
     }
 
     public DataTable GetMostRecentDataLoad()
     {
         if (_dataLoads == null) GetDataLoads();
         if (_dataLoads.Rows.Count == 0) return null;
-        var maxDataLoadId = _dataLoads.AsEnumerable().Select(r => int.Parse(r[0].ToString())).Distinct().Max();
+
+        var maxDataLoadId = _dataLoads.AsEnumerable().Select(static r => int.Parse(r[0].ToString())).Max();
         var loggingServers = _activator.RepositoryLocator.CatalogueRepository.GetAllObjectsWhere<ExternalDatabaseServer>("CreatedByAssembly", "Rdmp.Core/Databases.LoggingDatabase");
         var columnInfo = _catalogue.CatalogueItems.Where(c => c.Name == SpecialFieldNames.DataLoadRunID).Select(c => c.ColumnInfo).First();
         var server = columnInfo.Discover(DataAccessContext.InternalDataProcessing).Table.Database.Server;
@@ -253,12 +249,12 @@ public class OverviewModel
             dt.BeginLoadData();
             loggingDa.Fill(dt);
             dt.EndLoadData();
-            loggingCon.Dispose();
             if (dt.Rows.Count > 0)
             {
                 break;
             }
         }
+
         return dt;
     }
 
@@ -267,7 +263,5 @@ public class OverviewModel
         var datasets = _activator.RepositoryLocator.DataExportRepository.GetAllObjectsWhere<ExtractableDataSet>("Catalogue_ID", _catalogue.ID).Select(d => d.ID);
         var results = _activator.RepositoryLocator.DataExportRepository.GetAllObjects<CumulativeExtractionResults>().Where(result => datasets.Contains(result.ExtractableDataSet_ID)).ToList();
         return results;
-
     }
-
 }

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -323,11 +323,12 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
         if (includesReleaseIdentifier)
             foreach (var idx in _extractionIdentifiersidx.Distinct().ToList())
             {
-                var sub = Request.ReleaseIdentifierSubstitutions.Where(s => s.Alias == chunk.Columns[idx].ColumnName).FirstOrDefault();
-                if (sub != null && sub.ColumnInfo.ExtractionInformations.FirstOrDefault() != null && sub.ColumnInfo.ExtractionInformations.FirstOrDefault().IsPrimaryKey)
+                var sub = Request.ReleaseIdentifierSubstitutions.FirstOrDefault(s => s.Alias == chunk.Columns[idx].ColumnName);
+                if (sub?.ColumnInfo.ExtractionInformations.FirstOrDefault()?.IsPrimaryKey == true)
                 {
                     pks.Add(chunk.Columns[idx]);
                 }
+
                 foreach (DataRow r in chunk.Rows)
                 {
                     if (r[idx] == DBNull.Value)
@@ -347,10 +348,7 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
             }
 
         _timeSpentCalculatingDISTINCT.Stop();
-        foreach (string name in Request.ColumnsToExtract.Where(c => ((ExtractableColumn)(c)).CatalogueExtractionInformation.IsPrimaryKey).Select(column => ((ExtractableColumn)column).CatalogueExtractionInformation.ToString()))
-        {
-            pks.Add(chunk.Columns[name]);
-        }
+        pks.AddRange(Request.ColumnsToExtract.Where(static c => ((ExtractableColumn)c).CatalogueExtractionInformation.IsPrimaryKey).Select(static column => ((ExtractableColumn)column).CatalogueExtractionInformation.ToString()).Select(name => chunk.Columns[name]));
         chunk.PrimaryKey = pks.ToArray();
 
         return chunk;

--- a/Rdmp.Core/DataLoad/Engine/Job/JobFactory.cs
+++ b/Rdmp.Core/DataLoad/Engine/Job/JobFactory.cs
@@ -31,8 +31,7 @@ public class JobFactory : IJobFactory
         HICDatabaseConfiguration configuration)
     {
         var description = _loadMetadata.Name;
-        LoadDirectory loadDirectory;
-        loadDirectory = new LoadDirectory(_loadMetadata.LocationOfForLoadingDirectory, _loadMetadata.LocationOfForArchivingDirectory, _loadMetadata.LocationOfExecutablesDirectory, _loadMetadata.LocationOfCacheDirectory);
+        var loadDirectory = new LoadDirectory(_loadMetadata.LocationOfForLoadingDirectory, _loadMetadata.LocationOfForArchivingDirectory, _loadMetadata.LocationOfExecutablesDirectory, _loadMetadata.LocationOfCacheDirectory);
 
         return new DataLoadJob(repositoryLocator, description, _logManager, _loadMetadata, loadDirectory, listener,
             configuration);

--- a/Rdmp.Core/DataLoad/Engine/Job/Scheduling/SingleScheduledJobFactory.cs
+++ b/Rdmp.Core/DataLoad/Engine/Job/Scheduling/SingleScheduledJobFactory.cs
@@ -38,9 +38,7 @@ public class SingleScheduledJobFactory : ScheduledJobFactory
     protected override ScheduledDataLoadJob CreateImpl(IRDMPPlatformRepositoryServiceLocator repositoryLocator,
         IDataLoadEventListener listener, HICDatabaseConfiguration configuration)
     {
-        LoadDirectory loadDirectory;
-
-        loadDirectory = new LoadDirectory(LoadMetadata.LocationOfForLoadingDirectory, LoadMetadata.LocationOfForArchivingDirectory, LoadMetadata.LocationOfExecutablesDirectory, LoadMetadata.LocationOfCacheDirectory);
+        var loadDirectory = new LoadDirectory(LoadMetadata.LocationOfForLoadingDirectory, LoadMetadata.LocationOfForArchivingDirectory, LoadMetadata.LocationOfExecutablesDirectory, LoadMetadata.LocationOfCacheDirectory);
 
         return new ScheduledDataLoadJob(repositoryLocator, JobDescription, LogManager, LoadMetadata, loadDirectory,
             listener, configuration)

--- a/Rdmp.Core/DataLoad/Engine/Pipeline/Destinations/DataTableUploadDestination.cs
+++ b/Rdmp.Core/DataLoad/Engine/Pipeline/Destinations/DataTableUploadDestination.cs
@@ -669,15 +669,15 @@ public class DataTableUploadDestination : IPluginDataFlowComponent<DataTable>, I
             }
         }
 
-        if (UseTrigger && _discoveredTable.DiscoverColumns().Any(static col => col.IsPrimaryKey)) //can't use triggers without a PK
+        if (UseTrigger && _discoveredTable?.DiscoverColumns().Any(static col => col.IsPrimaryKey) == true) //can't use triggers without a PK
         {
             var factory = new TriggerImplementerFactory(_database.Server.DatabaseType);
-            var _triggerImplementer = factory.Create(_discoveredTable);
-            var currentStatus = _triggerImplementer.GetTriggerStatus();
+            var triggerImplementer = factory.Create(_discoveredTable);
+            var currentStatus = triggerImplementer.GetTriggerStatus();
             if (currentStatus == TriggerStatus.Missing)
                 try
                 {
-                    _triggerImplementer.CreateTrigger(ThrowImmediatelyCheckNotifier.Quiet);
+                    triggerImplementer.CreateTrigger(ThrowImmediatelyCheckNotifier.Quiet);
                 }
                 catch (Exception e)
                 {

--- a/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandReorderFilter.cs
+++ b/Rdmp.UI/CommandExecution/AtomicCommands/ExecuteCommandReorderFilter.cs
@@ -37,12 +37,9 @@ public class ExecuteCommandReorderFilter : BasicUICommandExecution
     {
         var order = _target.Order;
 
-        var filters = _target.FilterContainer.GetFilters().Where(f => f is ConcreteFilter).Select(f => (ConcreteFilter)f).ToArray();
-        Array.Sort(
-           filters,
-            delegate (ConcreteFilter a, ConcreteFilter b) { return a.Order.CompareTo(b.Order); }
-        );
-        if (!filters.All(c => c.Order != order))
+        var filters = _target.FilterContainer.GetFilters().OfType<ConcreteFilter>().OrderBy(static f => f.Order).ToArray();
+        // Conflict? Create a space by moving earlier filters down one, later filters up one
+        if (filters.Any(c => c.Order == order))
         {
             foreach (var orderable in filters)
             {
@@ -55,6 +52,7 @@ public class ExecuteCommandReorderFilter : BasicUICommandExecution
                 ((ISaveable)orderable).SaveToDatabase();
             }
         }
+
         _source.Order = order;
         _source.SaveToDatabase();
         Publish(_target.FilterContainer);

--- a/Rdmp.UI/ExtractionUIs/JoinsAndLookups/LookupConfigurationUI.cs
+++ b/Rdmp.UI/ExtractionUIs/JoinsAndLookups/LookupConfigurationUI.cs
@@ -259,29 +259,38 @@ public partial class LookupConfigurationUI : LookupConfiguration_Design
             HandleError("No Lookup table selected");
             return false;
         }
-        if (PKRelations.Where(d => d.SelectedItem != null).Count() == 0 || FKRelations.Where(d => d.SelectedItem != null).Count() == 0)
+
+        var pk = PKRelations.Count(static d => d.SelectedItem != null);
+        var fk = FKRelations.Count(static d => d.SelectedItem != null);
+
+        if (pk == 0 || fk == 0)
         {
             HandleError("At least one PK FK mapping must be set");
             return false;
         }
-        if (PKRelations.Where(d => d.SelectedItem != null).Count() != FKRelations.Where(d => d.SelectedItem != null).Count())
+
+        if (pk != fk)
         {
             HandleError("Must have a 1-to-1 mapping of PK and FK mappings");
             return false;
         }
-        if (Descriptions.Where(d => d.SelectedItem != null).Count() == 0)
+
+        var descColumnInfos = Descriptions.Where(static d => d.SelectedItem != null).Select(static d => ((ColumnInfo)d.SelectedItem).ID).ToArray();
+        if (descColumnInfos.Length == 0)
         {
             HandleError("At least one Description column must be set");
             return false;
         }
-        var descColumnInfos = Descriptions.Where(d => d.SelectedItem != null).Select(d => ((ColumnInfo)d.SelectedItem).ID);
-        var pkColumnInfos = PKRelations.Where(d => d.SelectedItem != null).Select(d => ((ColumnInfo)d.SelectedItem).ID);
-        var fkColumnInfos = FKRelations.Where(d => d.SelectedItem != null).Select(d => ((ColumnInfo)d.SelectedItem).ID);
+
+        var pkColumnInfos = PKRelations.Where(static d => d.SelectedItem != null).Select(static d => ((ColumnInfo)d.SelectedItem).ID);
+        var fkColumnInfos = FKRelations.Where(static d => d.SelectedItem != null).Select(static d => ((ColumnInfo)d.SelectedItem).ID);
+
         if (pkColumnInfos.Intersect(descColumnInfos).Any() || fkColumnInfos.Intersect(descColumnInfos).Any())
         {
             HandleError("A Description Column cannot be used in the PK FK mapping");
             return false;
         }
+
         return true;
     }
 

--- a/Rdmp.UI/LoadExecutionUIs/ExecuteLoadMetadataUI.cs
+++ b/Rdmp.UI/LoadExecutionUIs/ExecuteLoadMetadataUI.cs
@@ -77,12 +77,12 @@ public partial class ExecuteLoadMetadataUI : DatasetLoadControl_Design
 
         if (activator.IsInteractive)
         {
-            var ShowYestoAllNotoAlldataloadcheck = false;
-            var ShowYestoAllNotoAlldataloadcheckSetting = activator.RepositoryLocator.CatalogueRepository.GetAllObjects<Setting>().Where(s => s.Key == "ToggleYestoAllNotoAlldataloadcheck").FirstOrDefault();
-            if (ShowYestoAllNotoAlldataloadcheckSetting is not null) ShowYestoAllNotoAlldataloadcheck = Convert.ToBoolean(ShowYestoAllNotoAlldataloadcheckSetting.Value);
-            checkAndExecuteUI1.AllowsYesNoToAll = ShowYestoAllNotoAlldataloadcheck;
-
+            var showYestoAllNotoAlldataloadcheck = false;
+            var showYestoAllNotoAlldataloadcheckSetting = activator.RepositoryLocator.CatalogueRepository.GetAllObjects<Setting>().FirstOrDefault(static s => s.Key == "ToggleYestoAllNotoAlldataloadcheck");
+            if (showYestoAllNotoAlldataloadcheckSetting is not null) showYestoAllNotoAlldataloadcheck = Convert.ToBoolean(showYestoAllNotoAlldataloadcheckSetting.Value);
+            checkAndExecuteUI1.AllowsYesNoToAll = showYestoAllNotoAlldataloadcheck;
         }
+
         SetButtonStates(null, null);
 
         SetLoadProgressGroupBoxState();

--- a/Rdmp.UI/SimpleDialogs/InstanceSettings.cs
+++ b/Rdmp.UI/SimpleDialogs/InstanceSettings.cs
@@ -58,14 +58,14 @@ namespace Rdmp.UI.SimpleDialogs
 
         private void RegisterCheckbox(CheckBox cb, string propertyName)
         {
-            var prop = _settings.Where(s => s.Key == propertyName).FirstOrDefault();
-            var value = false;
+            var prop = _settings.FirstOrDefault(s => s.Key == propertyName);
             if (prop is null)
             {
                 prop = new Setting(_activator.RepositoryLocator.CatalogueRepository, propertyName, Convert.ToString(false));
                 prop.SaveToDatabase();
             }
-            value = Convert.ToBoolean(prop.Value);
+
+            var value = Convert.ToBoolean(prop.Value);
             checkboxDictionary.Add(cb, prop);
 
             cb.Checked = value;

--- a/Rdmp.UI/SimpleDialogs/NewfindUI.cs
+++ b/Rdmp.UI/SimpleDialogs/NewfindUI.cs
@@ -38,12 +38,12 @@ namespace Rdmp.UI.SimpleDialogs
 
         private readonly bool _showReplaceOptions = false;
 
-        private void SimulateClickForAutoFilter<T>()
+        private void SimulateClickForAutoFilter<T2>()
         {
-            var item = newFindToolStrip.Items.Find((typeof(T)).Name, false).FirstOrDefault();
-            if (item is not null)
-                item.PerformClick();
+            var item = newFindToolStrip.Items.Find(typeof(T2).Name, false).FirstOrDefault();
+            item?.PerformClick();
         }
+
         private void PresetFiltersBasedOnFocusItem(RDMPUserControl focusItem)
         {
             var focusItemType = focusItem.GetType();

--- a/Rdmp.UI/Wizard/CreateNewDataExtractionProjectUI.cs
+++ b/Rdmp.UI/Wizard/CreateNewDataExtractionProjectUI.cs
@@ -55,17 +55,15 @@ public partial class CreateNewDataExtractionProjectUI : RDMPForm
 
     private void GetNextProjectNumber(IActivateItems activator)
     {
-
-        var AutoSuggestProjectNumbers = false;
-        var AutoSuggestProjectNumbersSetting = activator.RepositoryLocator.CatalogueRepository.GetAllObjects<Setting>().Where(s => s.Key == "AutoSuggestProjectNumbers").FirstOrDefault();
-        if (AutoSuggestProjectNumbersSetting is not null) AutoSuggestProjectNumbers = Convert.ToBoolean(AutoSuggestProjectNumbersSetting.Value);
+        var autoSuggestProjectNumbers = false;
+        var autoSuggestProjectNumbersSetting = activator.RepositoryLocator.CatalogueRepository.GetAllObjects<Setting>().FirstOrDefault(static s => s.Key == "AutoSuggestProjectNumbers");
+        if (autoSuggestProjectNumbersSetting is not null) autoSuggestProjectNumbers = Convert.ToBoolean(autoSuggestProjectNumbersSetting.Value);
         _existingProjects = activator.RepositoryLocator.DataExportRepository.GetAllObjects<Project>();
-        if (AutoSuggestProjectNumbers)
-        {
-            var highestNumber = _existingProjects.Max(p => p.ProjectNumber);
-            tbProjectNumber.Text = highestNumber == null ? "1" : (highestNumber.Value + 1).ToString();
-        }
 
+        if (!autoSuggestProjectNumbers) return;
+
+        var highestNumber = _existingProjects.Max(static p => p.ProjectNumber);
+        tbProjectNumber.Text = highestNumber == null ? "1" : (highestNumber.Value + 1).ToString();
     }
 
     public CreateNewDataExtractionProjectUI(IActivateItems activator) : base(activator)

--- a/Tests.Common/UnitTests.cs
+++ b/Tests.Common/UnitTests.cs
@@ -124,7 +124,7 @@ public class UnitTests
     public static T WhenIHaveA<T>(MemoryDataExportRepository repository) where T : DatabaseEntity
     {
         if (typeof(T) == typeof(Catalogue))
-            return (T)(object)Save(new Catalogue(repository, "Mycata"));
+            return Save(new Catalogue(repository, "Mycata")) as T;
 
 
         if (typeof(T) == typeof(ExtendedProperty))


### PR DESCRIPTION
Fix up some .Dispose/using issues, make finding most recent load ID more efficient

## Proposed Change

- Fix up some missed `using` opportunities and duplicate `.Dispose()` calls, also inefficient LINQ invocations

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [x] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [ ] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [ ] Created or updated any tests if relevant
-   [ ] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [ ] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [ ] Have added an entry into the changelog
