### PR TITLE
Cohort Builder: partial-refresh AggregateConfiguration renames/moves

### DIFF
--- a/Rdmp.Core/Providers/CatalogueChildProvider.cs
+++ b/Rdmp.Core/Providers/CatalogueChildProvider.cs
@@ -1873,10 +1873,49 @@ public class CatalogueChildProvider : ICoreChildProvider
             AggregateFilter af => SelectiveRefresh(af),
             AggregateFilterContainer afc => SelectiveRefresh(afc),
             CohortAggregateContainer cac => SelectiveRefresh(cac),
+            AggregateConfiguration ac => SelectiveRefresh(ac),
             ExtractionInformation ei => SelectiveRefresh(ei),
             CatalogueItem ci => SelectiveRefresh(ci),
             _ => false
         };
+    }
+
+    public bool SelectiveRefresh(AggregateConfiguration ac)
+    {
+        var descendancy = GetDescendancyListIfAnyFor(ac);
+        if (descendancy == null) return false;
+
+        // Cohort builder set member: the aggregate sits under a CohortAggregateContainer.
+        // Refreshing the immediate parent container is enough — re-fetching all aggregates
+        // and the container hierarchy, then re-rendering the parent's subtree.
+        var parentContainer = descendancy.Parents.OfType<CohortAggregateContainer>().LastOrDefault();
+        if (parentContainer != null)
+        {
+            var parentDescendancy = GetDescendancyListIfAnyFor(parentContainer);
+            if (parentDescendancy != null)
+            {
+                BuildAggregateConfigurations();
+                BuildCohortCohortAggregateContainers();
+                AddChildren(parentContainer, parentDescendancy.Add(parentContainer));
+                return true;
+            }
+        }
+
+        // Graph / aggregate-graph aggregate: hangs directly off a Catalogue.
+        var parentCatalogue = descendancy.Parents.OfType<Catalogue>().LastOrDefault();
+        if (parentCatalogue != null)
+        {
+            var cataDescendancy = GetDescendancyListIfAnyFor(parentCatalogue);
+            if (cataDescendancy != null)
+            {
+                BuildAggregateConfigurations();
+                AddChildren(parentCatalogue, cataDescendancy.Add(parentCatalogue));
+                return true;
+            }
+        }
+
+        // Could not place the aggregate in a known subtree; fall back to full rebuild.
+        return false;
     }
 
 


### PR DESCRIPTION
## Proposed Change

Adds `AggregateConfiguration` to the `SelectiveRefresh` type switch in `CatalogueChildProvider.SelectiveRefresh(IMapsDirectlyToDatabaseTable)`. Previously this type fell through to `_ => false`, forcing `ActivateItems.RefreshBus_RefreshObject` down the full `GetChildProvider()` rebuild path (~9–10 s at HIC scale) on every aggregate rename, parameter edit, or other property change.

Implements `SelectiveRefresh(AggregateConfiguration ac)` following the established pattern from `SelectiveRefresh(CohortAggregateContainer)`:

- For cohort builder set members (parent `CohortAggregateContainer`): re-fetch aggregates + container hierarchy, refresh the parent container's subtree.
- For graph aggregates hanging off a `Catalogue`: re-fetch aggregates, refresh the catalogue's subtree.
- Falls back to `false` (i.e. full rebuild) if neither parent type is in the descendancy.

```diff
 return databaseEntity switch
 {
     AggregateFilterParameter afp => SelectiveRefresh(afp.AggregateFilter),
     AggregateFilter af => SelectiveRefresh(af),
     AggregateFilterContainer afc => SelectiveRefresh(afc),
     CohortAggregateContainer cac => SelectiveRefresh(cac),
+    AggregateConfiguration ac => SelectiveRefresh(ac),
     ExtractionInformation ei => SelectiveRefresh(ei),
     CatalogueItem ci => SelectiveRefresh(ci),
     _ => false
 };
```

### Companion PR

PR #2335 (`inject joinable knowledge after partial-refresh rebuild`) removes a hidden cost from `BuildAggregateConfigurations()` which this PR newly relies on. This PR is still a strict improvement on its own (~10 s → ~2–3 s for aggregate renames), but is faster (~10 s → ~1.5–2 s) when PR #2335 is also merged — without PR #2335, the menu rebuild after this partial refresh would still trigger N×DB-queries on first menu open (separate bug, traced and addressed by PR #2335).

### Measured impact

- All 102 `CohortCreation` tests continue to pass at parity (`3 m 6 s` on `darwin/arm64`, identical to baseline)
- Aggregate rename freeze drops from ~10 s to ~2 s on a HIC-scale platform DB (with PR #2335); ~3 s without
- Falls back cleanly to full rebuild for objects that aren't placed in a known subtree

## Type of change

- [x] Bugfix (non-breaking change which fixes an issue) — performance / UX bug; full child-provider rebuild on every aggregate edit
- [ ] New Feature (non-breaking change which adds functionality)
- [ ] Breaking Change (fix or feature that would cause existing functionality to not work as expected)
- [ ] Documentation-Only Update
- [ ] Other (if none of the other choices apply)

## Checklist

By opening this PR, I confirm that I have:

- [x] Ensured that the PR branch is in sync with the target branch (i.e. it is automatically merge-able) — single commit on top of latest `origin/develop` (`a53edfd24`).
- [ ] Created or updated any tests if relevant — no existing tests cover `SelectiveRefresh` directly (zero hits in `Rdmp.Core.Tests` / `Rdmp.UI.Tests`). New `SelectiveRefresh(AggregateConfiguration)` mirrors the existing `SelectiveRefresh(CohortAggregateContainer)` pattern. Happy to add a focused test if maintainers prefer.
- [x] Have validated this change against the [Test Plan](https://github.com/HicServices/RDMP/blob/develop/Documentation/CodeTutorials/TestPlan.md) — performance: aggregate-rename freeze ~10 s → ~2 s (with companion PR #2335) on HIC-scale platform DB. Verified empirically with stopwatch-instrumented build.
- [ ] Requested a review by one of the repository maintainers
- [x] Have written new documentation or updated existing documentation — code comments explain the chosen subtree to refresh.
- [ ] Have added an entry into the changelog
