### PR TITLE
fix simple file extractor check error

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 - Build on and target .Net 9 rather than 8
 - Simplify DB Patching Interface
+- Fix issue with Simple File Extractor pipeline component checking
 
 ## [8.4.2] - 2024-12-18
 

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/SimpleFileExtractor.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/SimpleFileExtractor.cs
@@ -113,7 +113,7 @@ $c - Configuration Extraction Directory  (e.g. c:\MyProject\Extractions\Extr_16)
         if (path.Contains("$p")) path = path.Replace("$p", _command.Project.ExtractionDirectory);
         if (path.Contains("$n")) path = path.Replace("$n", _command.Project.ProjectNumber.ToString());
 
-        if (path.Contains("$c") )
+        if (path.Contains("$c"))
             path = path.Replace("$c",
                 new ExtractionDirectory(_command.Project.ExtractionDirectory, _command.Configuration)
                     .ExtractionDirectoryInfo.FullName);

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/SimpleFileExtractor.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/SimpleFileExtractor.cs
@@ -72,17 +72,6 @@ $c - Configuration Extraction Directory  (e.g. c:\MyProject\Extractions\Extr_16)
             notifier.OnCheckPerformed(new CheckEventArgs(
                 $"PerPatient is false but Pattern {Pattern} contains token $p.  This token will never be matched in MoveAll mode",
                 CheckResult.Fail));
-
-        try
-        {
-            notifier.OnCheckPerformed(new CheckEventArgs($"Output path is:{GetDestinationDirectory()}",
-                CheckResult.Success));
-        }
-        catch (Exception ex)
-        {
-            throw new Exception(
-                "Unable to to determine output directory from 'OutputDirectoryName'.  Perhaps pattern is bad", ex);
-        }
     }
 
     protected override void MoveFiles(ExtractGlobalsCommand command, IDataLoadEventListener listener,
@@ -124,7 +113,7 @@ $c - Configuration Extraction Directory  (e.g. c:\MyProject\Extractions\Extr_16)
         if (path.Contains("$p")) path = path.Replace("$p", _command.Project.ExtractionDirectory);
         if (path.Contains("$n")) path = path.Replace("$n", _command.Project.ProjectNumber.ToString());
 
-        if (path.Contains("$c"))
+        if (path.Contains("$c") )
             path = path.Replace("$c",
                 new ExtractionDirectory(_command.Project.ExtractionDirectory, _command.Configuration)
                     .ExtractionDirectoryInfo.FullName);


### PR DESCRIPTION
## Proposed Change
There is an issue with the checking stage of the SimpleFileExtractor where it it trying to check an uninitialized variable.
This fix removes this from the checks, as the variable isn't set till runtime
## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [X] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [X] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [X] Created or updated any tests if relevant
-   [X] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [X] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [X] Have added an entry into the changelog
