### PR TITLE
RDMP-319: Clone and delete GlobalExtractionFilterParameters Adds logi…

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - Fix issue with global contextual search
 - Add MS Teams Extraction notifications (see [Documentation\DataExtractions\ExtractionTeamsNotifications.md])
 - Add ability to use Cohort Catalogue Filters in an Extraction Configuration
+- Update clone extraction configuration to include generic perameters
 
 ## [8.4.4] - 2025-05-08 
 


### PR DESCRIPTION
…c to DeepCloneWithNewIDs to clone GlobalExtractionFilterParameters with their values and comments. Updates DeleteInDatabase to remove only the parameters associated with the current configuration.

## Proposed Change

Summarise your proposed changes here, including any notes for reviewers.

## Type of change

What types of changes does your code introduce? Tick all that apply.

-   [ ] Bugfix (non-breaking change which fixes an issue)
-   [ ] New Feature (non-breaking change which adds functionality)
-   [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
-   [ ] Documentation-Only Update
-   [ ] Other  (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

-   [ ] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able)
-   [ ] Created or updated any tests if relevant
-   [ ] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md)
-   [ ] Requested a review by one of the repository maintainers
-   [ ] Have written new documentation or updated existing documentation to detail any new or updated functionality and how to use it
-   [ ] Have added an entry into the changelog
