### PR TITLE
Spike/rdmp 282 cohort temp tables

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -12,6 +12,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix application restart not closing all windows
 - Improve cohort deprecation override test
 - Add Filters for CatalogueItems to Dashboard graphs
+- Add ability to use cohort temp table during extractions
 
 ## [8.4.2] - 2024-12-18
 

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -190,7 +190,7 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
             if (Request.DatasetBundle.DataSet.DisableExtraction)
                 throw new Exception(
                     $"Cannot extract {Request.DatasetBundle.DataSet} because DisableExtraction is set to true");
-
+            var x = GetCommandSQL(listener);
             _hostedSource = new DbDataCommandDataFlowSource(GetCommandSQL(listener),
                 $"ExecuteDatasetExtraction {Request.DatasetBundle.DataSet}",
                 Request.GetDistinctLiveDatabaseServer().Builder,

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -1,4 +1,4 @@
-// Copyright (c) The University of Dundee 2018-2019
+// Copyright (c) The University of Dundee 2018-2025
 // This file is part of the Research Data Management Platform (RDMP).
 // RDMP is free software: you can redistribute it and/or modify it under the terms of the GNU General Public License as published by the Free Software Foundation, either version 3 of the License, or (at your option) any later version.
 // RDMP is distributed in the hope that it will be useful, but WITHOUT ANY WARRANTY; without even the implied warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the GNU General Public License for more details.
@@ -13,7 +13,6 @@ using System.Linq;
 using System.Threading.Tasks;
 using FAnsi;
 using FAnsi.Discovery.QuerySyntax;
-using MySqlConnector;
 using Rdmp.Core.Curation.Data;
 using Rdmp.Core.DataExport.Data;
 using Rdmp.Core.DataExport.DataExtraction.Commands;

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -165,7 +165,7 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
 
     private RowPeeker _peeker = new();
 
-    private static Random random = new Random();
+    private static readonly Random random = new Random();
 
     private static string RandomString(int length)
     {

--- a/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
+++ b/Rdmp.Core/DataExport/DataExtraction/Pipeline/Sources/ExecuteDatasetExtractionSource.cs
@@ -218,7 +218,14 @@ OrderByAndDistinctInMemory - Adds an ORDER BY statement to the query and applies
 
         using var cmd = db.Server.GetCommand(sql, con);
         cmd.CommandTimeout = ExecutionTimeout;
-        cmd.ExecuteNonQuery();
+        try
+        {
+            cmd.ExecuteNonQuery();
+        }
+        catch (Exception ex) {
+            listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Warning, $"Unable to create temporary table for cohort. Original cohort table will be used",ex));
+            _uuid = null;
+        }
         listener.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information, $"Cohort successfully copied to temporary table"));
 
     }

--- a/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
+++ b/Rdmp.Core/DataLoad/Engine/Pipeline/Sources/DbDataCommandDataFlowSource.cs
@@ -49,6 +49,17 @@ public class DbDataCommandDataFlowSource : IDbDataCommandDataFlowSource
         BatchSize = 10000;
     }
 
+    public DbDataCommandDataFlowSource(string sql, string taskBeingPerformed, DbConnection con,
+        int timeout)
+    {
+        Sql = sql;
+        _taskBeingPerformed = taskBeingPerformed;
+        _con = con;
+        _timeout = timeout;
+
+        BatchSize = 10000;
+    }
+
     private int _numberOfColumns;
 
     private bool _firstChunk = true;
