### PR TITLE
Cohort Builder: inject joinable knowledge after partial-refresh rebuild

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.2.2] - 2026-05-19
 - Add ability to force primary keys at each batch of data when extracting to a database
-- Update security vulnerability scanning dependencies
+- Fix Cohort Builder context menu freeze after partial refresh
 
 ## [9.2.1] - 2026-04-07
 - Update Sql Merge component to force destination column types

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@ All notable changes to this project will be documented in this file.
 The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## [9.2.3] - 2026-05-21
+- Add support for developing on macOS
+- Fix slow right-click context menu in Cohort Builder by re-injecting joinable knowledge after partial refresh of `AggregateConfiguration`s
+
 ## [9.2.2] - 2026-05-19
 - Add ability to force primary keys at each batch of data when extracting to a database
 - Update security vulnerability scanning dependencies

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,11 +6,11 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [9.2.3] - 2026-05-21
 - Add support for developing on macOS
-- Fix slow right-click context menu in Cohort Builder by re-injecting joinable knowledge after partial refresh of `AggregateConfiguration`s
+- Fix Cohort Builder context menu freeze after partial refresh
 
 ## [9.2.2] - 2026-05-19
 - Add ability to force primary keys at each batch of data when extracting to a database
-- Fix Cohort Builder context menu freeze after partial refresh
+- Update security vulnerability scanning dependencies
 
 ## [9.2.1] - 2026-04-07
 - Update Sql Merge component to force destination column types

--- a/Rdmp.Core/Providers/CatalogueChildProvider.cs
+++ b/Rdmp.Core/Providers/CatalogueChildProvider.cs
@@ -575,6 +575,21 @@ public class CatalogueChildProvider : ICoreChildProvider
         foreach (var d in AllAggregateDimensions)
             d.InjectKnown(AllExtractionInformationsDictionary[d.ExtractionInformation_ID]);
 
+        // When called from a partial refresh (e.g. SelectiveRefresh on a CohortAggregateContainer)
+        // AllJoinables is already populated from the prior full rebuild, but we have just
+        // replaced AllAggregateConfigurations with fresh instances whose joinable Lazy defaults
+        // to a per-object database lookup.  Without this re-injection, any subsequent enumeration
+        // that calls IsJoinablePatientIndexTable() (e.g. building the right-click menu for an
+        // aggregate container) fires N database round-trips at HIC scale — observed at >7s.
+        // No-op on first call from the main constructor: AllJoinables is null at that point and
+        // the explicit injection block in the constructor handles it.
+        if (AllJoinables != null)
+        {
+            var joinableDictionary = AllJoinables.ToDictionaryEx(j => j.AggregateConfiguration_ID, v => v);
+            foreach (var configuration in AllAggregateConfigurations)
+                configuration.InjectKnown(joinableDictionary.GetValueOrDefault(configuration.ID));
+        }
+
         ReportProgress("AggregateDimension injections");
 
         BuildAggregateFilterContainers();


### PR DESCRIPTION
## Proposed Change

After a partial refresh that calls `BuildAggregateConfigurations()` (e.g. `SelectiveRefresh` on a `CohortAggregateContainer`, fired on container rename / move), every `AggregateConfiguration` in `AllAggregateConfigurations` is replaced with a fresh DB-fetched instance. These fresh instances have their `JoinableCohortAggregateConfiguration` `Lazy<>` initialised to the default DB-fetching variant.

Any subsequent enumeration that calls `IsJoinablePatientIndexTable()` then triggers one `Repository.GetAllObjectsWithParent<...>(this)` round-trip per `AggregateConfiguration`. **At HIC scale this manifests as a >7 second freeze when constructing the cohort builder's right-click context menu**, because `ExecuteCommandAddAggregateConfigurationToCohortIdentificationSetContainer`'s constructor filters `AllAggregateConfigurations` by `IsJoinablePatientIndexTable`.

The main `CatalogueChildProvider` constructor already does this injection explicitly (see the `joinableDictionaryByAggregateConfigurationId` block around line 441), with the comment:

> *"We can inject this knowledge now so to avoid database lookups later"*

The partial-refresh path was missing the same step.

### Fix

At the end of `BuildAggregateConfigurations()`, re-inject the joinable knowledge from `AllJoinables` if it has already been populated by a prior full rebuild. No-op on the very first call (main constructor) where `AllJoinables` is still null at this point — the existing explicit injection block handles that case.

