### PR TITLE
Clarify cohort "Save Version" description prompt

### DIFF
--- a/Rdmp.UI/LocationsMenu/Versioning/VersioningControlUI.Designer.cs
+++ b/Rdmp.UI/LocationsMenu/Versioning/VersioningControlUI.Designer.cs
@@ -103,7 +103,7 @@ namespace Rdmp.UI.LocationsMenu.Versioning
                 return;
             }
             var versions = _cic.GetVersions();
-            var addedNewDescription = _activator.TypeText("Set Description for new Version", "Would you like to set a description for this new cohort version?", 250, _cic.Description, out string newDescription, false);
+            var addedNewDescription = _activator.TypeText("Describe Saved Version", "Saving a version stores a frozen snapshot of the cohort as it is now. Would you like to give that saved snapshot a description? (Your live configuration stays editable and keeps its current description.)", 250, _cic.Description, out string newDescription, false);
             var cmd = new ExecuteCommandCreateVersionOfCohortConfiguration(_activator, _cic, $"{_cic.Name}-v{versions.Count + 1}-{DateTime.Now.ToString("yyyy-MM-dd")}", addedNewDescription ? newDescription : null);
             cmd.Execute();
         }


### PR DESCRIPTION
When clicking **Save Version** on a cohort identification configuration, the dialog asked *"Would you like to set a description for this new cohort version?"*. This implied the description applied to the cohort you carry on editing.

In reality, `ExecuteCommandCreateVersionOfCohortConfiguration` clones the current cohort into a **frozen snapshot** and writes the description onto that snapshot — the live configuration is left untouched.

This reword makes the prompt match the actual behaviour: it now explains the description is stored against the frozen snapshot, and that the live configuration stays editable and keeps its current description.

No behavioural change — dialog text only.

🤖 Generated with [Claude Code](https://claude.com/claude-code)