@@ -59,8 +70,11 @@ public class DbDataCommandDataFlowSource : IDbDataCommandDataFlowSource
     {
         if (_reader == null)
         {
-            _con = DatabaseCommandHelper.GetConnection(_builder);
-            _con.Open();
+            _con = _con ==null?DatabaseCommandHelper.GetConnection(_builder):_con;
+            if(_con != null && _con.State == ConnectionState.Closed)
+{
+                _con.Open();
+            }
 
             job.OnNotify(this, new NotifyEventArgs(ProgressEventType.Information,
                 $"Running SQL:{Environment.NewLine}{Sql}"));
@@ -209,11 +223,13 @@ public class DbDataCommandDataFlowSource : IDbDataCommandDataFlowSource
     public DataTable TryGetPreview()
     {
         var chunk = new DataTable();
-        using var con = DatabaseCommandHelper.GetConnection(_builder);
-        con.Open();
-        using var da = DatabaseCommandHelper.GetDataAdapter(DatabaseCommandHelper.GetCommand(Sql, con));
+        _con = _con == null ? DatabaseCommandHelper.GetConnection(_builder) : _con;
+        if (_con != null && _con.State == ConnectionState.Closed)
+        {
+            _con.Open();
+        }
+        using var da = DatabaseCommandHelper.GetDataAdapter(DatabaseCommandHelper.GetCommand(Sql, _con));
         var read = da.Fill(0, 100, chunk);
-
         return read == 0 ? null : chunk;
     }
 }

--- a/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
+++ b/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
@@ -124,12 +124,7 @@ public class ExtractionQueryBuilder
 
         var externalCohortTable =
             _repository.GetObjectByID<ExternalCohortTable>(request.ExtractableCohort.ExternalCohortTable_ID);
-        //todo here is where we want to create a temp table
 
-        //var db = externalCohortTable.Discover();
-        //var con = db.Server.GetConnection();
-        //con.Open();
-        //var tempTable = CreateCohortTempTable(externalCohortTable, request.ExtractableCohort.WhereSQL(),con.db);
         if (request.ExtractableCohort != null)
         {
             //the JOIN with the cohort table:
@@ -149,32 +144,6 @@ public class ExtractionQueryBuilder
         request.QueryBuilder = queryBuilder;
         return queryBuilder;
     }
-
-    //private static Random random = new Random();
-
-    //private static string RandomString(int length)
-    //{
-    //    const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
-    //    return new string(Enumerable.Repeat(chars, length)
-    //        .Select(s => s[random.Next(s.Length)]).ToArray());
-    //}
-
-    //private string CreateCohortTempTable(ExternalCohortTable externalCohortTable, string whereSQL,DbConnection con, DiscoveredDatabase db)
-    //{
-    //    var uuid = $"#{RandomString(24)}";
-    //    var sql = $"""
-    //        SELECT *
-    //        INTO {uuid}
-    //        FROM(
-    //        SELECT * FROM {externalCohortTable.TableName}
-    //        WHERE {whereSQL}
-    //        ) as cohortTempTable
-        
-    //        """;
-    //            using var cmd = db.Server.GetCommand(sql, con);
-    //    cmd.ExecuteNonQuery();
-    //    return uuid;
-    //}
 
     private void HandleBatching(ExtractDatasetCommand request, QueryBuilder queryBuilder,
         IQuerySyntaxHelper syntaxHelper)

--- a/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
+++ b/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
@@ -8,6 +8,7 @@ using System;
 using System.Collections.Generic;
 using System.Linq;
 using FAnsi.Discovery.QuerySyntax;
+using Rdmp.Core.CohortCommitting;
 using Rdmp.Core.DataExport;
 using Rdmp.Core.DataExport.Data;
 using Rdmp.Core.DataExport.DataExtraction.Commands;
@@ -120,7 +121,8 @@ public class ExtractionQueryBuilder
 
         var externalCohortTable =
             _repository.GetObjectByID<ExternalCohortTable>(request.ExtractableCohort.ExternalCohortTable_ID);
-
+        //todo here is where we want to create a temp table
+        CreateCohortTempTable(externalCohortTable);
         if (request.ExtractableCohort != null)
         {
             //the JOIN with the cohort table:
@@ -140,6 +142,8 @@ public class ExtractionQueryBuilder
         request.QueryBuilder = queryBuilder;
         return queryBuilder;
     }
+
+    private void CreateCohortTempTable(ExternalCohortTable externalCohortTable) { }
 
     private void HandleBatching(ExtractDatasetCommand request, QueryBuilder queryBuilder,
         IQuerySyntaxHelper syntaxHelper)

--- a/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
+++ b/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
@@ -6,8 +6,11 @@
 
 using System;
 using System.Collections.Generic;
+using System.Data.Common;
 using System.Linq;
+using FAnsi.Discovery;
 using FAnsi.Discovery.QuerySyntax;
+using NPOI.SS.Formula.Functions;
 using Rdmp.Core.CohortCommitting;
 using Rdmp.Core.DataExport;
 using Rdmp.Core.DataExport.Data;
@@ -122,7 +125,11 @@ public class ExtractionQueryBuilder
         var externalCohortTable =
             _repository.GetObjectByID<ExternalCohortTable>(request.ExtractableCohort.ExternalCohortTable_ID);
         //todo here is where we want to create a temp table
-        CreateCohortTempTable(externalCohortTable);
+
+        //var db = externalCohortTable.Discover();
+        //var con = db.Server.GetConnection();
+        //con.Open();
+        //var tempTable = CreateCohortTempTable(externalCohortTable, request.ExtractableCohort.WhereSQL(),con.db);
         if (request.ExtractableCohort != null)
         {
             //the JOIN with the cohort table:
@@ -143,7 +150,31 @@ public class ExtractionQueryBuilder
         return queryBuilder;
     }
 
-    private void CreateCohortTempTable(ExternalCohortTable externalCohortTable) { }
+    //private static Random random = new Random();
+
+    //private static string RandomString(int length)
+    //{
+    //    const string chars = "ABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789";
+    //    return new string(Enumerable.Repeat(chars, length)
+    //        .Select(s => s[random.Next(s.Length)]).ToArray());
+    //}
+
+    //private string CreateCohortTempTable(ExternalCohortTable externalCohortTable, string whereSQL,DbConnection con, DiscoveredDatabase db)
+    //{
+    //    var uuid = $"#{RandomString(24)}";
+    //    var sql = $"""
+    //        SELECT *
+    //        INTO {uuid}
+    //        FROM(
+    //        SELECT * FROM {externalCohortTable.TableName}
+    //        WHERE {whereSQL}
+    //        ) as cohortTempTable
+        
+    //        """;
+    //            using var cmd = db.Server.GetCommand(sql, con);
+    //    cmd.ExecuteNonQuery();
+    //    return uuid;
+    //}
 
     private void HandleBatching(ExtractDatasetCommand request, QueryBuilder queryBuilder,
         IQuerySyntaxHelper syntaxHelper)

--- a/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
+++ b/Rdmp.Core/QueryBuilding/ExtractionQueryBuilder.cs
@@ -6,12 +6,8 @@
 
 using System;
 using System.Collections.Generic;
-using System.Data.Common;
 using System.Linq;
-using FAnsi.Discovery;
 using FAnsi.Discovery.QuerySyntax;
-using NPOI.SS.Formula.Functions;
-using Rdmp.Core.CohortCommitting;
 using Rdmp.Core.DataExport;
 using Rdmp.Core.DataExport.Data;
 using Rdmp.Core.DataExport.DataExtraction.Commands;


### PR DESCRIPTION
## Proposed Change

Add ability to clone cohort tables to a temp table when performing an extraction.
Has been shown to speed up DLS extractions by days

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [x] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [x] Created or updated any tests if relevant
-   [x] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [x] Requested a review by one of the repository maintainers
-   [x] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [x] Have added an entry into the changelog