```diff
 foreach (var d in AllAggregateDimensions)
     d.InjectKnown(AllExtractionInformationsDictionary[d.ExtractionInformation_ID]);

+// When called from a partial refresh (e.g. SelectiveRefresh on a CohortAggregateContainer)
+// AllJoinables is already populated from the prior full rebuild, but we have just
+// replaced AllAggregateConfigurations with fresh instances whose joinable Lazy defaults
+// to a per-object database lookup.  Without this re-injection, any subsequent enumeration
+// that calls IsJoinablePatientIndexTable() (e.g. building the right-click menu for an
+// aggregate container) fires N database round-trips at HIC scale — observed at >7s.
+// No-op on first call from the main constructor: AllJoinables is null at that point and
+// the explicit injection block in the constructor handles it.
+if (AllJoinables != null)
+{
+    var joinableDictionary = AllJoinables.ToDictionaryEx(j => j.AggregateConfiguration_ID, v => v);
+    foreach (var configuration in AllAggregateConfigurations)
+        configuration.InjectKnown(joinableDictionary.GetValueOrDefault(configuration.ID));
+}

 ReportProgress("AggregateDimension injections");
```

### How the bug was identified

A step-by-step trace investigation against a HIC-scale platform DB, summarised:

1. Wrapped `RefreshBus.Publish` with stopwatch instrumentation; `ActivateItems.RefreshBus_RefreshObject` was ~88% of every event's wall-clock.
2. Identified the `SelectiveRefresh` user-setting opt-in (defaults to `false`). Enabling it gave a 5× speedup for filter events but no change for container/aggregate events.
3. Re-traced container-rename events with the setting on; `RDMPCollectionCommonFunctionality.RefreshBus_RefreshObject` was now the bottleneck at ~8.8 s.
4. Drilled into that handler; the cost was in `RefreshContextMenuStrip` → `GetMenuIfExists` → `AddCommonMenuItems` → `AddFactoryMenuItems` → one specific command's constructor: `ExecuteCommandAddAggregateConfigurationToCohortIdentificationSetContainer`.
5. Reading that constructor, `c.IsJoinablePatientIndexTable()` was being called for every cohort aggregate.
6. Reading `IsJoinablePatientIndexTable`, it reads a `Lazy<>` that defaults to a per-object DB query.
7. Reading `CatalogueChildProvider`, the explicit injection at line 441-447 exists for the main constructor path, but `BuildAggregateConfigurations` (the partial-refresh helper) doesn't repeat it.

### Measured impact

- All 102 `CohortCreation` tests continue to pass at parity (`3 m 6 s` on `darwin/arm64`, identical to baseline)
- Container rename freeze drops from ~10.4 s to ~1.5–2 s on a HIC-scale platform DB
- No behavioural change otherwise; the in-memory result is identical to what the main constructor's explicit injection produces

### Companion PR

PR #2336 extends `SelectiveRefresh` to also cover `AggregateConfiguration` renames/moves directly. That PR's `SelectiveRefresh(AggregateConfiguration)` calls `BuildAggregateConfigurations()`, so it lands best when this PR is also merged. Either PR is a strict improvement on its own.

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue) — silent performance bug (~7s extra DB queries) on partial-refresh path
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update
- [ ] Other (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able) — single commit on top of latest `origin/develop` (`a53edfd24`).
- [ ] Created or updated any tests if relevant — no existing tests cover `SelectiveRefresh` directly (zero hits in `Rdmp.Core.Tests` / `Rdmp.UI.Tests`). The patched behaviour is observably identical to the main constructor's explicit injection (same lazy value, no DB hit), so existing tests stay green. Happy to add a focused test that asserts no `JoinableCohortAggregateConfiguration` queries fire on warm post-refresh menu access — needs a wrapper that counts repository queries; scoping as follow-up if maintainers prefer.
- [x] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md) — performance section: `IsJoinablePatientIndexTable()` becomes O(1) (cache hit) instead of one DB round-trip per `AggregateConfiguration` after every partial refresh. Verified empirically on a HIC-scale platform DB: container rename ~10.4 s → ~1.5–2 s.
- [ ] Requested a review by one of the repository maintainers
- [x] Have written new documentation or updated existing documentation — explanatory comment in code at the injection site.
- [ ] Have added an entry into the changelog
